### PR TITLE
(extension) fix auth options storage + password manager autofill [DA-456]

### DIFF
--- a/packages/danmaku-anywhere/src/background/ioc.ts
+++ b/packages/danmaku-anywhere/src/background/ioc.ts
@@ -15,6 +15,7 @@ import {
 } from '@/common/options/OptionsService/OptionServiceFactory'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import { SearchHistoryService } from '@/common/options/searchHistory/service'
+import { UserAuthStore } from '@/common/options/userAuth/service'
 import { Logger } from './backgroundLogger'
 import {
   DanmakuProviderFactory,
@@ -33,6 +34,7 @@ container.bind(StoreServiceSymbol).toService(ProviderConfigService)
 container.bind(StoreServiceSymbol).toService(AiProviderConfigService)
 container.bind(StoreServiceSymbol).toService(SearchHistoryService)
 container.bind(StoreServiceSymbol).toService(NamingRuleService)
+container.bind(StoreServiceSymbol).toService(UserAuthStore)
 
 // factory
 container

--- a/packages/danmaku-anywhere/src/background/services/Backup/ConfigStateService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/Backup/ConfigStateService.test.ts
@@ -173,5 +173,39 @@ describe('ConfigStateService', () => {
         'Invalid backup format'
       )
     })
+
+    it('should skip services with shouldBackup=false', async () => {
+      const mockUserAuthService = {
+        ...createMockOptionService('userAuth'),
+        shouldBackup: false,
+      }
+
+      service = new ConfigStateService(
+        [
+          mockDanmakuOptionsService,
+          mockExtensionOptionsService,
+          mockMountConfigService,
+          mockProviderConfigService,
+          mockIntegrationPolicyService,
+          mockUserAuthService,
+        ],
+        mockLogger
+      )
+
+      const maliciousBackup: BackupData = {
+        meta: { version: 1, timestamp: 12345 },
+        services: {
+          userAuth: {
+            data: { token: 'attacker-token', user: { id: 'evil' } },
+            version: 1,
+          },
+        },
+      }
+
+      await service.restoreState(maliciousBackup)
+
+      expect(mockUserAuthService.options.set).not.toHaveBeenCalled()
+      expect(mockUserAuthService.options.upgrade).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/Backup/ConfigStateService.ts
+++ b/packages/danmaku-anywhere/src/background/services/Backup/ConfigStateService.ts
@@ -96,9 +96,11 @@ export class ConfigStateService {
     }
 
     await Promise.all(
-      this.services.map((service) => {
-        return restoreService(service.name, service, services[service.name])
-      })
+      this.services
+        .filter((service) => service.shouldBackup !== false)
+        .map((service) => {
+          return restoreService(service.name, service, services[service.name])
+        })
     )
 
     return result

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/auth/components/SignInForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/auth/components/SignInForm.tsx
@@ -50,6 +50,7 @@ export const SignInForm = () => {
           label={t('optionsPage.auth.email', 'Email')}
           type="email"
           fullWidth
+          autoComplete="username"
           error={!!errors.email}
           helperText={errors.email?.message}
           {...register('email')}
@@ -58,6 +59,7 @@ export const SignInForm = () => {
           label={t('optionsPage.auth.password', 'Password')}
           type="password"
           fullWidth
+          autoComplete="current-password"
           error={!!errors.password}
           helperText={errors.password?.message}
           {...register('password')}

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/auth/components/SignUpForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/auth/components/SignUpForm.tsx
@@ -70,6 +70,7 @@ export const SignUpForm = () => {
         <TextField
           label={t('optionsPage.auth.name', 'User Name')}
           fullWidth
+          autoComplete="name"
           error={!!errors.name}
           helperText={
             errors.name?.message ||
@@ -84,6 +85,7 @@ export const SignUpForm = () => {
           label={t('optionsPage.auth.email', 'Email')}
           type="email"
           fullWidth
+          autoComplete="email"
           error={!!errors.email}
           helperText={
             errors.email?.message ||
@@ -98,6 +100,7 @@ export const SignUpForm = () => {
           label={t('optionsPage.auth.password', 'Password')}
           type="password"
           fullWidth
+          autoComplete="new-password"
           error={!!errors.password}
           helperText={
             errors.password?.message ||
@@ -112,6 +115,7 @@ export const SignUpForm = () => {
           label={t('optionsPage.auth.confirmPassword', 'Confirm Password')}
           type="password"
           fullWidth
+          autoComplete="new-password"
           error={!!errors.confirmPassword}
           helperText={errors.confirmPassword?.message}
           {...register('confirmPassword')}

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/auth/components/SignUpForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/auth/components/SignUpForm.tsx
@@ -70,7 +70,7 @@ export const SignUpForm = () => {
         <TextField
           label={t('optionsPage.auth.name', 'User Name')}
           fullWidth
-          autoComplete="name"
+          autoComplete="nickname"
           error={!!errors.name}
           helperText={
             errors.name?.message ||
@@ -85,7 +85,7 @@ export const SignUpForm = () => {
           label={t('optionsPage.auth.email', 'Email')}
           type="email"
           fullWidth
-          autoComplete="email"
+          autoComplete="username"
           error={!!errors.email}
           helperText={
             errors.email?.message ||


### PR DESCRIPTION
## Summary
- Bind `UserAuthStore` to `StoreServiceSymbol` in the background IoC so the `userAuth` key in `chrome.storage.local` gets seeded by `UpgradeService` on install. Without this, signIn/signUp threw `Cannot set options without existing options` because `OptionsService.setInternal` read `null` from storage.
- Add `autoComplete` hints to `SignInForm` (`username`, `current-password`) and `SignUpForm` (`name`, `email`, `new-password`, `new-password`) so the browser password manager can offer to save and fill credentials.
- Filter `shouldBackup !== false` in `ConfigStateService.restoreState()` to mirror `getState()`. Without this filter, once `UserAuthStore` was added to the `StoreServiceSymbol` multi-injection list, a crafted backup JSON with a `userAuth` key could overwrite session tokens on import.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm test` (259 passed, +1 regression test for the `shouldBackup` restore filter)
- [ ] Manual: sign up / sign in from the extension popup and confirm no `Cannot set options without existing options` error in the console
- [ ] Manual: `chrome.storage.local.get('userAuth')` returns seeded defaults after install
- [ ] Manual: browser offers to save credentials after successful sign-up