### PR TITLE
(extension) fix title mapping clear not persisting [DA-448]

### DIFF
--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -166,6 +166,9 @@ export class RpcManager {
         seasonMapAdd: async (data) => {
           return this.titleMappingService.add(SeasonMap.from(data))
         },
+        seasonMapPut: async (data) => {
+          return this.titleMappingService.put(SeasonMap.from(data))
+        },
         seasonMapDelete: async (data) => {
           return this.titleMappingService.remove(data.key)
         },

--- a/packages/danmaku-anywhere/src/background/services/persistence/TitleMappingService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/TitleMappingService.ts
@@ -34,6 +34,11 @@ export class TitleMappingService {
     })
   }
 
+  async put(map: SeasonMap) {
+    this.logger.debug('Replacing title mapping:', map.toSnapshot())
+    await this.db.seasonMap.put(map.toSnapshot())
+  }
+
   async remove(key: string) {
     this.logger.debug('Removing title mapping:', key)
     await this.db.seasonMap.where({ key }).delete()

--- a/packages/danmaku-anywhere/src/common/components/TitleMapping/TitleMappingDetails.tsx
+++ b/packages/danmaku-anywhere/src/common/components/TitleMapping/TitleMappingDetails.tsx
@@ -35,13 +35,10 @@ export const TitleMappingDetails = ({ map }: TitleMappingDetailsProps) => {
     providerConfigId: string,
     newValue: Season | null
   ) => {
-    if (newValue) {
-      await mutations.add.mutateAsync(
-        map.withMapping(providerConfigId, newValue.id)
-      )
-    } else {
-      await mutations.add.mutateAsync(map.withoutProvider(providerConfigId))
-    }
+    const updated = newValue
+      ? map.withMapping(providerConfigId, newValue.id)
+      : map.withoutProvider(providerConfigId)
+    await mutations.put.mutateAsync(updated)
   }
 
   const seasonsByProvider = useMemo(() => {

--- a/packages/danmaku-anywhere/src/common/components/TitleMapping/TitleMappingDetails.tsx
+++ b/packages/danmaku-anywhere/src/common/components/TitleMapping/TitleMappingDetails.tsx
@@ -38,7 +38,11 @@ export const TitleMappingDetails = ({ map }: TitleMappingDetailsProps) => {
     const updated = newValue
       ? map.withMapping(providerConfigId, newValue.id)
       : map.withoutProvider(providerConfigId)
-    await mutations.put.mutateAsync(updated)
+    if (updated.isEmpty()) {
+      await mutations.delete.mutateAsync(updated.key)
+    } else {
+      await mutations.put.mutateAsync(updated)
+    }
   }
 
   const seasonsByProvider = useMemo(() => {

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -120,6 +120,7 @@ export type BackgroundMethods = {
   episodeDeleteCustom: RPCDef<CustomEpisodeQueryFilter, void>
   episodeImport: RPCDef<DanmakuImportData[], DanmakuImportResult>
   seasonMapAdd: RPCDef<SeasonMapSnapshot, void>
+  seasonMapPut: RPCDef<SeasonMapSnapshot, void>
   seasonMapDelete: RPCDef<{ key: string }, void>
   seasonMapDeleteMany: RPCDef<{ keys: string[] }, void>
 

--- a/packages/danmaku-anywhere/src/common/seasonMap/queries/useAllSeasonMap.ts
+++ b/packages/danmaku-anywhere/src/common/seasonMap/queries/useAllSeasonMap.ts
@@ -23,6 +23,12 @@ export const useSeasonMapMutations = () => {
       },
       meta,
     }),
+    put: useMutation({
+      mutationFn: async (map: SeasonMap) => {
+        return chromeRpcClient.seasonMapPut(map.toSnapshot())
+      },
+      meta,
+    }),
     delete: useMutation({
       mutationFn: async (key: string) => {
         return chromeRpcClient.seasonMapDelete({ key })

--- a/packages/danmaku-anywhere/src/common/standalone/standaloneHandlers.ts
+++ b/packages/danmaku-anywhere/src/common/standalone/standaloneHandlers.ts
@@ -77,6 +77,7 @@ export const standaloneBackgroundHandlers: StandaloneRpcHandlers<BackgroundMetho
     seasonGetAll: () => [],
     seasonMapGetAll: () => [],
     seasonMapAdd: () => undefined,
+    seasonMapPut: () => undefined,
     seasonMapDelete: () => undefined,
     seasonDelete: () => undefined,
     seasonRefresh: () => undefined,


### PR DESCRIPTION
## Summary
- Fix Autocomplete clear button in the title mapping details view being a silent no-op
- Root cause: `handleChange` called `seasonMapAdd` with the modified map, but the service merges the incoming map into the existing DB snapshot, and `SeasonMap.merge` only adds/updates entries — it never removes them, so clearing a provider was never persisted
- Add a `seasonMapPut` RPC with replace semantics and use it in `handleChange`; the merge-semantics `seasonMapAdd` is preserved for the search dialog flow, which benefits from merging new single-provider entries into existing mappings