### PR TITLE
(extension) differentiate mount unavailable banner [DA-453]

### DIFF
--- a/.claude/commands/da-dev.md
+++ b/.claude/commands/da-dev.md
@@ -45,6 +45,12 @@ for f in packages/danmaku-anywhere/.env packages/danmaku-anywhere/.env.local; do
 done
 ```
 
+**Install dependencies** — `node_modules/` is not shared between worktrees, so type-check/lint/tests will fail until deps are installed. Build packages too so downstream type-checks can find `dist/`:
+
+```bash
+cd ../danmaku-anywhere-DA-XXX && pnpm install && pnpm build:packages
+```
+
 **Register worktree for permissions** — add the worktree root path to `additionalDirectories` in the user's Claude Code settings (use the `update-config` skill) so the new session has file access without re-prompting.
 
 ### 2b. Worktree Handoff
@@ -93,10 +99,10 @@ Always run lint and type-check. For tests and build, follow the relevant area's 
 
 #### Extension: open dev browser
 
-For extension changes, launch a dev browser with HMR **at the start of implementation**:
+For extension changes, launch a dev browser with HMR **at the start of implementation**. Always run `pnpm install` first — fresh worktrees have no `node_modules`, and stale worktrees may be out of date with the lockfile:
 
 ```bash
-wt -w 0 new-tab --title 'DA-XXX: dev browser' -d '<worktree-path>/packages/danmaku-anywhere' -- powershell -NoExit -Command "node e2e/open-browser.ts"
+wt -w 0 new-tab --title 'DA-XXX: dev browser' -d '<worktree-path>/packages/danmaku-anywhere' -- powershell -NoExit -Command "pnpm install; node e2e/open-browser.ts"
 ```
 
 Human verifies behavior live. Skip for trivial changes (config-only, types, docs).

--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -4,6 +4,7 @@ import { ContextMenuManager } from '@/background/contextMenu/ContextMenuManager'
 import { NetRequestManager } from '@/background/netRequest/NetrequestManager'
 import { PortsManager } from '@/background/ports/PortsManager'
 import { RpcManager } from '@/background/rpc/RpcManager'
+import { MountConfigTabReloader } from '@/background/scripting/MountConfigTabReloader'
 import { ScriptingManager } from '@/background/scripting/ScriptingManager'
 import { OptionsManager } from '@/background/syncOptions/OptionsManager'
 import { deferredConfigureStore } from '@/background/utils/deferredConfigureStore'
@@ -20,6 +21,7 @@ configureApiStore({
 
 container.get(OptionsManager).setup()
 container.get(ScriptingManager).setup()
+container.get(MountConfigTabReloader).setup()
 container.get(RpcManager).setup()
 container.get(NetRequestManager).setup()
 container.get(AlarmManager).setup()

--- a/packages/danmaku-anywhere/src/background/scripting/MountConfigTabReloader.ts
+++ b/packages/danmaku-anywhere/src/background/scripting/MountConfigTabReloader.ts
@@ -1,0 +1,121 @@
+import { inject, injectable } from 'inversify'
+import { type ILogger, LoggerSymbol } from '@/common/Logger'
+import type { MountConfig } from '@/common/options/mountConfig/schema'
+import { MountConfigService } from '@/common/options/mountConfig/service'
+
+/**
+ * When the user adds a new mount config (or enables an existing one), existing
+ * tabs that match the new patterns do not automatically get the freshly
+ * registered content script — `chrome.scripting.registerContentScripts` only
+ * affects future navigations. This manager diffs mount config changes and
+ * reloads any open tabs that newly match, so the user doesn't have to refresh
+ * manually.
+ */
+@injectable('Singleton')
+export class MountConfigTabReloader {
+  private logger: ILogger
+  private previousEnabledPatterns = new Set<string>()
+  private initialized = false
+
+  constructor(
+    @inject(MountConfigService)
+    private mountConfigService: MountConfigService,
+    @inject(LoggerSymbol) logger: ILogger
+  ) {
+    this.logger = logger.sub('[MountConfigTabReloader]')
+  }
+
+  setup() {
+    void this.initializePreviousPatterns()
+
+    this.mountConfigService.options.onChange(async (configs) => {
+      if (!configs) {
+        return
+      }
+      await this.handleConfigChange(configs)
+    })
+  }
+
+  private async initializePreviousPatterns() {
+    try {
+      const configs = await this.mountConfigService.getAll()
+      this.previousEnabledPatterns = collectEnabledPatterns(configs)
+    } finally {
+      this.initialized = true
+    }
+  }
+
+  private async handleConfigChange(configs: MountConfig[]) {
+    // Skip the first change event before our baseline is ready, otherwise we
+    // would treat every existing pattern as newly-added on startup.
+    if (!this.initialized) {
+      this.previousEnabledPatterns = collectEnabledPatterns(configs)
+      return
+    }
+
+    const nextPatterns = collectEnabledPatterns(configs)
+    const addedPatterns: string[] = []
+    for (const pattern of nextPatterns) {
+      if (!this.previousEnabledPatterns.has(pattern)) {
+        addedPatterns.push(pattern)
+      }
+    }
+    this.previousEnabledPatterns = nextPatterns
+
+    if (addedPatterns.length === 0) {
+      return
+    }
+
+    await this.reloadTabsMatching(addedPatterns)
+  }
+
+  private async reloadTabsMatching(patterns: string[]) {
+    const seenTabIds = new Set<number>()
+
+    for (const pattern of patterns) {
+      let tabs: chrome.tabs.Tab[]
+      try {
+        tabs = await chrome.tabs.query({ url: pattern })
+      } catch (error) {
+        this.logger.debug('Failed to query tabs for pattern', {
+          pattern,
+          error,
+        })
+        continue
+      }
+
+      for (const tab of tabs) {
+        if (tab.id === undefined || seenTabIds.has(tab.id)) {
+          continue
+        }
+        seenTabIds.add(tab.id)
+        this.logger.debug('Reloading tab', {
+          tabId: tab.id,
+          url: tab.url,
+          pattern,
+        })
+        try {
+          await chrome.tabs.reload(tab.id)
+        } catch (error) {
+          this.logger.debug('Failed to reload tab', {
+            tabId: tab.id,
+            error,
+          })
+        }
+      }
+    }
+  }
+}
+
+function collectEnabledPatterns(configs: MountConfig[]): Set<string> {
+  const patterns = new Set<string>()
+  for (const config of configs) {
+    if (!config.enabled) {
+      continue
+    }
+    for (const pattern of config.patterns) {
+      patterns.add(pattern)
+    }
+  }
+  return patterns
+}

--- a/packages/danmaku-anywhere/src/background/scripting/MountConfigTabReloader.ts
+++ b/packages/danmaku-anywhere/src/background/scripting/MountConfigTabReloader.ts
@@ -26,23 +26,28 @@ export class MountConfigTabReloader {
   }
 
   setup() {
-    void this.initializePreviousPatterns()
-
+    // Register the change listener first so we don't miss events that arrive
+    // while the initial getAll() is still in flight. Whichever of the two
+    // completes first seeds `previousEnabledPatterns`; the other is a no-op
+    // guarded by `initialized`.
     this.mountConfigService.options.onChange(async (configs) => {
       if (!configs) {
         return
       }
       await this.handleConfigChange(configs)
     })
+
+    void this.initializePreviousPatterns()
   }
 
   private async initializePreviousPatterns() {
-    try {
-      const configs = await this.mountConfigService.getAll()
-      this.previousEnabledPatterns = collectEnabledPatterns(configs)
-    } finally {
-      this.initialized = true
+    const configs = await this.mountConfigService.getAll()
+    if (this.initialized) {
+      // An onChange already seeded us with fresher data — don't overwrite.
+      return
     }
+    this.previousEnabledPatterns = collectEnabledPatterns(configs)
+    this.initialized = true
   }
 
   private async handleConfigChange(configs: MountConfig[]) {
@@ -50,6 +55,7 @@ export class MountConfigTabReloader {
     // would treat every existing pattern as newly-added on startup.
     if (!this.initialized) {
       this.previousEnabledPatterns = collectEnabledPatterns(configs)
+      this.initialized = true
       return
     }
 
@@ -70,38 +76,27 @@ export class MountConfigTabReloader {
   }
 
   private async reloadTabsMatching(patterns: string[]) {
-    const seenTabIds = new Set<number>()
+    let tabs: chrome.tabs.Tab[]
+    try {
+      // chrome.tabs.query accepts a string array, deduping matches for us.
+      tabs = await chrome.tabs.query({ url: patterns })
+    } catch (error) {
+      this.logger.debug('Failed to query tabs for patterns', {
+        patterns,
+        error,
+      })
+      return
+    }
 
-    for (const pattern of patterns) {
-      let tabs: chrome.tabs.Tab[]
-      try {
-        tabs = await chrome.tabs.query({ url: pattern })
-      } catch (error) {
-        this.logger.debug('Failed to query tabs for pattern', {
-          pattern,
-          error,
-        })
+    for (const tab of tabs) {
+      if (tab.id === undefined) {
         continue
       }
-
-      for (const tab of tabs) {
-        if (tab.id === undefined || seenTabIds.has(tab.id)) {
-          continue
-        }
-        seenTabIds.add(tab.id)
-        this.logger.debug('Reloading tab', {
-          tabId: tab.id,
-          url: tab.url,
-          pattern,
-        })
-        try {
-          await chrome.tabs.reload(tab.id)
-        } catch (error) {
-          this.logger.debug('Failed to reload tab', {
-            tabId: tab.id,
-            error,
-          })
-        }
+      this.logger.debug('Reloading tab', { tabId: tab.id, url: tab.url })
+      try {
+        await chrome.tabs.reload(tab.id)
+      } catch (error) {
+        this.logger.debug('Failed to reload tab', { tabId: tab.id, error })
       }
     }
   }

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/MountPageContent.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/MountPageContent.tsx
@@ -3,7 +3,6 @@ import type {
   GenericEpisodeLite,
 } from '@danmaku-anywhere/danmaku-converter'
 import { UploadFile } from '@mui/icons-material'
-import { Alert, Button, Collapse } from '@mui/material'
 import type { ReactElement } from 'react'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -25,20 +24,6 @@ import { ImportResultContent } from '../ImportPageCore/ImportResultContent'
 import { ScrollBox } from '../layout/ScrollBox'
 import type { DAMenuItemConfig } from '../Menu/DAMenuItemConfig'
 
-export type MountAvailability =
-  | { kind: 'pending' }
-  | { kind: 'connected' }
-  | { kind: 'unsupported' }
-  | { kind: 'disabled' }
-  | {
-      kind: 'noConfig'
-      url: string
-      pattern: string
-      name: string
-    }
-
-const CONNECTED_AVAILABILITY: MountAvailability = { kind: 'connected' }
-
 export interface MountPageContentProps {
   filter: string
   onFilterChange: (filter: string) => void
@@ -51,9 +36,8 @@ export interface MountPageContentProps {
 
   onUnmount?: () => void
   isMounted?: boolean
-  availability?: MountAvailability
+  isConnected?: boolean
   onGoSearch: () => void
-  onGoCreateMountConfig?: () => void
 }
 
 export const MountPageContent = ({
@@ -67,9 +51,8 @@ export const MountPageContent = ({
   isMounting,
   onUnmount,
   isMounted = false,
-  availability = CONNECTED_AVAILABILITY,
+  isConnected = true,
   onGoSearch,
-  onGoCreateMountConfig,
 }: MountPageContentProps): ReactElement => {
   const { t } = useTranslation()
   const { isMobile } = usePlatformInfo()
@@ -113,61 +96,6 @@ export const MountPageContent = ({
     ],
     [importFlow, t]
   )
-
-  const showAlert =
-    availability.kind !== 'connected' && availability.kind !== 'pending'
-
-  // Keep the last visible availability mounted so Collapse can animate the
-  // alert out after the state flips back to connected/pending.
-  const displayedAvailabilityRef = useRef<MountAvailability | null>(null)
-  if (showAlert) {
-    displayedAvailabilityRef.current = availability
-  }
-  const displayedAvailability = displayedAvailabilityRef.current
-
-  function renderAlertContent(av: MountAvailability) {
-    if (av.kind === 'disabled') {
-      return (
-        <Alert severity="warning" square>
-          {t(
-            'mountPage.alert.extensionDisabled',
-            'Danmaku Anywhere is disabled'
-          )}
-        </Alert>
-      )
-    }
-    if (av.kind === 'unsupported') {
-      return (
-        <Alert severity="warning" square>
-          {t(
-            'mountPage.alert.pageUnsupported',
-            'This page cannot host danmaku'
-          )}
-        </Alert>
-      )
-    }
-    if (av.kind === 'noConfig') {
-      return (
-        <Alert
-          severity="info"
-          square
-          action={
-            <Button
-              onClick={onGoCreateMountConfig}
-              size="small"
-              color="inherit"
-              variant="text"
-            >
-              {t('mountPage.alert.createMountConfig', 'Create mount config')}
-            </Button>
-          }
-        >
-          {t('mountPage.alert.noMountConfig', 'No mount config for this site')}
-        </Alert>
-      )
-    }
-    return null
-  }
 
   if (viewingEpisode) {
     return (
@@ -236,11 +164,6 @@ export const MountPageContent = ({
           selectionCount={selectionCount}
         />
 
-        <Collapse in={showAlert} unmountOnExit>
-          {displayedAvailability !== null &&
-            renderAlertContent(displayedAvailability)}
-        </Collapse>
-
         <ScrollBox flexGrow={1} overflow="auto">
           <DanmakuTree
             ref={danmakuTreeRef}
@@ -249,7 +172,7 @@ export const MountPageContent = ({
             onSelect={(ep) => onMount([ep])}
             onViewDanmaku={setViewingEpisode}
             onSelectionChange={(s) => setSelectionCount(s.length)}
-            canMount={availability.kind === 'connected' && !isMounting}
+            canMount={isConnected && !isMounting}
             multiselect={multiselect}
             onImport={importFlow.openFileInput}
             onGoSearch={onGoSearch}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/MountPageContent.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/MountPageContent.tsx
@@ -3,7 +3,7 @@ import type {
   GenericEpisodeLite,
 } from '@danmaku-anywhere/danmaku-converter'
 import { UploadFile } from '@mui/icons-material'
-import { Alert, Button } from '@mui/material'
+import { Alert, Button, Collapse } from '@mui/material'
 import type { ReactElement } from 'react'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -25,6 +25,20 @@ import { ImportResultContent } from '../ImportPageCore/ImportResultContent'
 import { ScrollBox } from '../layout/ScrollBox'
 import type { DAMenuItemConfig } from '../Menu/DAMenuItemConfig'
 
+export type MountAvailability =
+  | { kind: 'pending' }
+  | { kind: 'connected' }
+  | { kind: 'unsupported' }
+  | { kind: 'disabled' }
+  | {
+      kind: 'noConfig'
+      url: string
+      pattern: string
+      name: string
+    }
+
+const CONNECTED_AVAILABILITY: MountAvailability = { kind: 'connected' }
+
 export interface MountPageContentProps {
   filter: string
   onFilterChange: (filter: string) => void
@@ -37,7 +51,7 @@ export interface MountPageContentProps {
 
   onUnmount?: () => void
   isMounted?: boolean
-  isConnected?: boolean
+  availability?: MountAvailability
   onGoSearch: () => void
   onGoCreateMountConfig?: () => void
 }
@@ -53,7 +67,7 @@ export const MountPageContent = ({
   isMounting,
   onUnmount,
   isMounted = false,
-  isConnected = true,
+  availability = CONNECTED_AVAILABILITY,
   onGoSearch,
   onGoCreateMountConfig,
 }: MountPageContentProps): ReactElement => {
@@ -100,31 +114,59 @@ export const MountPageContent = ({
     [importFlow, t]
   )
 
-  function renderAlert() {
-    if (isConnected === undefined || isConnected) {
-      return null
+  const showAlert =
+    availability.kind !== 'connected' && availability.kind !== 'pending'
+
+  // Keep the last visible availability mounted so Collapse can animate the
+  // alert out after the state flips back to connected/pending.
+  const displayedAvailabilityRef = useRef<MountAvailability | null>(null)
+  if (showAlert) {
+    displayedAvailabilityRef.current = availability
+  }
+  const displayedAvailability = displayedAvailabilityRef.current
+
+  function renderAlertContent(av: MountAvailability) {
+    if (av.kind === 'disabled') {
+      return (
+        <Alert severity="warning" square>
+          {t(
+            'mountPage.alert.extensionDisabled',
+            'Danmaku Anywhere is disabled'
+          )}
+        </Alert>
+      )
     }
-    return (
-      <Alert
-        severity="warning"
-        square
-        action={
-          <Button
-            onClick={onGoCreateMountConfig}
-            size="small"
-            color="inherit"
-            variant="text"
-          >
-            {t('mountPage.alert.checkMountConfig', 'Check Mount config')}
-          </Button>
-        }
-      >
-        {t(
-          'mountPage.alert.mountingDisabled',
-          'Cannot mount danmaku on this page'
-        )}
-      </Alert>
-    )
+    if (av.kind === 'unsupported') {
+      return (
+        <Alert severity="warning" square>
+          {t(
+            'mountPage.alert.pageUnsupported',
+            'This page cannot host danmaku'
+          )}
+        </Alert>
+      )
+    }
+    if (av.kind === 'noConfig') {
+      return (
+        <Alert
+          severity="info"
+          square
+          action={
+            <Button
+              onClick={onGoCreateMountConfig}
+              size="small"
+              color="inherit"
+              variant="text"
+            >
+              {t('mountPage.alert.createMountConfig', 'Create mount config')}
+            </Button>
+          }
+        >
+          {t('mountPage.alert.noMountConfig', 'No mount config for this site')}
+        </Alert>
+      )
+    }
+    return null
   }
 
   if (viewingEpisode) {
@@ -194,7 +236,10 @@ export const MountPageContent = ({
           selectionCount={selectionCount}
         />
 
-        {renderAlert()}
+        <Collapse in={showAlert} unmountOnExit>
+          {displayedAvailability !== null &&
+            renderAlertContent(displayedAvailability)}
+        </Collapse>
 
         <ScrollBox flexGrow={1} overflow="auto">
           <DanmakuTree
@@ -204,7 +249,7 @@ export const MountPageContent = ({
             onSelect={(ep) => onMount([ep])}
             onViewDanmaku={setViewingEpisode}
             onSelectionChange={(s) => setSelectionCount(s.length)}
-            canMount={isConnected && !isMounting}
+            canMount={availability.kind === 'connected' && !isMounting}
             multiselect={multiselect}
             onImport={importFlow.openFileInput}
             onGoSearch={onGoSearch}

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -361,8 +361,10 @@
   },
   "mountPage": {
     "alert": {
-      "checkMountConfig": "Check Mount config",
-      "mountingDisabled": "Cannot mount danmaku on this page"
+      "createMountConfig": "Create mount config",
+      "extensionDisabled": "Danmaku Anywhere is disabled",
+      "noMountConfig": "No mount config for this site",
+      "pageUnsupported": "This page cannot host danmaku"
     },
     "confirmDeleteMultiple_one": "Are you sure you want to delete {{count}} item?",
     "confirmDeleteMultiple_other": "Are you sure you want to delete {{count}} items?",

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -362,6 +362,8 @@
   "mountPage": {
     "alert": {
       "createMountConfig": "Create mount config",
+      "disabledMountConfig": "Mount config \"{{name}}\" is disabled",
+      "enableMountConfig": "Enable config",
       "extensionDisabled": "Danmaku Anywhere is disabled",
       "noMountConfig": "No mount config for this site",
       "pageUnsupported": "This page cannot host danmaku"

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -351,6 +351,8 @@
   "mountPage": {
     "alert": {
       "createMountConfig": "创建装填配置",
+      "disabledMountConfig": "装填配置 \"{{name}}\" 已禁用",
+      "enableMountConfig": "启用配置",
       "extensionDisabled": "弹幕任何地方已禁用",
       "noMountConfig": "该网站暂无装填配置",
       "pageUnsupported": "该类型页面无法装填弹幕"

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -350,8 +350,10 @@
   },
   "mountPage": {
     "alert": {
-      "checkMountConfig": "检查装填配置",
-      "mountingDisabled": "无法在当前页面装填弹幕"
+      "createMountConfig": "创建装填配置",
+      "extensionDisabled": "弹幕任何地方已禁用",
+      "noMountConfig": "该网站暂无装填配置",
+      "pageUnsupported": "该类型页面无法装填弹幕"
     },
     "confirmDeleteMultiple_other": "确定要删除{{count}}个弹幕吗？",
     "goSearch": "前往搜索",

--- a/packages/danmaku-anywhere/src/popup/component/MountAvailabilityBanner.tsx
+++ b/packages/danmaku-anywhere/src/popup/component/MountAvailabilityBanner.tsx
@@ -1,7 +1,8 @@
 import { Close } from '@mui/icons-material'
+import type { AlertColor } from '@mui/material'
 import { Alert, Box, Button, Collapse, IconButton } from '@mui/material'
 import type { ReactElement } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 
@@ -11,6 +12,75 @@ import { useEditMountConfig } from '@/common/options/mountConfig/useMountConfig'
 import type { MountAvailability } from '@/popup/hooks/useMountAvailability'
 import { useMountAvailability } from '@/popup/hooks/useMountAvailability'
 import { useStore } from '@/popup/store'
+
+type TFunc = ReturnType<typeof useTranslation>['t']
+
+interface AlertDescriptor {
+  severity: AlertColor
+  message: string
+  cta?: {
+    label: string
+    onClick: () => void
+  }
+}
+
+interface AlertContext {
+  onCreateMountConfig: () => void
+  onEnableMountConfig: (configId: string) => void
+}
+
+function describeAlert(
+  av: MountAvailability,
+  t: TFunc,
+  ctx: AlertContext
+): AlertDescriptor | null {
+  switch (av.kind) {
+    case 'connected':
+    case 'pending':
+      return null
+    case 'disabled':
+      return {
+        severity: 'warning',
+        message: t(
+          'mountPage.alert.extensionDisabled',
+          'Danmaku Anywhere is disabled'
+        ),
+      }
+    case 'unsupported':
+      return {
+        severity: 'warning',
+        message: t(
+          'mountPage.alert.pageUnsupported',
+          'This page cannot host danmaku'
+        ),
+      }
+    case 'disabledConfig':
+      return {
+        severity: 'info',
+        message: t(
+          'mountPage.alert.disabledMountConfig',
+          'Mount config "{{name}}" is disabled',
+          { name: av.configName }
+        ),
+        cta: {
+          label: t('mountPage.alert.enableMountConfig', 'Enable config'),
+          onClick: () => ctx.onEnableMountConfig(av.configId),
+        },
+      }
+    case 'noConfig':
+      return {
+        severity: 'info',
+        message: t(
+          'mountPage.alert.noMountConfig',
+          'No mount config for this site'
+        ),
+        cta: {
+          label: t('mountPage.alert.createMountConfig', 'Create mount config'),
+          onClick: ctx.onCreateMountConfig,
+        },
+      }
+  }
+}
 
 export const MountAvailabilityBanner = (): ReactElement => {
   const { t } = useTranslation()
@@ -24,31 +94,32 @@ export const MountAvailabilityBanner = (): ReactElement => {
   const [dismissedKind, setDismissedKind] = useState<
     MountAvailability['kind'] | null
   >(null)
+  const [displayedAvailability, setDisplayedAvailability] =
+    useState<MountAvailability | null>(null)
 
-  // A new availability kind means a new reason to alert — clear any previous
-  // dismissal so the user sees the new banner.
-  useEffect(() => {
+  const shouldShow =
+    availability.kind !== 'connected' &&
+    availability.kind !== 'pending' &&
+    dismissedKind !== availability.kind
+
+  // Sync the displayed availability before paint so Collapse has content to
+  // measure on the frame the banner opens. We clear on the Collapse onExited
+  // callback below instead of tearing down mid-animation.
+  useLayoutEffect(() => {
     if (dismissedKind !== null && dismissedKind !== availability.kind) {
       setDismissedKind(null)
     }
-  }, [availability.kind, dismissedKind])
-
-  const hasAlertableAvailability =
-    availability.kind !== 'connected' && availability.kind !== 'pending'
-  const showAlert =
-    hasAlertableAvailability && dismissedKind !== availability.kind
-
-  // Keep the last visible availability mounted so Collapse can animate the
-  // alert out after the state flips back to connected/pending or after the
-  // user dismisses it.
-  const displayedAvailabilityRef = useRef<MountAvailability | null>(null)
-  if (showAlert) {
-    displayedAvailabilityRef.current = availability
-  }
-  const displayedAvailability = displayedAvailabilityRef.current
+    if (shouldShow) {
+      setDisplayedAvailability(availability)
+    }
+  }, [availability, dismissedKind, shouldShow])
 
   const handleDismiss = () => {
     setDismissedKind(availability.kind)
+  }
+
+  const handleExited = () => {
+    setDisplayedAvailability(null)
   }
 
   const handleCreateMountConfig = () => {
@@ -75,107 +146,60 @@ export const MountAvailabilityBanner = (): ReactElement => {
     )
   }
 
+  const descriptor = displayedAvailability
+    ? describeAlert(displayedAvailability, t, {
+        onCreateMountConfig: handleCreateMountConfig,
+        onEnableMountConfig: handleEnableMountConfig,
+      })
+    : null
+
   return (
-    <Collapse in={showAlert} unmountOnExit>
-      {displayedAvailability !== null &&
-        renderAlertContent(displayedAvailability, {
-          t,
-          onDismiss: handleDismiss,
-          onCreateMountConfig: handleCreateMountConfig,
-          onEnableMountConfig: handleEnableMountConfig,
-        })}
+    <Collapse
+      in={shouldShow && descriptor !== null}
+      onExited={handleExited}
+      // Pin to natural height in the popup's flex column — without this the
+      // Box below (which has flexGrow=1) shrinks the banner by a couple of
+      // pixels and the alert's bottom border clips into the content.
+      sx={{ flexShrink: 0 }}
+    >
+      {descriptor && (
+        <Alert
+          severity={descriptor.severity}
+          square
+          action={
+            <AlertActions
+              t={t}
+              onDismiss={handleDismiss}
+              cta={descriptor.cta}
+            />
+          }
+        >
+          {descriptor.message}
+        </Alert>
+      )}
     </Collapse>
   )
 }
 
-interface RenderContext {
-  t: ReturnType<typeof useTranslation>['t']
-  onDismiss: () => void
-  onCreateMountConfig: () => void
-  onEnableMountConfig: (configId: string) => void
-}
-
-function renderAlertContent(
-  av: MountAvailability,
-  ctx: RenderContext
-): ReactElement | null {
-  const { t, onDismiss, onCreateMountConfig, onEnableMountConfig } = ctx
-
-  if (av.kind === 'disabled') {
-    return (
-      <Alert severity="warning" square onClose={onDismiss}>
-        {t('mountPage.alert.extensionDisabled', 'Danmaku Anywhere is disabled')}
-      </Alert>
-    )
-  }
-  if (av.kind === 'unsupported') {
-    return (
-      <Alert severity="warning" square onClose={onDismiss}>
-        {t('mountPage.alert.pageUnsupported', 'This page cannot host danmaku')}
-      </Alert>
-    )
-  }
-  if (av.kind === 'disabledConfig') {
-    return (
-      <Alert
-        severity="info"
-        square
-        action={
-          <AlertActions t={t} onDismiss={onDismiss}>
-            <Button
-              onClick={() => onEnableMountConfig(av.configId)}
-              size="small"
-              color="inherit"
-              variant="text"
-            >
-              {t('mountPage.alert.enableMountConfig', 'Enable config')}
-            </Button>
-          </AlertActions>
-        }
-      >
-        {t(
-          'mountPage.alert.disabledMountConfig',
-          'Mount config "{{name}}" is disabled',
-          { name: av.configName }
-        )}
-      </Alert>
-    )
-  }
-  if (av.kind === 'noConfig') {
-    return (
-      <Alert
-        severity="info"
-        square
-        action={
-          <AlertActions t={t} onDismiss={onDismiss}>
-            <Button
-              onClick={onCreateMountConfig}
-              size="small"
-              color="inherit"
-              variant="text"
-            >
-              {t('mountPage.alert.createMountConfig', 'Create mount config')}
-            </Button>
-          </AlertActions>
-        }
-      >
-        {t('mountPage.alert.noMountConfig', 'No mount config for this site')}
-      </Alert>
-    )
-  }
-  return null
-}
-
 interface AlertActionsProps {
-  t: ReturnType<typeof useTranslation>['t']
+  t: TFunc
   onDismiss: () => void
-  children: ReactElement
+  cta?: AlertDescriptor['cta']
 }
 
-function AlertActions({ t, onDismiss, children }: AlertActionsProps) {
+function AlertActions({ t, onDismiss, cta }: AlertActionsProps) {
   return (
     <Box display="flex" alignItems="center" gap={0.5}>
-      {children}
+      {cta && (
+        <Button
+          onClick={cta.onClick}
+          size="small"
+          color="inherit"
+          variant="text"
+        >
+          {cta.label}
+        </Button>
+      )}
       <IconButton
         size="small"
         color="inherit"

--- a/packages/danmaku-anywhere/src/popup/component/MountAvailabilityBanner.tsx
+++ b/packages/danmaku-anywhere/src/popup/component/MountAvailabilityBanner.tsx
@@ -1,0 +1,189 @@
+import { Close } from '@mui/icons-material'
+import { Alert, Box, Button, Collapse, IconButton } from '@mui/material'
+import type { ReactElement } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router'
+
+import { useToast } from '@/common/components/Toast/toastStore'
+import { createMountConfig } from '@/common/options/mountConfig/constant'
+import { useEditMountConfig } from '@/common/options/mountConfig/useMountConfig'
+import type { MountAvailability } from '@/popup/hooks/useMountAvailability'
+import { useMountAvailability } from '@/popup/hooks/useMountAvailability'
+import { useStore } from '@/popup/store'
+
+export const MountAvailabilityBanner = (): ReactElement => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const toast = useToast.use.toast()
+  const { setEditingConfig } = useStore.use.config()
+  const { update: updateMountConfig } = useEditMountConfig()
+
+  const availability = useMountAvailability()
+
+  const [dismissedKind, setDismissedKind] = useState<
+    MountAvailability['kind'] | null
+  >(null)
+
+  // A new availability kind means a new reason to alert — clear any previous
+  // dismissal so the user sees the new banner.
+  useEffect(() => {
+    if (dismissedKind !== null && dismissedKind !== availability.kind) {
+      setDismissedKind(null)
+    }
+  }, [availability.kind, dismissedKind])
+
+  const hasAlertableAvailability =
+    availability.kind !== 'connected' && availability.kind !== 'pending'
+  const showAlert =
+    hasAlertableAvailability && dismissedKind !== availability.kind
+
+  // Keep the last visible availability mounted so Collapse can animate the
+  // alert out after the state flips back to connected/pending or after the
+  // user dismisses it.
+  const displayedAvailabilityRef = useRef<MountAvailability | null>(null)
+  if (showAlert) {
+    displayedAvailabilityRef.current = availability
+  }
+  const displayedAvailability = displayedAvailabilityRef.current
+
+  const handleDismiss = () => {
+    setDismissedKind(availability.kind)
+  }
+
+  const handleCreateMountConfig = () => {
+    if (availability.kind !== 'noConfig') {
+      return
+    }
+    setEditingConfig(
+      createMountConfig({
+        patterns: [availability.pattern],
+        name: availability.name,
+      })
+    )
+    navigate('/config/add')
+  }
+
+  const handleEnableMountConfig = (configId: string) => {
+    updateMountConfig.mutate(
+      { id: configId, config: { enabled: true } },
+      {
+        onError: (error) => {
+          toast.error(error.message)
+        },
+      }
+    )
+  }
+
+  return (
+    <Collapse in={showAlert} unmountOnExit>
+      {displayedAvailability !== null &&
+        renderAlertContent(displayedAvailability, {
+          t,
+          onDismiss: handleDismiss,
+          onCreateMountConfig: handleCreateMountConfig,
+          onEnableMountConfig: handleEnableMountConfig,
+        })}
+    </Collapse>
+  )
+}
+
+interface RenderContext {
+  t: ReturnType<typeof useTranslation>['t']
+  onDismiss: () => void
+  onCreateMountConfig: () => void
+  onEnableMountConfig: (configId: string) => void
+}
+
+function renderAlertContent(
+  av: MountAvailability,
+  ctx: RenderContext
+): ReactElement | null {
+  const { t, onDismiss, onCreateMountConfig, onEnableMountConfig } = ctx
+
+  if (av.kind === 'disabled') {
+    return (
+      <Alert severity="warning" square onClose={onDismiss}>
+        {t('mountPage.alert.extensionDisabled', 'Danmaku Anywhere is disabled')}
+      </Alert>
+    )
+  }
+  if (av.kind === 'unsupported') {
+    return (
+      <Alert severity="warning" square onClose={onDismiss}>
+        {t('mountPage.alert.pageUnsupported', 'This page cannot host danmaku')}
+      </Alert>
+    )
+  }
+  if (av.kind === 'disabledConfig') {
+    return (
+      <Alert
+        severity="info"
+        square
+        action={
+          <AlertActions t={t} onDismiss={onDismiss}>
+            <Button
+              onClick={() => onEnableMountConfig(av.configId)}
+              size="small"
+              color="inherit"
+              variant="text"
+            >
+              {t('mountPage.alert.enableMountConfig', 'Enable config')}
+            </Button>
+          </AlertActions>
+        }
+      >
+        {t(
+          'mountPage.alert.disabledMountConfig',
+          'Mount config "{{name}}" is disabled',
+          { name: av.configName }
+        )}
+      </Alert>
+    )
+  }
+  if (av.kind === 'noConfig') {
+    return (
+      <Alert
+        severity="info"
+        square
+        action={
+          <AlertActions t={t} onDismiss={onDismiss}>
+            <Button
+              onClick={onCreateMountConfig}
+              size="small"
+              color="inherit"
+              variant="text"
+            >
+              {t('mountPage.alert.createMountConfig', 'Create mount config')}
+            </Button>
+          </AlertActions>
+        }
+      >
+        {t('mountPage.alert.noMountConfig', 'No mount config for this site')}
+      </Alert>
+    )
+  }
+  return null
+}
+
+interface AlertActionsProps {
+  t: ReturnType<typeof useTranslation>['t']
+  onDismiss: () => void
+  children: ReactElement
+}
+
+function AlertActions({ t, onDismiss, children }: AlertActionsProps) {
+  return (
+    <Box display="flex" alignItems="center" gap={0.5}>
+      {children}
+      <IconButton
+        size="small"
+        color="inherit"
+        onClick={onDismiss}
+        aria-label={t('common.close', 'Close')}
+      >
+        <Close fontSize="small" />
+      </IconButton>
+    </Box>
+  )
+}

--- a/packages/danmaku-anywhere/src/popup/hooks/useActiveTabInfo.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useActiveTabInfo.ts
@@ -1,0 +1,52 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { controlQueryKeys } from '@/common/queries/queryKeys'
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
+
+export interface ActiveTabInfo {
+  url: string
+  protocol: string
+  pattern: string
+  name: string
+}
+
+function deriveActiveTabInfo(rawUrl: string): ActiveTabInfo | null {
+  try {
+    const url = new URL(rawUrl)
+    // file:// URLs have `origin === 'null'` per the WHATWG URL spec, so fall
+    // back to a match-all file pattern the user can narrow down.
+    if (url.protocol === 'file:') {
+      return {
+        url: url.href,
+        protocol: url.protocol,
+        pattern: 'file:///*',
+        name: 'file://',
+      }
+    }
+    return {
+      url: url.href,
+      protocol: url.protocol,
+      pattern: `${url.origin}/*`,
+      name: url.origin,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function useActiveTabInfo(): ActiveTabInfo | null {
+  const { data } = useSuspenseQuery({
+    queryKey: controlQueryKeys.activeTab(),
+    queryFn: async () => {
+      try {
+        const res = await chromeRpcClient.getActiveTabUrl()
+        return res.data ?? ''
+      } catch {
+        return ''
+      }
+    },
+    select: deriveActiveTabInfo,
+  })
+
+  return data
+}

--- a/packages/danmaku-anywhere/src/popup/hooks/useActiveTabInfo.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useActiveTabInfo.ts
@@ -10,27 +10,37 @@ export interface ActiveTabInfo {
   name: string
 }
 
+const MOUNTABLE_PROTOCOLS = new Set(['http:', 'https:', 'file:'])
+
 function deriveActiveTabInfo(rawUrl: string): ActiveTabInfo | null {
+  let url: URL
   try {
-    const url = new URL(rawUrl)
-    // file:// URLs have `origin === 'null'` per the WHATWG URL spec, so fall
-    // back to a match-all file pattern the user can narrow down.
-    if (url.protocol === 'file:') {
-      return {
-        url: url.href,
-        protocol: url.protocol,
-        pattern: 'file:///*',
-        name: 'file://',
-      }
-    }
+    url = new URL(rawUrl)
+  } catch {
+    return null
+  }
+  // Non-mountable schemes (chrome:, chrome-extension:, about:, etc.) have
+  // `origin === 'null'` per the WHATWG URL spec, which would turn into a
+  // garbage `null/*` pattern. Reject them outright so callers fall back to
+  // empty defaults instead of pre-filling with bad data.
+  if (!MOUNTABLE_PROTOCOLS.has(url.protocol)) {
+    return null
+  }
+  // file:// URLs also have a `null` origin, so fall back to a match-all file
+  // pattern the user can narrow down.
+  if (url.protocol === 'file:') {
     return {
       url: url.href,
       protocol: url.protocol,
-      pattern: `${url.origin}/*`,
-      name: url.origin,
+      pattern: 'file:///*',
+      name: 'file://',
     }
-  } catch {
-    return null
+  }
+  return {
+    url: url.href,
+    protocol: url.protocol,
+    pattern: `${url.origin}/*`,
+    name: url.origin,
   }
 }
 

--- a/packages/danmaku-anywhere/src/popup/hooks/useIsConnected.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useIsConnected.ts
@@ -5,9 +5,16 @@ import { tabQueryKeys } from '@/common/queries/queryKeys'
 import { controllerRpcClient } from '@/common/rpcClient/controller/client'
 import { sleep } from '@/common/utils/utils'
 
-export const useIsConnected = () => {
+interface UseIsConnectedOptions {
+  enabled?: boolean
+}
+
+export const useIsConnected = ({
+  enabled = true,
+}: UseIsConnectedOptions = {}) => {
   const query = useQuery({
     queryKey: tabQueryKeys.isConnected(),
+    enabled,
     queryFn: async () => {
       try {
         const res = (await Promise.any([

--- a/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
@@ -1,8 +1,11 @@
 import { useMemo } from 'react'
+import { match, P } from 'ts-pattern'
 
 import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
+import type { MountConfig } from '@/common/options/mountConfig/schema'
 import { useMountConfig } from '@/common/options/mountConfig/useMountConfig'
 import { matchUrl } from '@/common/utils/matchUrl'
+import type { ActiveTabInfo } from '@/popup/hooks/useActiveTabInfo'
 import { useActiveTabInfo } from '@/popup/hooks/useActiveTabInfo'
 import { useIsConnected } from '@/popup/hooks/useIsConnected'
 
@@ -23,75 +26,101 @@ export type MountAvailability =
       name: string
     }
 
+interface UrlMatches {
+  enabledMatch: MountConfig | undefined
+  disabledMatch: MountConfig | undefined
+}
+
+function findConfigMatchingUrl(
+  configs: readonly MountConfig[],
+  url: string,
+  enabled: boolean
+): MountConfig | undefined {
+  return configs.find((config) => {
+    if (config.enabled !== enabled) {
+      return false
+    }
+    return config.patterns.some((pattern) => matchUrl(url, pattern))
+  })
+}
+
+// Prefer an enabled match. A disabled config only surfaces as an "enable me"
+// banner when no enabled config is matching the URL.
+function findUrlMatches(
+  configs: readonly MountConfig[],
+  info: ActiveTabInfo | null
+): UrlMatches {
+  if (info === null) {
+    return { enabledMatch: undefined, disabledMatch: undefined }
+  }
+  const enabledMatch = findConfigMatchingUrl(configs, info.url, true)
+  if (enabledMatch) {
+    return { enabledMatch, disabledMatch: undefined }
+  }
+  return {
+    enabledMatch: undefined,
+    disabledMatch: findConfigMatchingUrl(configs, info.url, false),
+  }
+}
+
+interface AvailabilityInputs {
+  extensionEnabled: boolean
+  info: ActiveTabInfo | null
+  enabledMatch: MountConfig | undefined
+  disabledMatch: MountConfig | undefined
+  isConnected: boolean | undefined
+}
+
+function deriveAvailability(inputs: AvailabilityInputs): MountAvailability {
+  return match(inputs)
+    .returnType<MountAvailability>()
+    .with({ extensionEnabled: false }, () => ({ kind: 'disabled' }))
+    .with({ info: null }, () => ({ kind: 'unsupported' }))
+    .with({ disabledMatch: P.not(P.nullish) }, ({ disabledMatch }) => ({
+      kind: 'disabledConfig',
+      configId: disabledMatch.id,
+      configName: disabledMatch.name,
+    }))
+    .with({ enabledMatch: P.nullish, info: P.not(null) }, ({ info }) => ({
+      kind: 'noConfig',
+      url: info.url,
+      pattern: info.pattern,
+      name: info.name,
+    }))
+    .with({ isConnected: true }, () => ({ kind: 'connected' }))
+    .otherwise(() => ({ kind: 'pending' }))
+}
+
 export function useMountAvailability(): MountAvailability {
   const { data: extensionOptions } = useExtensionOptions()
   const { configs } = useMountConfig()
   const info = useActiveTabInfo()
 
-  const isExtensionEnabled = extensionOptions.enabled
+  const extensionEnabled = extensionOptions.enabled
+  const { enabledMatch, disabledMatch } = findUrlMatches(configs, info)
 
-  // Prefer an enabled match — only fall back to a disabled match when there
-  // is no enabled config for this URL. Otherwise a disabled config listed
-  // before an enabled one would incorrectly show the "disabled" banner.
-  const matchUrlAgainstConfig = (config: (typeof configs)[number]) =>
-    info !== null &&
-    config.patterns.some((pattern) => matchUrl(info.url, pattern))
-  const enabledMatch = info
-    ? configs.find((config) => config.enabled && matchUrlAgainstConfig(config))
-    : undefined
-  const disabledMatch =
-    info && !enabledMatch
-      ? configs.find(
-          (config) => !config.enabled && matchUrlAgainstConfig(config)
-        )
-      : undefined
-
-  // Only ping the content script when we expect one to be running: extension
-  // globally enabled, URL is mountable (non-null info), and an enabled config
-  // matches.
   const isConnected = useIsConnected({
-    enabled: isExtensionEnabled && info !== null && enabledMatch !== undefined,
+    enabled: extensionEnabled && enabledMatch !== undefined,
   })
 
-  // Memoize by primitive identifiers so the returned object has a stable
-  // reference across renders when nothing actually changed. Consumers (the
-  // banner) rely on this stability to avoid infinite render loops when the
-  // availability is used as a useEffect dependency.
-  return useMemo<MountAvailability>(() => {
-    if (!isExtensionEnabled) {
-      return { kind: 'disabled' }
-    }
-    if (info === null) {
-      return { kind: 'unsupported' }
-    }
-    if (disabledMatch) {
-      return {
-        kind: 'disabledConfig',
-        configId: disabledMatch.id,
-        configName: disabledMatch.name,
-      }
-    }
-    if (!enabledMatch) {
-      return {
-        kind: 'noConfig',
-        url: info.url,
-        pattern: info.pattern,
-        name: info.name,
-      }
-    }
-    // Matching enabled config: wait for the content script to respond.
-    if (isConnected === undefined || !isConnected) {
-      return { kind: 'pending' }
-    }
-    return { kind: 'connected' }
-  }, [
-    isExtensionEnabled,
-    info?.url,
-    info?.pattern,
-    info?.name,
-    disabledMatch?.id,
-    disabledMatch?.name,
-    enabledMatch?.id,
-    isConnected,
-  ])
+  // Memoize by primitive identifiers so consumers can rely on reference
+  // stability when using availability as an effect dependency.
+  return useMemo(
+    () =>
+      deriveAvailability({
+        extensionEnabled,
+        info,
+        enabledMatch,
+        disabledMatch,
+        isConnected,
+      }),
+    [
+      extensionEnabled,
+      info,
+      enabledMatch?.id,
+      disabledMatch?.id,
+      disabledMatch?.name,
+      isConnected,
+    ]
+  )
 }

--- a/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
@@ -31,14 +31,22 @@ export function useMountAvailability(): MountAvailability {
   const isExtensionEnabled = extensionOptions.enabled
   const isMountableUrl = info !== null && MOUNTABLE_PROTOCOLS.has(info.protocol)
 
-  // Match against the URL ignoring the enabled flag so we can tell the
-  // difference between "no config exists" and "config exists but is disabled".
-  const matchingConfig = info
-    ? configs.find((config) =>
-        config.patterns.some((pattern) => matchUrl(info.url, pattern))
-      )
+  // Prefer an enabled match — only fall back to a disabled match when there
+  // is no enabled config for this URL. Otherwise a disabled config listed
+  // before an enabled one would incorrectly show the "disabled" banner.
+  const matchUrlAgainstConfig = (config: (typeof configs)[number]) =>
+    info !== null &&
+    config.patterns.some((pattern) => matchUrl(info.url, pattern))
+  const enabledMatch = info
+    ? configs.find((config) => config.enabled && matchUrlAgainstConfig(config))
     : undefined
-  const hasEnabledMatch = matchingConfig?.enabled === true
+  const disabledMatch =
+    info && !enabledMatch
+      ? configs.find(
+          (config) => !config.enabled && matchUrlAgainstConfig(config)
+        )
+      : undefined
+  const hasEnabledMatch = enabledMatch !== undefined
 
   // Only ping the content script when we expect one to be running: extension
   // globally enabled, URL mountable, and an enabled config matches.
@@ -52,14 +60,14 @@ export function useMountAvailability(): MountAvailability {
   if (!isMountableUrl || info === null) {
     return { kind: 'unsupported' }
   }
-  if (matchingConfig && !matchingConfig.enabled) {
+  if (disabledMatch) {
     return {
       kind: 'disabledConfig',
-      configId: matchingConfig.id,
-      configName: matchingConfig.name,
+      configId: disabledMatch.id,
+      configName: disabledMatch.name,
     }
   }
-  if (!matchingConfig) {
+  if (!enabledMatch) {
     return {
       kind: 'noConfig',
       url: info.url,

--- a/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
@@ -1,22 +1,49 @@
-import type { MountAvailability } from '@/common/components/DanmakuSelector/MountPageContent'
 import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
+import { useMountConfig } from '@/common/options/mountConfig/useMountConfig'
+import { matchUrl } from '@/common/utils/matchUrl'
 import { useActiveTabInfo } from '@/popup/hooks/useActiveTabInfo'
 import { useIsConnected } from '@/popup/hooks/useIsConnected'
+
+export type MountAvailability =
+  | { kind: 'pending' }
+  | { kind: 'connected' }
+  | { kind: 'unsupported' }
+  | { kind: 'disabled' }
+  | {
+      kind: 'disabledConfig'
+      configId: string
+      configName: string
+    }
+  | {
+      kind: 'noConfig'
+      url: string
+      pattern: string
+      name: string
+    }
 
 const MOUNTABLE_PROTOCOLS = new Set(['http:', 'https:', 'file:'])
 
 export function useMountAvailability(): MountAvailability {
   const { data: extensionOptions } = useExtensionOptions()
+  const { configs } = useMountConfig()
   const info = useActiveTabInfo()
 
   const isExtensionEnabled = extensionOptions.enabled
   const isMountableUrl = info !== null && MOUNTABLE_PROTOCOLS.has(info.protocol)
 
-  // Only ping the content script on pages that could host danmaku, and only
-  // when the extension is globally enabled — unsupported schemes and disabled
-  // extensions can never connect, so there's no reason to poll.
+  // Match against the URL ignoring the enabled flag so we can tell the
+  // difference between "no config exists" and "config exists but is disabled".
+  const matchingConfig = info
+    ? configs.find((config) =>
+        config.patterns.some((pattern) => matchUrl(info.url, pattern))
+      )
+    : undefined
+  const hasEnabledMatch = matchingConfig?.enabled === true
+
+  // Only ping the content script when we expect one to be running: extension
+  // globally enabled, URL mountable, and an enabled config matches.
   const isConnected = useIsConnected({
-    enabled: isExtensionEnabled && isMountableUrl,
+    enabled: isExtensionEnabled && isMountableUrl && hasEnabledMatch,
   })
 
   if (!isExtensionEnabled) {
@@ -25,16 +52,24 @@ export function useMountAvailability(): MountAvailability {
   if (!isMountableUrl || info === null) {
     return { kind: 'unsupported' }
   }
-  if (isConnected === undefined) {
+  if (matchingConfig && !matchingConfig.enabled) {
+    return {
+      kind: 'disabledConfig',
+      configId: matchingConfig.id,
+      configName: matchingConfig.name,
+    }
+  }
+  if (!matchingConfig) {
+    return {
+      kind: 'noConfig',
+      url: info.url,
+      pattern: info.pattern,
+      name: info.name,
+    }
+  }
+  // Matching enabled config: wait for the content script to respond.
+  if (isConnected === undefined || !isConnected) {
     return { kind: 'pending' }
   }
-  if (isConnected) {
-    return { kind: 'connected' }
-  }
-  return {
-    kind: 'noConfig',
-    url: info.url,
-    pattern: info.pattern,
-    name: info.name,
-  }
+  return { kind: 'connected' }
 }

--- a/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
@@ -1,0 +1,40 @@
+import type { MountAvailability } from '@/common/components/DanmakuSelector/MountPageContent'
+import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
+import { useActiveTabInfo } from '@/popup/hooks/useActiveTabInfo'
+import { useIsConnected } from '@/popup/hooks/useIsConnected'
+
+const MOUNTABLE_PROTOCOLS = new Set(['http:', 'https:', 'file:'])
+
+export function useMountAvailability(): MountAvailability {
+  const { data: extensionOptions } = useExtensionOptions()
+  const info = useActiveTabInfo()
+
+  const isExtensionEnabled = extensionOptions.enabled
+  const isMountableUrl = info !== null && MOUNTABLE_PROTOCOLS.has(info.protocol)
+
+  // Only ping the content script on pages that could host danmaku, and only
+  // when the extension is globally enabled — unsupported schemes and disabled
+  // extensions can never connect, so there's no reason to poll.
+  const isConnected = useIsConnected({
+    enabled: isExtensionEnabled && isMountableUrl,
+  })
+
+  if (!isExtensionEnabled) {
+    return { kind: 'disabled' }
+  }
+  if (!isMountableUrl || info === null) {
+    return { kind: 'unsupported' }
+  }
+  if (isConnected === undefined) {
+    return { kind: 'pending' }
+  }
+  if (isConnected) {
+    return { kind: 'connected' }
+  }
+  return {
+    kind: 'noConfig',
+    url: info.url,
+    pattern: info.pattern,
+    name: info.name,
+  }
+}

--- a/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
 import { useMountConfig } from '@/common/options/mountConfig/useMountConfig'
 import { matchUrl } from '@/common/utils/matchUrl'
@@ -21,15 +23,12 @@ export type MountAvailability =
       name: string
     }
 
-const MOUNTABLE_PROTOCOLS = new Set(['http:', 'https:', 'file:'])
-
 export function useMountAvailability(): MountAvailability {
   const { data: extensionOptions } = useExtensionOptions()
   const { configs } = useMountConfig()
   const info = useActiveTabInfo()
 
   const isExtensionEnabled = extensionOptions.enabled
-  const isMountableUrl = info !== null && MOUNTABLE_PROTOCOLS.has(info.protocol)
 
   // Prefer an enabled match — only fall back to a disabled match when there
   // is no enabled config for this URL. Otherwise a disabled config listed
@@ -46,38 +45,56 @@ export function useMountAvailability(): MountAvailability {
           (config) => !config.enabled && matchUrlAgainstConfig(config)
         )
       : undefined
-  const hasEnabledMatch = enabledMatch !== undefined
 
   // Only ping the content script when we expect one to be running: extension
-  // globally enabled, URL mountable, and an enabled config matches.
+  // globally enabled, URL is mountable (non-null info), and an enabled config
+  // matches.
   const isConnected = useIsConnected({
-    enabled: isExtensionEnabled && isMountableUrl && hasEnabledMatch,
+    enabled: isExtensionEnabled && info !== null && enabledMatch !== undefined,
   })
 
-  if (!isExtensionEnabled) {
-    return { kind: 'disabled' }
-  }
-  if (!isMountableUrl || info === null) {
-    return { kind: 'unsupported' }
-  }
-  if (disabledMatch) {
-    return {
-      kind: 'disabledConfig',
-      configId: disabledMatch.id,
-      configName: disabledMatch.name,
+  // Memoize by primitive identifiers so the returned object has a stable
+  // reference across renders when nothing actually changed. Consumers (the
+  // banner) rely on this stability to avoid infinite render loops when the
+  // availability is used as a useEffect dependency.
+  return useMemo<MountAvailability>(() => {
+    if (!isExtensionEnabled) {
+      return { kind: 'disabled' }
     }
-  }
-  if (!enabledMatch) {
-    return {
-      kind: 'noConfig',
-      url: info.url,
-      pattern: info.pattern,
-      name: info.name,
+    if (info === null) {
+      return { kind: 'unsupported' }
     }
-  }
-  // Matching enabled config: wait for the content script to respond.
-  if (isConnected === undefined || !isConnected) {
-    return { kind: 'pending' }
-  }
-  return { kind: 'connected' }
+    if (disabledMatch) {
+      return {
+        kind: 'disabledConfig',
+        configId: disabledMatch.id,
+        configName: disabledMatch.name,
+      }
+    }
+    if (!enabledMatch) {
+      return {
+        kind: 'noConfig',
+        url: info.url,
+        pattern: info.pattern,
+        name: info.name,
+      }
+    }
+    // Matching enabled config: wait for the content script to respond.
+    if (isConnected === undefined || !isConnected) {
+      return { kind: 'pending' }
+    }
+    return { kind: 'connected' }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally
+    // keyed on primitive fields of info / matches so the result stays stable
+    // across unstable object references from upstream queries.
+  }, [
+    isExtensionEnabled,
+    info?.url,
+    info?.pattern,
+    info?.name,
+    disabledMatch?.id,
+    disabledMatch?.name,
+    enabledMatch?.id,
+    isConnected,
+  ])
 }

--- a/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useMountAvailability.ts
@@ -84,9 +84,6 @@ export function useMountAvailability(): MountAvailability {
       return { kind: 'pending' }
     }
     return { kind: 'connected' }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally
-    // keyed on primitive fields of info / matches so the result stays stable
-    // across unstable object references from upstream queries.
   }, [
     isExtensionEnabled,
     info?.url,

--- a/packages/danmaku-anywhere/src/popup/pages/config/pages/ConfigPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/config/pages/ConfigPage.tsx
@@ -1,11 +1,9 @@
-import { useSuspenseQuery } from '@tanstack/react-query'
 import { Outlet, useNavigate } from 'react-router'
 import { TabLayout } from '@/common/components/layout/TabLayout'
 import { createMountConfig } from '@/common/options/mountConfig/constant'
 import type { MountConfigInput } from '@/common/options/mountConfig/schema'
-import { controlQueryKeys } from '@/common/queries/queryKeys'
-import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { getTrackingService } from '@/common/telemetry/getTrackingService'
+import { useActiveTabInfo } from '@/popup/hooks/useActiveTabInfo'
 import { useStore } from '@/popup/store'
 import { ConfigToolbar } from '../components/ConfigToolbar'
 import { MountConfigList } from '../components/MountConfigList'
@@ -14,35 +12,7 @@ export const ConfigPage = () => {
   const { setEditingConfig } = useStore.use.config()
   const navigate = useNavigate()
 
-  const { data } = useSuspenseQuery({
-    queryFn: async () => {
-      // this must not throw for any reason so the page doesn't break
-      try {
-        const res = await chromeRpcClient.getActiveTabUrl()
-        if (!res.data) {
-          return ''
-        }
-        return res.data
-      } catch {
-        return ''
-      }
-    },
-    queryKey: controlQueryKeys.activeTab(),
-    select: (data) => {
-      try {
-        // try to convert url to a pattern
-        // https://www.example.com/abc -> https://www.example.com/*
-        const url = new URL(data)
-        return {
-          url: url.href,
-          pattern: url.origin + '/*',
-          name: url.origin,
-        }
-      } catch {
-        return null
-      }
-    },
-  })
+  const activeTabInfo = useActiveTabInfo()
 
   const handleEditConfig = (config: MountConfigInput) => {
     navigate('edit')
@@ -52,17 +22,17 @@ export const ConfigPage = () => {
 
   const handleAddConfig = async () => {
     navigate('add')
-    if (data) {
+    if (activeTabInfo) {
       setEditingConfig(
         createMountConfig({
-          patterns: [data.pattern],
-          name: data.name,
+          patterns: [activeTabInfo.pattern],
+          name: activeTabInfo.name,
         })
       )
     } else {
       setEditingConfig(createMountConfig())
     }
-    getTrackingService().track('addConfig', { data })
+    getTrackingService().track('addConfig', { data: activeTabInfo })
   }
 
   return (

--- a/packages/danmaku-anywhere/src/popup/pages/home/Home.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/home/Home.tsx
@@ -7,6 +7,7 @@ import { Link, Outlet, useLocation, useMatches } from 'react-router'
 import { ErrorMessage } from '@/common/components/ErrorMessage'
 import { FullPageSpinner } from '@/common/components/FullPageSpinner'
 import { TabLayout } from '@/common/components/layout/TabLayout'
+import { MountAvailabilityBanner } from '@/popup/component/MountAvailabilityBanner'
 import { ReleaseNotes } from '@/popup/component/releaseNotes/ReleaseNotes'
 import { AppToolBar } from './AppToolBar'
 
@@ -19,6 +20,9 @@ export const Home = () => {
   return (
     <Stack direction="column" spacing={0} height={1}>
       <AppToolBar />
+      <Suspense fallback={null}>
+        <MountAvailabilityBanner />
+      </Suspense>
       <Box display="flex" flexGrow={1} height={1} minHeight={0}>
         <Tabs
           value={currentTab === '/' ? '/mount' : currentTab}

--- a/packages/danmaku-anywhere/src/popup/pages/mount/MountPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/mount/MountPage.tsx
@@ -5,9 +5,10 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { MountPageContent } from '@/common/components/DanmakuSelector/MountPageContent'
 import { useToast } from '@/common/components/Toast/toastStore'
+import { createMountConfig } from '@/common/options/mountConfig/constant'
 import { tabQueryKeys } from '@/common/queries/queryKeys'
 import { controllerRpcClient } from '@/common/rpcClient/controller/client'
-import { useIsConnected } from '@/popup/hooks/useIsConnected'
+import { useMountAvailability } from '@/popup/hooks/useMountAvailability'
 import { useMountDanmakuPopup } from '@/popup/pages/mount/useMountDanmakuPopup'
 import { useStore } from '@/popup/store'
 
@@ -23,8 +24,9 @@ export const MountPage = (): ReactElement => {
     multiselect,
   } = useStore.use.mount()
   const { selectedTypes, setSelectedType } = useStore.use.danmaku()
+  const { setEditingConfig } = useStore.use.config()
 
-  const isConnected = useIsConnected()
+  const availability = useMountAvailability()
 
   const navigate = useNavigate()
 
@@ -63,7 +65,16 @@ export const MountPage = (): ReactElement => {
   }
 
   function handleGoCreateMountConfig() {
-    navigate('/config')
+    if (availability.kind !== 'noConfig') {
+      return
+    }
+    setEditingConfig(
+      createMountConfig({
+        patterns: [availability.pattern],
+        name: availability.name,
+      })
+    )
+    navigate('/config/add')
   }
 
   return (
@@ -78,7 +89,7 @@ export const MountPage = (): ReactElement => {
       isMounting={isMounting}
       onUnmount={() => unmount()}
       isMounted={isMounted}
-      isConnected={isConnected}
+      availability={availability}
       onGoSearch={handleGoSearch}
       onGoCreateMountConfig={handleGoCreateMountConfig}
     />

--- a/packages/danmaku-anywhere/src/popup/pages/mount/MountPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/mount/MountPage.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { MountPageContent } from '@/common/components/DanmakuSelector/MountPageContent'
 import { useToast } from '@/common/components/Toast/toastStore'
-import { createMountConfig } from '@/common/options/mountConfig/constant'
 import { tabQueryKeys } from '@/common/queries/queryKeys'
 import { controllerRpcClient } from '@/common/rpcClient/controller/client'
 import { useMountAvailability } from '@/popup/hooks/useMountAvailability'
@@ -24,9 +23,9 @@ export const MountPage = (): ReactElement => {
     multiselect,
   } = useStore.use.mount()
   const { selectedTypes, setSelectedType } = useStore.use.danmaku()
-  const { setEditingConfig } = useStore.use.config()
 
   const availability = useMountAvailability()
+  const isConnected = availability.kind === 'connected'
 
   const navigate = useNavigate()
 
@@ -64,19 +63,6 @@ export const MountPage = (): ReactElement => {
     navigate('/search')
   }
 
-  function handleGoCreateMountConfig() {
-    if (availability.kind !== 'noConfig') {
-      return
-    }
-    setEditingConfig(
-      createMountConfig({
-        patterns: [availability.pattern],
-        name: availability.name,
-      })
-    )
-    navigate('/config/add')
-  }
-
   return (
     <MountPageContent
       filter={filter}
@@ -89,9 +75,8 @@ export const MountPage = (): ReactElement => {
       isMounting={isMounting}
       onUnmount={() => unmount()}
       isMounted={isMounted}
-      availability={availability}
+      isConnected={isConnected}
       onGoSearch={handleGoSearch}
-      onGoCreateMountConfig={handleGoCreateMountConfig}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Split the popup "cannot mount" banner into distinct states — **unsupported page**, **globally-disabled extension**, **disabled mount config**, and **no mount config** — each with its own copy and (where applicable) a targeted CTA.
- The banner now lives at the popup root level (`Home.tsx`) via a new `MountAvailabilityBanner` component, so it stays visible across tab navigation and isn't tied to the Library tab.
- `noConfig` CTA pre-fills a new mount config from the active tab URL (incl. a sane fallback for `file://` URLs) and jumps to `/config/add`. `disabledConfig` CTA enables the matching config in place.
- New background `MountConfigTabReloader` watches for newly-added enabled patterns and reloads any open tabs that match, so the freshly-registered content script starts running without a manual refresh.
- Polling is now gated: `useIsConnected` only pings the content script when the extension is globally enabled, the URL is mountable, and an enabled config actually matches — saves unnecessary work on unsupported/disabled pages.
- Every banner variant is dismissable via a close button; dismissal is popup-session-local (resets on reopen or when the availability kind changes) and the transition is animated with MUI `Collapse`.
- Shared `useActiveTabInfo` hook extracted and adopted by `ConfigPage`, so both consumers share one RPC and the same URL-to-pattern derivation.
- Chore: `da-dev.md` now runs `pnpm install` (and `build:packages`) during worktree setup and before launching the dev browser tab, so fresh worktrees don't fail type-check on first run.

## Test plan
- [ ] Open popup on `chrome://extensions` → "This page cannot host danmaku" banner, no CTA.
- [ ] Open popup on `about:blank` → same unsupported banner.
- [ ] Open popup on a plain `https://example.com` (no config) → "No mount config for this site" banner with Create CTA. Clicking navigates to `/config/add` with origin pre-filled.
- [ ] Create the config from that flow → backend reloader reloads example.com, banner transitions to connected.
- [ ] Disable the example.com config in `/config`, reopen popup → "Mount config \"...\" is disabled" banner with Enable CTA. Clicking enables the config, reloader reloads the tab, banner clears.
- [ ] Toggle the global Enable switch off → "Danmaku Anywhere is disabled" banner on every popup tab, no polling activity in devtools.
- [ ] Open popup on a `file:///` URL → noConfig banner, CTA pre-fills `file:///*` pattern.
- [ ] Open popup on a configured site (Plex/Jellyfin) → no banner.
- [ ] For each banner, click the close (X) button → Collapse animates out. Close popup and reopen → banner returns.
- [ ] Trigger a banner, navigate to `/config` tab → banner stays visible above the tab bar.