### PR TITLE
(extension) fix use-gesture touch-action warning on danmaku tree items [DA-449]

### DIFF
--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
@@ -31,6 +31,7 @@ const StyledTreeRoot = styled(TreeItemRoot)({
 const StyledTreeContent = styled(TreeItemContent)({
   height: '40px',
   paddingRight: '32px',
+  touchAction: 'none',
 })
 
 interface CustomTreeItemProps

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
@@ -31,7 +31,8 @@ const StyledTreeRoot = styled(TreeItemRoot)({
 const StyledTreeContent = styled(TreeItemContent)({
   height: '40px',
   paddingRight: '32px',
-  touchAction: 'none',
+  // pan-y preserves native vertical scroll of the enclosing tree container
+  touchAction: 'pan-y',
 })
 
 interface CustomTreeItemProps


### PR DESCRIPTION
## Summary
- Add `touchAction: 'none'` to `StyledTreeContent` in `DanmakuTreeItem` so the `useLongPress` (`useDrag`) target suppresses the `@use-gesture` dev warning and the drag gesture behaves correctly on touch devices.
- Matches the existing pattern used by `Window.tsx` and `FloatingButton.tsx`, the other drag targets in the extension.