### PR TITLE
Fix danmaku density chart resizing

### DIFF
--- a/packages/danmaku-anywhere/src/content/player/densityPlot/DanmakuDensity.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/densityPlot/DanmakuDensity.service.ts
@@ -85,6 +85,12 @@ export class DanmakuDensityService {
       this.boundHandleTimeUpdate
     )
     document.addEventListener('mousemove', this.boundHandleMouseMove)
+    
+    // Set the current video element for resize observation
+    const videoElement = this.videoEventService.getVideoElement()
+    if (videoElement) {
+      this.chart.setVideoElement(videoElement)
+    }
   }
 
   private removeEventListeners() {
@@ -125,7 +131,11 @@ export class DanmakuDensityService {
   }
 
   private handleTimeUpdate(event: Event) {
-    this.currentVideo = event.target as HTMLVideoElement
+    const newVideo = event.target as HTMLVideoElement
+    if (this.currentVideo !== newVideo) {
+      this.currentVideo = newVideo
+      this.chart.setVideoElement(newVideo)
+    }
     if (this.data.length === 0) {
       this.tryComputeAndRender()
     } else {
@@ -156,6 +166,7 @@ export class DanmakuDensityService {
 
   private cleanup() {
     this.removeEventListeners()
+    this.chart.setVideoElement(null)
     this.chart.teardown()
   }
 }

--- a/packages/danmaku-anywhere/src/content/player/densityPlot/DanmakuDensityChart.ts
+++ b/packages/danmaku-anywhere/src/content/player/densityPlot/DanmakuDensityChart.ts
@@ -48,6 +48,8 @@ export class DanmakuDensityChart {
   private lastCurrentTime = 0
 
   private readonly boundResize: () => void
+  private resizeObserver: ResizeObserver | null = null
+  private videoElement: HTMLVideoElement | null = null
 
   constructor(wrapper: HTMLElement, options: DanmakuDensityChartOptions = {}) {
     this.wrapper = wrapper
@@ -99,10 +101,12 @@ export class DanmakuDensityChart {
     this.clipRect = clipRect
 
     window.addEventListener('resize', this.boundResize)
+    this.setupVideoResizeObserver()
   }
 
   teardown() {
     window.removeEventListener('resize', this.boundResize)
+    this.cleanupVideoResizeObserver()
     this.svg?.remove()
     this.svg = null
     this.pathUnplayed = null
@@ -173,6 +177,14 @@ export class DanmakuDensityChart {
     this.svg?.classed('da-density-chart-visible', false)
   }
 
+  setVideoElement(videoElement: HTMLVideoElement | null) {
+    this.cleanupVideoResizeObserver()
+    this.videoElement = videoElement
+    if (this.videoElement) {
+      this.setupVideoResizeObserver()
+    }
+  }
+
   private getSvgSize(): { width: number; height: number } {
     const width =
       (this.svg?.node() as SVGSVGElement | null)?.clientWidth ||
@@ -206,5 +218,23 @@ export class DanmakuDensityChart {
     this.pathPlayed.attr('d', d)
 
     this.updateProgress(this.lastCurrentTime)
+  }
+
+  private setupVideoResizeObserver() {
+    if (!this.videoElement || this.resizeObserver) {
+      return
+    }
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.redraw()
+    })
+    this.resizeObserver.observe(this.videoElement)
+  }
+
+  private cleanupVideoResizeObserver() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect()
+      this.resizeObserver = null
+    }
   }
 }


### PR DESCRIPTION
Add a ResizeObserver to the danmaku density chart to make it resize with the video element.

The chart previously only responded to window resize events, leading to incorrect sizing when the video player itself changed dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-705e0b83-c0b3-483e-aff7-35fd01b926f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-705e0b83-c0b3-483e-aff7-35fd01b926f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

