### PR TITLE
(chore) check pr title format with github action [DA-179]

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,31 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  check-title:
+    name: Validate PR title format
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request?.title || '';
+            // Required format: (TYPE) description [TASK-ID]
+            // TYPE ∈ {extension,app,proxy,chore}
+            // TASK-ID matches DA-<number>
+            const pattern = /^\((extension|app|proxy|chore)\)\s.+\s\[DA-\d+\]$/;
+
+            if (!pattern.test(title)) {
+              core.setFailed(
+                `Invalid PR title: "${title}".\n\nExpected: (TYPE) description [TASK-ID]\n- TYPE: one of extension, app, proxy, chore\n- TASK-ID: DA-<number> (e.g., DA-123)`
+              );
+            } else {
+              core.info(`PR title is valid: ${title}`);
+            }


### PR DESCRIPTION
Add a GitHub Actions workflow to validate PR titles, enforcing the `(TYPE) description [TASK-ID]` format for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-488580c3-427c-44ac-b81f-cf87fa9f4d23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-488580c3-427c-44ac-b81f-cf87fa9f4d23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

