### PR TITLE
Animate fab loading indicator as spinner

### DIFF
--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/CircularSpinner.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/CircularSpinner.tsx
@@ -1,0 +1,33 @@
+import { keyframes, styled } from '@mui/material'
+
+const spinAnimation = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`
+
+const SpinnerContainer = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  top: -4,
+  left: -4,
+  width: 48, // 40px FAB + 8px margin
+  height: 48,
+  borderRadius: '50%',
+  border: `2px solid transparent`,
+  borderTop: `2px solid ${theme.palette.primary.main}`,
+  animation: `${spinAnimation} 1s linear infinite`,
+  pointerEvents: 'none',
+}))
+
+interface CircularSpinnerProps {
+  isLoading: boolean
+}
+
+export const CircularSpinner = ({ isLoading }: CircularSpinnerProps) => {
+  if (!isLoading) return null
+  
+  return <SpinnerContainer />
+}

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabLoadingIndicator.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabLoadingIndicator.tsx
@@ -1,7 +1,7 @@
 import { Box, Fade } from '@mui/material'
 import { createPortal } from 'react-dom'
 
-import { LoadingRing } from '@/content/controller/ui/floatingButton/components/LoadingRing'
+import { CircularSpinner } from '@/content/controller/ui/floatingButton/components/CircularSpinner'
 
 interface FabLoadingIndicatorProps {
   anchor: Element
@@ -24,7 +24,7 @@ export const FabLoadingIndicator = ({
           pointerEvents: 'none',
         }}
       >
-        <LoadingRing isLoading={isLoading} />
+        <CircularSpinner isLoading={isLoading} />
       </Box>
     </Fade>,
     anchor


### PR DESCRIPTION
Replaced the FAB loading indicator with a circular spinner to make it less obtrusive.

---
<a href="https://cursor.com/background-agent?bcId=bc-02677749-24e4-4713-bb8d-33657d56462d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02677749-24e4-4713-bb8d-33657d56462d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

