### PR TITLE
(chore) add comment when pr title validation fails [DA-225]

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Validate title
         uses: actions/github-script@v7
@@ -23,9 +23,43 @@ jobs:
             const pattern = /^\((extension|app|proxy|chore|docs)\)\s.+\s\[DA-\d+\]$/;
 
             if (!pattern.test(title)) {
-              core.setFailed(
-                `Invalid PR title: "${title}".\n\nExpected: (TYPE) description [TASK-ID]\n- TYPE: one of extension, app, proxy, chore\n- TASK-ID: DA-<number> (e.g., DA-123)`
-              );
+              const errorMessage = `Invalid PR title: "${title}".\n\nExpected: (TYPE) description [TASK-ID]\n- TYPE: one of extension, app, proxy, chore, docs\n- TASK-ID: DA-<number> (e.g., DA-123)`;
+              
+              // Post a comment explaining the correct format
+              const commentBody = `## ⚠️ PR Title Format Issue
+
+The PR title doesn't match the required format.
+
+**Current title:**
+\`\`\`
+${title}
+\`\`\`
+
+**Expected format:**
+\`\`\`
+(TYPE) description [TASK-ID]
+\`\`\`
+
+**Details:**
+- **TYPE**: Must be one of: \`extension\`, \`app\`, \`proxy\`, \`chore\`, \`docs\`
+- **description**: A brief description of the changes
+- **TASK-ID**: Must match the pattern \`DA-<number>\` (e.g., \`DA-123\`)
+
+**Example:**
+\`\`\`
+(app) Add user authentication [DA-456]
+\`\`\`
+
+Please update your PR title to match this format.`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: commentBody
+              });
+              
+              core.setFailed(errorMessage);
             } else {
               core.info(`PR title is valid: ${title}`);
             }


### PR DESCRIPTION
Enhance PR title validation GitHub Action to post a comment with the correct format when validation fails.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4501153-6d0b-4f5d-ab08-8bb16be4a0a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4501153-6d0b-4f5d-ab08-8bb16be4a0a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

