### PR TITLE
Migrate danmaku to compressed storage

### DIFF
--- a/packages/danmaku-anywhere/src/background/services/SeasonService.ts
+++ b/packages/danmaku-anywhere/src/background/services/SeasonService.ts
@@ -89,7 +89,17 @@ export class SeasonService {
       db.episode,
       db.season,
       db.seasonMap,
+      db.danmakuData,
       async () => {
+        const episodes: any[] = await db.episode
+          .where({
+            seasonId: id,
+          })
+          .toArray()
+        const refIds = episodes
+          .map((e: any) => e.commentsRefId)
+          .filter((v: any) => v !== undefined)
+        if (refIds.length) await db.danmakuData.bulkDelete(refIds)
         await db.episode
           .where({
             seasonId: id,


### PR DESCRIPTION
Extract and compress danmaku comments into a new `danmakuData` table, referencing them from `episode` and `customEpisode` to optimize storage and ensure atomic operations.

This change introduces a new IndexedDB table (`danmakuData`) to store `comments` as gzip-compressed blobs, reducing the footprint of `episode` and `customEpisode` records. A new DB migration (v12) handles existing data. `DanmakuService` and `SeasonService` are updated to read/write/delete comments via this new table, ensuring all related operations remain atomic.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab8e4db6-a370-4a32-9498-51dd7fd6ad4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab8e4db6-a370-4a32-9498-51dd7fd6ad4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

