### PR TITLE
(extension) fix dandanplay episode matching [DA-134]

### DIFF
--- a/packages/danmaku-anywhere/src/background/services/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/ProviderService.ts
@@ -8,6 +8,7 @@ import { match } from 'ts-pattern'
 import type { BilibiliService } from '@/background/services/BilibiliService'
 import type { DanDanPlayService } from '@/background/services/DanDanPlayService'
 import type { DanmakuService } from '@/background/services/DanmakuService'
+import { findDanDanPlayEpisodeInList } from '@/background/services/episodeMatching'
 import type { SeasonService } from '@/background/services/SeasonService'
 import type { TencentService } from '@/background/services/TencentService'
 import type { TitleMappingService } from '@/background/services/TitleMappingService'
@@ -22,7 +23,6 @@ import { DanmakuSourceType } from '@/common/danmaku/enums'
 import { assertProvider } from '@/common/danmaku/utils'
 import { Logger } from '@/common/Logger'
 import { invariant, isServiceWorker } from '@/common/utils/utils'
-import { findDanDanPlayEpisodeInList } from '@/background/services/episodeMatching'
 
 export class ProviderService {
   private logger: typeof Logger
@@ -201,8 +201,7 @@ export class ProviderService {
       const episode = findDanDanPlayEpisodeInList(
         episodes,
         episodeNumber,
-        season.providerIds.animeId,
-        (message?: any, ...optionalParams: any[]) => this.logger.debug(message, ...optionalParams)
+        season.providerIds.animeId
       )
 
       if (!episode) {

--- a/packages/danmaku-anywhere/src/background/services/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/ProviderService.ts
@@ -22,6 +22,7 @@ import { DanmakuSourceType } from '@/common/danmaku/enums'
 import { assertProvider } from '@/common/danmaku/utils'
 import { Logger } from '@/common/Logger'
 import { invariant, isServiceWorker } from '@/common/utils/utils'
+import { findDanDanPlayEpisodeInList } from '@/background/services/episodeMatching'
 
 export class ProviderService {
   private logger: typeof Logger
@@ -197,13 +198,11 @@ export class ProviderService {
         throw new Error(`No episodes found for season: ${season}`)
       }
 
-      const episodeId = this.danDanPlayService.computeEpisodeId(
+      const episode = findDanDanPlayEpisodeInList(
+        episodes,
+        episodeNumber,
         season.providerIds.animeId,
-        episodeNumber
-      )
-
-      const episode = episodes.find(
-        (ep) => ep.providerIds.episodeId === episodeId
+        (message?: any, ...optionalParams: any[]) => this.logger.debug(message, ...optionalParams)
       )
 
       if (!episode) {

--- a/packages/danmaku-anywhere/src/background/services/episodeMatching.ts
+++ b/packages/danmaku-anywhere/src/background/services/episodeMatching.ts
@@ -1,54 +1,27 @@
-import type { DanDanPlayOf, EpisodeMeta } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  DanDanPlayOf,
+  EpisodeMeta,
+} from '@danmaku-anywhere/danmaku-converter'
 
-export type DebugLog = (message?: any, ...optionalParams: any[]) => void
-
-/**
- * Legacy DDP computed episodeId formula. Kept here to avoid coupling to class instances.
- */
-export const computeDanDanPlayEpisodeId = (animeId: number, episodeNumber: number) => {
+const computeDanDanPlayEpisodeId = (animeId: number, episodeNumber: number) => {
   return animeId * 10000 + episodeNumber
 }
 
-/**
- * Find an episode in a DDP episode list by its episode number, with a fallback to the legacy computed episodeId.
- * Returns undefined if no match is found.
- */
 export function findDanDanPlayEpisodeInList(
   episodes: DanDanPlayOf<EpisodeMeta>[],
   episodeNumber: number,
-  animeId: number,
-  debugLog?: DebugLog
+  animeId: number
 ): DanDanPlayOf<EpisodeMeta> | undefined {
-  // Preferred: match by the actual episodeNumber field
+  // prefer to match by the actual episodeNumber field
   const episodeByNumber = episodes.find(
     (ep) => String(ep.episodeNumber) === String(episodeNumber)
   )
 
   if (episodeByNumber) {
-    debugLog?.(
-      '[findDanDanPlayEpisodeInList] Matched by episodeNumber',
-      { requested: episodeNumber, matchedEpisodeId: episodeByNumber.providerIds.episodeId }
-    )
     return episodeByNumber
   }
 
-  // Fallback: legacy matching using computed episodeId
+  // if episode number not found, try to match using computed episodeId
   const computedId = computeDanDanPlayEpisodeId(animeId, episodeNumber)
-  const episodeByComputedId = episodes.find(
-    (ep) => ep.providerIds.episodeId === computedId
-  )
-
-  if (episodeByComputedId) {
-    debugLog?.(
-      '[findDanDanPlayEpisodeInList] Fallback matched by computed episodeId',
-      { requested: episodeNumber, computedId }
-    )
-  } else {
-    debugLog?.(
-      '[findDanDanPlayEpisodeInList] No episode matched',
-      { requested: episodeNumber, computedId }
-    )
-  }
-
-  return episodeByComputedId
+  return episodes.find((ep) => ep.providerIds.episodeId === computedId)
 }

--- a/packages/danmaku-anywhere/src/background/services/episodeMatching.ts
+++ b/packages/danmaku-anywhere/src/background/services/episodeMatching.ts
@@ -1,0 +1,54 @@
+import type { DanDanPlayOf, EpisodeMeta } from '@danmaku-anywhere/danmaku-converter'
+
+export type DebugLog = (message?: any, ...optionalParams: any[]) => void
+
+/**
+ * Legacy DDP computed episodeId formula. Kept here to avoid coupling to class instances.
+ */
+export const computeDanDanPlayEpisodeId = (animeId: number, episodeNumber: number) => {
+  return animeId * 10000 + episodeNumber
+}
+
+/**
+ * Find an episode in a DDP episode list by its episode number, with a fallback to the legacy computed episodeId.
+ * Returns undefined if no match is found.
+ */
+export function findDanDanPlayEpisodeInList(
+  episodes: DanDanPlayOf<EpisodeMeta>[],
+  episodeNumber: number,
+  animeId: number,
+  debugLog?: DebugLog
+): DanDanPlayOf<EpisodeMeta> | undefined {
+  // Preferred: match by the actual episodeNumber field
+  const episodeByNumber = episodes.find(
+    (ep) => String(ep.episodeNumber) === String(episodeNumber)
+  )
+
+  if (episodeByNumber) {
+    debugLog?.(
+      '[findDanDanPlayEpisodeInList] Matched by episodeNumber',
+      { requested: episodeNumber, matchedEpisodeId: episodeByNumber.providerIds.episodeId }
+    )
+    return episodeByNumber
+  }
+
+  // Fallback: legacy matching using computed episodeId
+  const computedId = computeDanDanPlayEpisodeId(animeId, episodeNumber)
+  const episodeByComputedId = episodes.find(
+    (ep) => ep.providerIds.episodeId === computedId
+  )
+
+  if (episodeByComputedId) {
+    debugLog?.(
+      '[findDanDanPlayEpisodeInList] Fallback matched by computed episodeId',
+      { requested: episodeNumber, computedId }
+    )
+  } else {
+    debugLog?.(
+      '[findDanDanPlayEpisodeInList] No episode matched',
+      { requested: episodeNumber, computedId }
+    )
+  }
+
+  return episodeByComputedId
+}

--- a/packages/danmaku-anywhere/src/background/services/episodeMatching.ts
+++ b/packages/danmaku-anywhere/src/background/services/episodeMatching.ts
@@ -13,9 +13,9 @@ export function findDanDanPlayEpisodeInList(
   animeId: number
 ): DanDanPlayOf<EpisodeMeta> | undefined {
   // prefer to match by the actual episodeNumber field
-  const episodeByNumber = episodes.find(
-    (ep) => String(ep.episodeNumber) === String(episodeNumber)
-  )
+  const episodeByNumber = episodes.find((ep) => {
+    return ep.episodeNumber?.toString() === episodeNumber.toString()
+  })
 
   if (episodeByNumber) {
     return episodeByNumber

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
@@ -109,11 +109,12 @@ export const SearchPage = () => {
     if (boxRef.current) {
       setScrollTop(boxRef.current.scrollTop)
     }
-    if (isProvider(season, DanmakuSourceType.Custom) || !mediaInfo) {
+    if (isProvider(season, DanmakuSourceType.Custom)) {
       return
     }
     if (
       isProvider(season, DanmakuSourceType.DanDanPlay) &&
+      mediaInfo &&
       !doesSeasonMapExist(
         seasonMaps,
         mediaInfo.getKey(),


### PR DESCRIPTION
Fixes danmaku episode search by prioritizing actual episode numbers and providing an extensible matching strategy.

The previous logic incorrectly matched episodes using a computed ID, leading to wrong results. This PR introduces a two-step search: first by `episodeNumber` (preferred) and then by the legacy computed ID. The new `findDanDanPlayEpisodeInList` function is extracted for reusability and future multi-provider support.

---
<a href="https://cursor.com/background-agent?bcId=bc-701d15f4-1286-445b-b9c1-fd5ec7eb762a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-701d15f4-1286-445b-b9c1-fd5ec7eb762a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

