### PR TITLE
(extension) fix draggable list jank [DA-235]

### DIFF
--- a/packages/danmaku-anywhere/src/common/components/DraggableList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DraggableList.tsx
@@ -10,8 +10,8 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import {
-  SortableContext,
   arrayMove,
+  SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,


### PR DESCRIPTION
Fixes draggable list jank by optimistically updating the order in UI while `onReorder` runs asynchronously, and simplifies item rendering.

The previous implementation relied solely on the `items` prop, which was updated asynchronously via `onReorder`. This caused the dragged item to visually snap back to its original position before the `items` prop was updated, leading to a "janky" user experience. By introducing an internal `orderedItems` state that updates optimistically, the UI now reflects the new order immediately, providing a smoother drag-and-drop experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f6c00a3-8400-4366-8416-33873e895646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f6c00a3-8400-4366-8416-33873e895646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

