### PR TITLE
(extension) make indexeddb operations atomic [DA-167]

### DIFF
--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -14,7 +14,6 @@ import { TitleMappingService } from '@/background/services/TitleMappingService'
 import { configureHeaders } from '@/background/utils/configureHeaders'
 import { generateId } from '@/background/utils/generateId'
 import { EXTENSION_VERSION, IS_FIREFOX } from '@/common/constants'
-import { db } from '@/common/db/db'
 import { setupAlarms } from './alarm/setupAlarms'
 import { setupContextMenu } from './contextMenu/setupContextMenu'
 import { setupNetRequest } from './netRequest/setupNetrequest'
@@ -23,19 +22,15 @@ import { setupScripting } from './scripting/setupScripting'
 import { setupOptions } from './syncOptions/setupOptions'
 
 // dependency injection
-const seasonService = new SeasonService(db.season, db.episode)
-const danmakuService = new DanmakuService(
-  seasonService,
-  db.episode,
-  db.customEpisode
-)
+const seasonService = new SeasonService()
+const danmakuService = new DanmakuService(seasonService)
 
 const danDanPlayService = new DanDanPlayService(seasonService, danmakuService)
 const tencentService = new TencentService(seasonService, danmakuService)
 const bilibiliService = new BilibiliService(seasonService, danmakuService)
 const customProviderService = new MacCmsProviderService(danmakuService)
 
-const titleMappingService = new TitleMappingService(db.seasonMap)
+const titleMappingService = new TitleMappingService()
 const providerService = new ProviderService(
   titleMappingService,
   danmakuService,

--- a/packages/danmaku-anywhere/src/background/services/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/ProviderService.ts
@@ -258,7 +258,15 @@ export class ProviderService {
         throw new Error('No season id provided')
       }
 
-      const season = await this.seasonService.mustGetById(sid)
+      const season = await this.seasonService.getById(sid)
+
+      if (!season) {
+        return {
+          status: 'notFound',
+          data: null,
+        }
+      }
+
       assertProvider(season, DanmakuSourceType.DanDanPlay)
 
       return {

--- a/packages/danmaku-anywhere/src/background/services/TitleMappingService.ts
+++ b/packages/danmaku-anywhere/src/background/services/TitleMappingService.ts
@@ -18,10 +18,10 @@ export class TitleMappingService {
     const existing = await db.seasonMap.get({ key: map.key })
     if (existing) {
       this.logger.debug('Updating title mapping:', map)
-      db.seasonMap.put(map, existing.key)
+      await db.seasonMap.put(map, existing.key)
     } else {
       this.logger.debug('Adding title mapping:', map)
-      db.seasonMap.add(map)
+      await db.seasonMap.add(map)
     }
   }
 

--- a/packages/danmaku-anywhere/src/background/services/TitleMappingService.ts
+++ b/packages/danmaku-anywhere/src/background/services/TitleMappingService.ts
@@ -1,4 +1,4 @@
-import type { db } from '@/common/db/db'
+import { db } from '@/common/db/db'
 import { Logger } from '@/common/Logger'
 import type { SeasonMap } from '@/common/seasonMap/types'
 import { invariant, isServiceWorker } from '@/common/utils/utils'
@@ -6,7 +6,7 @@ import { invariant, isServiceWorker } from '@/common/utils/utils'
 export class TitleMappingService {
   private logger: typeof Logger
 
-  constructor(private table: typeof db.seasonMap) {
+  constructor() {
     invariant(
       isServiceWorker(),
       'TitleMappingService is only available in service worker'
@@ -15,26 +15,26 @@ export class TitleMappingService {
   }
 
   async add(map: SeasonMap) {
-    const existing = await this.table.get({ key: map.key })
+    const existing = await db.seasonMap.get({ key: map.key })
     if (existing) {
       this.logger.debug('Updating title mapping:', map)
-      this.table.put(map, existing.key)
+      db.seasonMap.put(map, existing.key)
     } else {
       this.logger.debug('Adding title mapping:', map)
-      this.table.add(map)
+      db.seasonMap.add(map)
     }
   }
 
   async remove(key: string) {
     this.logger.debug('Removing title mapping:', key)
-    await this.table.where({ key }).delete()
+    await db.seasonMap.where({ key }).delete()
   }
 
   async get(key: string) {
-    return this.table.get({ key })
+    return db.seasonMap.get({ key })
   }
 
   async getAll() {
-    return this.table.toArray()
+    return db.seasonMap.toArray()
   }
 }


### PR DESCRIPTION
Ensure atomicity for cross-store IndexedDB operations in `SeasonService` and `DanmakuService`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5219aeb-f9e9-4bc8-b459-87c59331e259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5219aeb-f9e9-4bc8-b459-87c59331e259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

