### PR TITLE
(extension) add more shortcut and context menu settings [DA-239]

### DIFF
--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -564,8 +564,10 @@
       "enterKey": "Enter key",
       "openSearchPanel": "Open search panel",
       "refreshComments": "Refresh comments",
+      "toggleDanmakuTimeline": "Show/Hide danmaku density",
       "toggleEnableDanmaku": "Show/Hide danmaku",
       "togglePip": "Picture-in-picture",
+      "toggleSkipButton": "Show/Hide skip button",
       "unmountComments": "Unmount comments"
     },
     "infoPanel": {
@@ -600,6 +602,8 @@
       "player": "Player Settings"
     },
     "player": {
+      "hideDanmakuTimeline": "Hide danmaku density",
+      "hideSkipButton": "Hide skip button (OP/ED)",
       "inPlayerControls": "In-player controls",
       "showDanmakuTimeline": "Show danmaku density",
       "showDanmakuTimelineDesc": "Overlay a comment-density timeline above the scrubber.",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -549,8 +549,10 @@
       "enterKey": "输入快捷键",
       "openSearchPanel": "打开搜索面板",
       "refreshComments": "刷新弹幕",
+      "toggleDanmakuTimeline": "显示/隐藏弹幕密度",
       "toggleEnableDanmaku": "显示/隐藏弹幕",
       "togglePip": "画中画（实验）",
+      "toggleSkipButton": "显示/隐藏跳过按钮",
       "unmountComments": "卸载弹幕"
     },
     "infoPanel": {
@@ -583,6 +585,8 @@
       "player": "播放设置"
     },
     "player": {
+      "hideDanmakuTimeline": "隐藏弹幕密度",
+      "hideSkipButton": "隐藏跳过按钮（OP/ED）",
       "inPlayerControls": "播放器内控制",
       "showDanmakuTimeline": "显示弹幕密度",
       "showDanmakuTimelineDesc": "在进度条上方叠加弹幕密度时间轴。",

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/hotkeys.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/hotkeys.ts
@@ -16,6 +16,8 @@ export const ALL_HOTKEYS = [
   'refreshComments',
   'unmountComments',
   'openSearchPanel',
+  'toggleSkipButton',
+  'toggleDanmakuTimeline',
 ] as const
 
 export type AllHotkeys = (typeof ALL_HOTKEYS)[number]
@@ -31,6 +33,13 @@ export const HOTKEY_LABELS = createLocalizationMap<AllHotkeys>({
     i18n.t('optionsPage.hotkeys.unmountComments', 'Unmount comments'),
   openSearchPanel: () =>
     i18n.t('optionsPage.hotkeys.openSearchPanel', 'Open search panel'),
+  toggleSkipButton: () =>
+    i18n.t('optionsPage.hotkeys.toggleSkipButton', 'Show/Hide skip button'),
+  toggleDanmakuTimeline: () =>
+    i18n.t(
+      'optionsPage.hotkeys.toggleDanmakuTimeline',
+      'Show/Hide danmaku density'
+    ),
 })
 
 export type Keymap = Record<AllHotkeys, Hotkey>
@@ -41,6 +50,8 @@ export const defaultKeymap: Keymap = {
   unmountComments: createHotkey('shift+u'),
   togglePip: createHotkey('shift+p'),
   openSearchPanel: createHotkey('alt+k'),
+  toggleSkipButton: createHotkey('shift+s'),
+  toggleDanmakuTimeline: createHotkey('shift+d'),
 } as const
 
 const macModifierSymbols: Record<string, string> = {

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/service.ts
@@ -285,6 +285,21 @@ export class ExtensionOptionsService implements IStoreService {
             }
           }),
       })
+      .version(28, {
+        upgrade: (data) =>
+          produce<ExtensionOptions>(data, (draft) => {
+            draft.hotkeys = {
+              ...defaultKeymap,
+              ...draft.hotkeys,
+              toggleSkipButton:
+                draft.hotkeys?.toggleSkipButton ??
+                defaultKeymap.toggleSkipButton,
+              toggleDanmakuTimeline:
+                draft.hotkeys?.toggleDanmakuTimeline ??
+                defaultKeymap.toggleDanmakuTimeline,
+            }
+          }),
+      })
   }
 
   async get() {

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
@@ -10,9 +10,8 @@ import {
 import type { PopperProps } from '@mui/material'
 import { MenuList, Paper, Popper } from '@mui/material'
 import { useTranslation } from 'react-i18next'
-
-import { useHotkeyOptions } from '@/common/options/extensionOptions/useHotkeyOptions'
 import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
+import { useHotkeyOptions } from '@/common/options/extensionOptions/useHotkeyOptions'
 import { playerRpcClient } from '@/common/rpcClient/background/client'
 import { useLoadDanmaku } from '@/content/controller/common/hooks/useLoadDanmaku'
 import { useShowDanmaku } from '@/content/controller/common/hooks/useShowDanmaku'

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
@@ -1,7 +1,9 @@
 import {
   Eject,
   PictureInPicture,
+  SkipNext,
   Sync,
+  Timeline,
   Visibility,
   VisibilityOff,
 } from '@mui/icons-material'
@@ -10,6 +12,7 @@ import { MenuList, Paper, Popper } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 import { useHotkeyOptions } from '@/common/options/extensionOptions/useHotkeyOptions'
+import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
 import { playerRpcClient } from '@/common/rpcClient/background/client'
 import { useLoadDanmaku } from '@/content/controller/common/hooks/useLoadDanmaku'
 import { useShowDanmaku } from '@/content/controller/common/hooks/useShowDanmaku'
@@ -47,8 +50,28 @@ export const FabContextMenu = (props: FabContextMenuProps) => {
   const { refreshComments, loadMutation, canRefresh } = useLoadDanmaku()
 
   const { getKeyCombo } = useHotkeyOptions()
+  const { data: extensionOptions, partialUpdate } = useExtensionOptions()
 
   const isLoading = loadMutation.isPending
+  const playerOptions = extensionOptions.playerOptions
+
+  const toggleSkipButton = () => {
+    void partialUpdate({
+      playerOptions: {
+        ...playerOptions,
+        showSkipButton: !playerOptions.showSkipButton,
+      },
+    })
+  }
+
+  const toggleDanmakuTimeline = () => {
+    void partialUpdate({
+      playerOptions: {
+        ...playerOptions,
+        showDanmakuTimeline: !playerOptions.showDanmakuTimeline,
+      },
+    })
+  }
 
   const menuItems: ContextMenuItemProps[] = [
     {
@@ -78,6 +101,24 @@ export const FabContextMenu = (props: FabContextMenuProps) => {
           ? t('danmaku.disable', 'Hide Danmaku')
           : t('danmaku.enable', 'Show Danmaku'),
       hotkey: getKeyCombo('toggleEnableDanmaku'),
+    },
+    {
+      action: toggleSkipButton,
+      icon: () => <SkipNext fontSize="small" />,
+      label: () =>
+        playerOptions.showSkipButton
+          ? t('optionsPage.player.hideSkipButton', 'Hide skip button (OP/ED)')
+          : t('optionsPage.player.showSkipButton', 'Show skip button (OP/ED)'),
+      hotkey: getKeyCombo('toggleSkipButton'),
+    },
+    {
+      action: toggleDanmakuTimeline,
+      icon: () => <Timeline fontSize="small" />,
+      label: () =>
+        playerOptions.showDanmakuTimeline
+          ? t('optionsPage.player.hideDanmakuTimeline', 'Hide danmaku density')
+          : t('optionsPage.player.showDanmakuTimeline', 'Show danmaku density'),
+      hotkey: getKeyCombo('toggleDanmakuTimeline'),
     },
     {
       action: () => enterPip(),


### PR DESCRIPTION
Add hotkey and context menu options for skip button and danmaku density to improve player settings accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-16562a8b-bf2e-496d-9542-7a218c09855e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16562a8b-bf2e-496d-9542-7a218c09855e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

