### PR TITLE
(extension) deduplicate danmaku with opt-out whitelist [DA-457]

### DIFF
--- a/.claude/commands/da-dev.md
+++ b/.claude/commands/da-dev.md
@@ -107,6 +107,16 @@ wt -w 0 new-tab --title 'DA-XXX: dev browser' -d '<worktree-path>/packages/danma
 
 Human verifies behavior live. Skip for trivial changes (config-only, types, docs).
 
+#### Extension: i18n extraction
+
+When adding or modifying i18n keys (`t('...')` calls), run extraction **before committing**:
+
+```bash
+cd <worktree-path>/packages/danmaku-anywhere && pnpm i18n extract
+```
+
+This regenerates the JSON translation files (sorts keys, removes unused entries). Then translate any new entries in the `zh` locale. CI runs `i18n:check` and will fail if the committed JSON doesn't match what extraction produces.
+
 #### Web app: Cloudflare preview
 
 After the PR is created, Cloudflare posts a preview URL. Include it when alerting the human.

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ patch-*
 
 .wrangler
 .claude-task.md
+docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ docs/                   # Astro-based documentation site
 | Dev extension | `cd packages/danmaku-anywhere && pnpm dev` |
 | Dev web app | `cd app/web && pnpm start` |
 | Dev backend | `cd backend/proxy && pnpm dev` |
+| Extract i18n keys | `cd packages/danmaku-anywhere && pnpm i18n extract` |
 
 Always prefer scripts defined in `package.json` over ad-hoc commands. Run `pnpm type-check` instead of `tsc`/`tsgo`, `pnpm lint` instead of `biome check`, etc. When you need to run a CLI tool not available as a script, use `pnpx` (never `npx`).
 

--- a/packages/danmaku-anywhere/AGENTS.md
+++ b/packages/danmaku-anywhere/AGENTS.md
@@ -37,4 +37,5 @@ Inversify IoC container (`src/common/ioc/`) wires up dependencies across these c
 
 - `@crxjs/vite-plugin` has its own HMR behavior — don't confuse with standard Vite
 - Content scripts run in an isolated world — communication with the page requires messaging
+- **i18n workflow**: after adding or changing translation keys in source code, run `pnpm i18n extract` in this package to regenerate the JSON files (it sorts keys and removes unused ones). Then translate any new entries in the `zh` locale file. CI validates that extracted keys match the committed JSON — commits will fail the `Validate i18n translations` check if extraction is skipped.
 - See `package.json` for available scripts and dependencies

--- a/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
+++ b/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
@@ -1,6 +1,7 @@
 import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
 import { parseCommentEntityP } from '@danmaku-anywhere/danmaku-converter'
-import { ContentCopy, FilterList, Sync } from '@mui/icons-material'
+import { dedupComments } from '@danmaku-anywhere/danmaku-engine'
+import { ContentCopy, Deblur, FilterList, Sync } from '@mui/icons-material'
 import {
   Box,
   CircularProgress,
@@ -22,6 +23,7 @@ import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { match } from 'ts-pattern'
 import { FilterButton } from '@/common/components/FilterButton'
+import { useDanmakuOptions } from '@/common/options/danmakuOptions/useDanmakuOptions'
 import { compareLocale } from '@/common/utils/collator'
 import { ScrollBox } from './layout/ScrollBox'
 
@@ -69,13 +71,25 @@ export const CommentsTable = ({
   const [hoverRow, setHoverRow] = useState<number>()
   const [filter, setFilter] = useState('')
 
+  const { data: danmakuOptions } = useDanmakuOptions()
+  const [hideDuplicates, setHideDuplicates] = useState(
+    danmakuOptions.dedup.enabled
+  )
+
+  const dedupedComments = useMemo(() => {
+    if (!hideDuplicates) {
+      return comments
+    }
+    return dedupComments(comments, danmakuOptions.dedup)
+  }, [comments, hideDuplicates, danmakuOptions.dedup])
+
   const filteredComments = useMemo(() => {
     const keyword = filter.trim().toLowerCase()
     if (!keyword) {
-      return comments
+      return dedupedComments
     }
-    return comments.filter((c) => c.m.toLowerCase().includes(keyword))
-  }, [comments, filter])
+    return dedupedComments.filter((c) => c.m.toLowerCase().includes(keyword))
+  }, [dedupedComments, filter])
 
   const sortedComments = useMemo(() => {
     return match(orderBy)
@@ -119,8 +133,19 @@ export const CommentsTable = ({
         }}
       >
         <Typography variant="h6" sx={{ flexGrow: 1 }}>
-          {t('danmaku.commentCounted', { count: comments.length })}
+          {t('danmaku.commentCounted', { count: dedupedComments.length })}
         </Typography>
+        <Tooltip
+          title={t('danmakuFilter.dedup.hideDuplicates', 'Hide duplicates')}
+        >
+          <IconButton
+            color={hideDuplicates ? 'primary' : 'default'}
+            onClick={() => setHideDuplicates((prev) => !prev)}
+            size="small"
+          >
+            <Deblur />
+          </IconButton>
+        </Tooltip>
         <FilterButton filter={filter} onChange={setFilter} />
         {showRefresh && (
           <Tooltip title={t('danmaku.refresh', 'Refresh Danmaku')}>

--- a/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
+++ b/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
@@ -80,7 +80,10 @@ export const CommentsTable = ({
     if (!hideDuplicates) {
       return comments
     }
-    return dedupComments(comments, danmakuOptions.dedup)
+    return dedupComments(comments, {
+      ...danmakuOptions.dedup,
+      enabled: true,
+    })
   }, [comments, hideDuplicates, danmakuOptions.dedup])
 
   const filteredComments = useMemo(() => {

--- a/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
+++ b/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
@@ -72,9 +72,10 @@ export const CommentsTable = ({
   const [filter, setFilter] = useState('')
 
   const { data: danmakuOptions } = useDanmakuOptions()
-  const [hideDuplicates, setHideDuplicates] = useState(
-    danmakuOptions.dedup.enabled
-  )
+  const [localHideDuplicates, setLocalHideDuplicates] = useState<
+    boolean | null
+  >(null)
+  const hideDuplicates = localHideDuplicates ?? danmakuOptions.dedup.enabled
 
   const dedupedComments = useMemo(() => {
     if (!hideDuplicates) {
@@ -143,7 +144,11 @@ export const CommentsTable = ({
         >
           <IconButton
             color={hideDuplicates ? 'primary' : 'default'}
-            onClick={() => setHideDuplicates((prev) => !prev)}
+            onClick={() =>
+              setLocalHideDuplicates(
+                (prev) => !(prev ?? danmakuOptions.dedup.enabled)
+              )
+            }
             size="small"
           >
             <Deblur />

--- a/packages/danmaku-anywhere/src/common/components/DanmakuFilter/FilterPageCore.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuFilter/FilterPageCore.tsx
@@ -1,10 +1,21 @@
-import { Box, Stack, Typography } from '@mui/material'
+import {
+  Box,
+  Button,
+  FormControlLabel,
+  Slider,
+  Stack,
+  Switch,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material'
 import type { Draft } from 'immer'
 import { produce } from 'immer'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TabLayout } from '@/common/components/layout/TabLayout'
 import type { DanmakuOptions } from '@/common/options/danmakuOptions/constant'
+import { defaultDanmakuOptions } from '@/common/options/danmakuOptions/constant'
 import { useDanmakuOptions } from '@/common/options/danmakuOptions/useDanmakuOptions'
 import { TabToolbar } from '../layout/TabToolbar'
 import { ActiveFilterList } from './ActiveFilterList'
@@ -30,11 +41,15 @@ export const FilterPageCore = ({
     update: { isPending },
   } = useDanmakuOptions()
 
+  const [activeTab, setActiveTab] = useState(0)
   const [filterError, setFilterError] = useState<string>('')
+  const [dedupFilterError, setDedupFilterError] = useState<string>('')
 
   const handleUpdate = (updater: (draft: Draft<DanmakuOptions>) => void) => {
     void partialUpdate(produce(config, updater))
   }
+
+  // --- Filter tab handlers ---
 
   const handleAddFilter = (pattern: string) => {
     if (isRegex(pattern)) {
@@ -74,6 +89,148 @@ export const FilterPageCore = ({
     })
   }
 
+  // --- Dedup tab handlers ---
+
+  const handleAddWhitelistEntry = (pattern: string) => {
+    if (isRegex(pattern)) {
+      const result = validateRegex(pattern, config.dedup.whitelist)
+      if (!result.success) {
+        setDedupFilterError(result.error())
+        return false
+      }
+      handleUpdate((draft) => {
+        draft.dedup.whitelist.push({
+          type: 'regex',
+          value: result.pattern,
+          enabled: true,
+        })
+      })
+    } else {
+      const result = validatePattern(pattern, config.dedup.whitelist)
+      if (!result.success) {
+        setDedupFilterError(result.error())
+        return false
+      }
+      handleUpdate((draft) => {
+        draft.dedup.whitelist.push({
+          type: 'text',
+          value: result.pattern,
+          enabled: true,
+        })
+      })
+    }
+    setDedupFilterError('')
+    return true
+  }
+
+  const handleDeleteWhitelistEntry = (index: number) => {
+    handleUpdate((draft) => {
+      draft.dedup.whitelist.splice(index, 1)
+    })
+  }
+
+  const handleResetWhitelist = () => {
+    handleUpdate((draft) => {
+      draft.dedup.whitelist = defaultDanmakuOptions.dedup.whitelist.map(
+        (f) => ({ ...f })
+      )
+    })
+  }
+
+  const renderFilterTab = () => (
+    <Box p={2}>
+      <Stack spacing={3}>
+        <Typography variant="body1" color="text.secondary">
+          {t('danmakuFilter.description')}
+        </Typography>
+
+        <AddFilter
+          onAdd={handleAddFilter}
+          isPending={isPending}
+          error={filterError}
+          onErrorClear={() => setFilterError('')}
+          initialFilter={initialFilter}
+        />
+
+        <ActiveFilterList
+          filters={config.filters}
+          onDelete={handleDeleteFilter}
+        />
+
+        <TestFilter filters={config.filters} />
+      </Stack>
+    </Box>
+  )
+
+  const renderDedupTab = () => (
+    <Box p={2}>
+      <Stack spacing={3}>
+        <Typography variant="body1" color="text.secondary">
+          {t('danmakuFilter.dedup.description')}
+        </Typography>
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={config.dedup.enabled}
+              onChange={(_, checked) => {
+                handleUpdate((draft) => {
+                  draft.dedup.enabled = checked
+                })
+              }}
+            />
+          }
+          label={t('danmakuFilter.dedup.enableLabel')}
+        />
+
+        <Box>
+          <Typography variant="subtitle2" gutterBottom>
+            {t('danmakuFilter.dedup.toleranceLabel')}
+          </Typography>
+          <Slider
+            value={config.dedup.tolerance}
+            onChange={(_, value) => {
+              handleUpdate((draft) => {
+                draft.dedup.tolerance = value as number
+              })
+            }}
+            min={0}
+            max={2}
+            step={0.1}
+            valueLabelDisplay="auto"
+            marks={[
+              { value: 0, label: '0s' },
+              { value: 1, label: '1s' },
+              { value: 2, label: '2s' },
+            ]}
+          />
+        </Box>
+
+        <Typography variant="subtitle2" color="text.secondary">
+          {t('danmakuFilter.dedup.whitelistHelp')}
+        </Typography>
+
+        <AddFilter
+          onAdd={handleAddWhitelistEntry}
+          isPending={isPending}
+          error={dedupFilterError}
+          onErrorClear={() => setDedupFilterError('')}
+        />
+
+        <ActiveFilterList
+          filters={config.dedup.whitelist}
+          onDelete={handleDeleteWhitelistEntry}
+        />
+
+        <Button variant="outlined" onClick={handleResetWhitelist}>
+          {t('danmakuFilter.dedup.resetButton')}
+        </Button>
+
+        <TestFilter filters={config.dedup.whitelist} />
+      </Stack>
+    </Box>
+  )
+
   return (
     <TabLayout>
       <TabToolbar
@@ -81,28 +238,16 @@ export const FilterPageCore = ({
         onGoBack={onGoBack}
         showBackButton={showBackButton}
       />
-      <Box p={2}>
-        <Stack spacing={3}>
-          <Typography variant="body1" color="text.secondary">
-            {t('danmakuFilter.description')}
-          </Typography>
-
-          <AddFilter
-            onAdd={handleAddFilter}
-            isPending={isPending}
-            error={filterError}
-            onErrorClear={() => setFilterError('')}
-            initialFilter={initialFilter}
-          />
-
-          <ActiveFilterList
-            filters={config.filters}
-            onDelete={handleDeleteFilter}
-          />
-
-          <TestFilter filters={config.filters} />
-        </Stack>
-      </Box>
+      <Tabs
+        value={activeTab}
+        onChange={(_, v) => setActiveTab(v)}
+        variant="fullWidth"
+      >
+        <Tab label={t('danmakuFilter.filterTab', 'Filter')} />
+        <Tab label={t('danmakuFilter.dedupTab', 'Dedup')} />
+      </Tabs>
+      {activeTab === 0 && renderFilterTab()}
+      {activeTab === 1 && renderDedupTab()}
     </TabLayout>
   )
 }

--- a/packages/danmaku-anywhere/src/common/components/DanmakuFilter/FilterPageCore.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuFilter/FilterPageCore.tsx
@@ -44,6 +44,7 @@ export const FilterPageCore = ({
   const [activeTab, setActiveTab] = useState(0)
   const [filterError, setFilterError] = useState<string>('')
   const [dedupFilterError, setDedupFilterError] = useState<string>('')
+  const [localTolerance, setLocalTolerance] = useState<number | null>(null)
 
   const handleUpdate = (updater: (draft: Draft<DanmakuOptions>) => void) => {
     void partialUpdate(produce(config, updater))
@@ -188,8 +189,12 @@ export const FilterPageCore = ({
             {t('danmakuFilter.dedup.toleranceLabel')}
           </Typography>
           <Slider
-            value={config.dedup.tolerance}
+            value={localTolerance ?? config.dedup.tolerance}
             onChange={(_, value) => {
+              setLocalTolerance(value as number)
+            }}
+            onChangeCommitted={(_, value) => {
+              setLocalTolerance(null)
               handleUpdate((draft) => {
                 draft.dedup.tolerance = value as number
               })

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -207,10 +207,20 @@
   "danmakuFilter": {
     "activeFilters": "Active Filters",
     "addFilterPattern": "Add Filter Pattern",
+    "dedup": {
+      "description": "Hide duplicate danmaku that appear at similar timestamps. Whitelist entries are exempt from deduplication.",
+      "enableLabel": "Enable deduplication",
+      "hideDuplicates": "Hide duplicates",
+      "resetButton": "Reset whitelist to defaults",
+      "toleranceLabel": "Time tolerance (seconds)",
+      "whitelistHelp": "Danmaku matching these patterns will not be deduplicated"
+    },
+    "dedupTab": "Dedup",
     "description": "Filter out unwanted danmaku by keywords or regex patterns",
     "enterFilterPattern": "Enter filter pattern, regex starts and ends with '/'",
     "enterFilterPatternPlaceholder": "Enter Filter Pattern",
     "enterTestText": "Enter test text",
+    "filterTab": "Filter",
     "noActiveFilters": "No active filters",
     "testFilterPatterns": "Test Filter Patterns",
     "testResultExclude": "This text will be filtered out",
@@ -219,18 +229,6 @@
       "duplicate": "Pattern already exists",
       "invalidRegex": "Invalid regex {{message}}",
       "patternEmpty": "Pattern cannot be empty"
-    },
-    "filterTab": "Filter",
-    "dedupTab": "Dedup",
-    "dedup": {
-      "title": "Deduplication",
-      "description": "Hide duplicate danmaku that appear at similar timestamps. Whitelist entries are exempt from deduplication.",
-      "enableLabel": "Enable deduplication",
-      "toleranceLabel": "Time tolerance (seconds)",
-      "resetButton": "Reset whitelist to defaults",
-      "whitelistTitle": "Whitelist",
-      "whitelistHelp": "Danmaku matching these patterns will not be deduplicated",
-      "hideDuplicates": "Hide duplicates"
     }
   },
   "danmakuPage": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -219,6 +219,18 @@
       "duplicate": "Pattern already exists",
       "invalidRegex": "Invalid regex {{message}}",
       "patternEmpty": "Pattern cannot be empty"
+    },
+    "filterTab": "Filter",
+    "dedupTab": "Dedup",
+    "dedup": {
+      "title": "Deduplication",
+      "description": "Hide duplicate danmaku that appear at similar timestamps. Whitelist entries are exempt from deduplication.",
+      "enableLabel": "Enable deduplication",
+      "toleranceLabel": "Time tolerance (seconds)",
+      "resetButton": "Reset whitelist to defaults",
+      "whitelistTitle": "Whitelist",
+      "whitelistHelp": "Danmaku matching these patterns will not be deduplicated",
+      "hideDuplicates": "Hide duplicates"
     }
   },
   "danmakuPage": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -214,6 +214,18 @@
       "duplicate": "重复的屏蔽词",
       "invalidRegex": "无效的正则 {{message}}",
       "patternEmpty": "屏蔽词不能为空"
+    },
+    "filterTab": "过滤",
+    "dedupTab": "去重",
+    "dedup": {
+      "title": "去重",
+      "description": "隐藏在相近时间出现的重复弹幕。白名单中的弹幕不受去重影响。",
+      "enableLabel": "启用去重",
+      "toleranceLabel": "时间容差（秒）",
+      "resetButton": "重置白名单为默认值",
+      "whitelistTitle": "白名单",
+      "whitelistHelp": "匹配这些规则的弹幕不会被去重",
+      "hideDuplicates": "隐藏重复"
     }
   },
   "danmakuPage": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -202,10 +202,20 @@
   "danmakuFilter": {
     "activeFilters": "生效的屏蔽词",
     "addFilterPattern": "添加屏蔽词",
+    "dedup": {
+      "description": "隐藏在相近时间出现的重复弹幕。白名单中的弹幕不受去重影响。",
+      "enableLabel": "启用去重",
+      "hideDuplicates": "隐藏重复",
+      "resetButton": "重置白名单为默认值",
+      "toleranceLabel": "时间容差（秒）",
+      "whitelistHelp": "匹配这些规则的弹幕不会被去重"
+    },
+    "dedupTab": "去重",
     "description": "通过关键字或正则屏蔽不需要的弹幕",
     "enterFilterPattern": "输入屏蔽词，正则以 \"/\" 开头和结尾",
     "enterFilterPatternPlaceholder": "输入屏蔽词",
     "enterTestText": "输入测试文本",
+    "filterTab": "过滤",
     "noActiveFilters": "没有生效的屏蔽词",
     "testFilterPatterns": "测试屏蔽词",
     "testResultExclude": "这段文本将被过滤",
@@ -214,18 +224,6 @@
       "duplicate": "重复的屏蔽词",
       "invalidRegex": "无效的正则 {{message}}",
       "patternEmpty": "屏蔽词不能为空"
-    },
-    "filterTab": "过滤",
-    "dedupTab": "去重",
-    "dedup": {
-      "title": "去重",
-      "description": "隐藏在相近时间出现的重复弹幕。白名单中的弹幕不受去重影响。",
-      "enableLabel": "启用去重",
-      "toleranceLabel": "时间容差（秒）",
-      "resetButton": "重置白名单为默认值",
-      "whitelistTitle": "白名单",
-      "whitelistHelp": "匹配这些规则的弹幕不会被去重",
-      "hideDuplicates": "隐藏重复"
     }
   },
   "danmakuPage": {

--- a/packages/danmaku-anywhere/src/common/options/OptionsService/migrationOptions.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/OptionsService/migrationOptions.test.ts
@@ -111,6 +111,55 @@ describe('migrateOptions', () => {
     expect(result).toEqual(createOptions({ foo: { bar: {} } }, 2))
   })
 
+  it('should add dedup options in v8 migration', () => {
+    const options = createOptions(
+      {
+        filters: [],
+        customCss: '',
+        useCustomCss: false,
+      },
+      7
+    )
+    const versions: Version[] = [
+      {
+        version: 8,
+        upgrade: (d) =>
+          produce<any>(d, (draft) => {
+            draft.dedup = {
+              enabled: true,
+              tolerance: 0.5,
+              whitelist: [
+                {
+                  type: 'regex',
+                  value: '^[?？!！。.,，~～\\s]+$',
+                  enabled: true,
+                },
+                { type: 'regex', value: '^(哈|h){2,}$', enabled: true },
+                { type: 'regex', value: '^w{2,}$', enabled: true },
+                { type: 'regex', value: '^(6|六){2,}$', enabled: true },
+                { type: 'regex', value: '^(草|艹)+$', enabled: true },
+                { type: 'regex', value: '^(笑|lol|LOL)$', enabled: true },
+              ],
+            }
+          }),
+      },
+    ]
+
+    const result = migrateOptions(options, versions, logger, {})
+    const data = result.data as Record<string, unknown>
+    const dedup = data.dedup as {
+      enabled: boolean
+      tolerance: number
+      whitelist: unknown[]
+    }
+
+    expect(result.version).toBe(8)
+    expect(dedup).toBeDefined()
+    expect(dedup.enabled).toBe(true)
+    expect(dedup.tolerance).toBe(0.5)
+    expect(dedup.whitelist).toHaveLength(6)
+  })
+
   it('should handle complex nested changes (add, remove, update)', () => {
     const options = createOptions({ a: { b: 1, c: 2 }, d: 3 }, 1)
     const versions: Version[] = [

--- a/packages/danmaku-anywhere/src/common/options/danmakuOptions/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/danmakuOptions/constant.ts
@@ -1,10 +1,22 @@
-import type { DanmakuOptions as DanmakuEngineOptions } from '@danmaku-anywhere/danmaku-engine'
+import type {
+  DanmakuOptions as DanmakuEngineOptions,
+  DanmakuFilter,
+} from '@danmaku-anywhere/danmaku-engine'
 
 import type { Options } from '@/common/options/OptionsService/types'
 
-export type DanmakuOptions = Omit<DanmakuEngineOptions, 'show'> & {
+export interface DedupOptions {
+  readonly enabled: boolean
+  /** Seconds tolerance for same-timestamp bucket. */
+  readonly tolerance: number
+  /** Comments whose text matches any enabled entry are exempted from dedup. */
+  readonly whitelist: DanmakuFilter[]
+}
+
+export type DanmakuOptions = Omit<DanmakuEngineOptions, 'show' | 'dedup'> & {
   readonly customCss: string
   readonly useCustomCss: boolean
+  readonly dedup: DedupOptions
 }
 
 export type DanmakuOptionsOptions = Options<DanmakuOptions>
@@ -37,4 +49,16 @@ export const defaultDanmakuOptions: DanmakuOptions = {
   },
   offset: 0,
   distribution: 'random',
+  dedup: {
+    enabled: true,
+    tolerance: 0.5,
+    whitelist: [
+      { type: 'regex', value: '^[?？!！。.,，~～\\s]+$', enabled: true },
+      { type: 'regex', value: '^(哈|h){2,}$', enabled: true },
+      { type: 'regex', value: '^w{2,}$', enabled: true },
+      { type: 'regex', value: '^(6|六){2,}$', enabled: true },
+      { type: 'regex', value: '^(草|艹)+$', enabled: true },
+      { type: 'regex', value: '^(笑|lol|LOL)$', enabled: true },
+    ],
+  },
 }

--- a/packages/danmaku-anywhere/src/common/options/danmakuOptions/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/danmakuOptions/constant.ts
@@ -7,7 +7,7 @@ import type { Options } from '@/common/options/OptionsService/types'
 
 export interface DedupOptions {
   readonly enabled: boolean
-  /** Seconds tolerance for same-timestamp bucket. */
+  /** Seconds tolerance for considering comments duplicates within a rolling +/- time window. */
   readonly tolerance: number
   /** Comments whose text matches any enabled entry are exempted from dedup. */
   readonly whitelist: DanmakuFilter[]

--- a/packages/danmaku-anywhere/src/common/options/danmakuOptions/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/danmakuOptions/service.ts
@@ -100,6 +100,28 @@ export class DanmakuOptionsService implements IStoreService {
           })
         },
       })
+      .version(8, {
+        upgrade: (data) => {
+          return produce<PrevOptions>(data, (draft) => {
+            draft.dedup = {
+              enabled: true,
+              tolerance: 0.5,
+              whitelist: [
+                {
+                  type: 'regex',
+                  value: '^[?？!！。.,，~～\\s]+$',
+                  enabled: true,
+                },
+                { type: 'regex', value: '^(哈|h){2,}$', enabled: true },
+                { type: 'regex', value: '^w{2,}$', enabled: true },
+                { type: 'regex', value: '^(6|六){2,}$', enabled: true },
+                { type: 'regex', value: '^(草|艹)+$', enabled: true },
+                { type: 'regex', value: '^(笑|lol|LOL)$', enabled: true },
+              ],
+            }
+          })
+        },
+      })
   }
 
   async get() {

--- a/packages/danmaku-engine/src/DanmakuRenderer.ts
+++ b/packages/danmaku-engine/src/DanmakuRenderer.ts
@@ -2,7 +2,12 @@ import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
 import { create, type Manager } from '@mr-quin/danmu'
 import { mapIter, sampleByTime } from './iterator'
 import { type DanmakuOptions, DEFAULT_DANMAKU_OPTIONS } from './options'
-import { applyFilter, type ParsedComment, transformComment } from './parser'
+import {
+  applyFilter,
+  dedupComments,
+  type ParsedComment,
+  transformComment,
+} from './parser'
 import { bindVideo } from './plugins/bindVideo'
 import { deepEqual } from './utils'
 
@@ -39,7 +44,9 @@ export class DanmakuRenderer {
     this.comments = comments
     this.config = this.mergeConfig(config)
 
-    const commentGenerator = mapIter(comments, (comment) =>
+    const dedupedComments = dedupComments(comments, this.config.dedup)
+
+    const commentGenerator = mapIter(dedupedComments, (comment) =>
       transformComment(comment, 0)
     )
 
@@ -127,6 +134,15 @@ export class DanmakuRenderer {
 
     if (!this.manager) return
 
+    // If dedup config changed, we need to re-create with the original comments
+    // because dedup is a set-level operation
+    if (!deepEqual(prevConfig.dedup, this.config.dedup)) {
+      if (this.container && this.media) {
+        this.create(this.container, this.media, this.comments, this.config)
+      }
+      return
+    }
+
     if (!deepEqual(prevConfig.area, this.config.area)) {
       this.setArea()
     }
@@ -171,9 +187,12 @@ export class DanmakuRenderer {
   private mergeConfig = (config?: Partial<DanmakuOptions>): DanmakuOptions => {
     if (!config) return this.config
 
-    // manually merge styles
+    // manually merge nested objects
     const style = { ...this.config.style, ...config.style }
-    return { ...this.config, ...config, style }
+    const dedup = config.dedup
+      ? { ...this.config.dedup, ...config.dedup }
+      : this.config.dedup
+    return { ...this.config, ...config, style, dedup }
   }
 
   destroy(): void {

--- a/packages/danmaku-engine/src/options.ts
+++ b/packages/danmaku-engine/src/options.ts
@@ -4,6 +4,12 @@ export interface DanmakuFilter {
   enabled: boolean
 }
 
+export interface DedupConfig {
+  enabled: boolean
+  tolerance: number
+  whitelist: DanmakuFilter[]
+}
+
 export interface DanmakuStyle {
   opacity: number
   fontSize: number
@@ -56,6 +62,10 @@ export interface DanmakuOptions {
    */
   readonly overlap: number
   /**
+   * Deduplication configuration
+   */
+  readonly dedup: DedupConfig
+  /**
    * How to handle special comments
    */
   readonly specialComments: {
@@ -88,6 +98,11 @@ export const DEFAULT_DANMAKU_OPTIONS: DanmakuOptions = {
   specialComments: {
     top: 'normal',
     bottom: 'scroll',
+  },
+  dedup: {
+    enabled: false,
+    tolerance: 0,
+    whitelist: [],
   },
   offset: 0,
   distribution: 'random',

--- a/packages/danmaku-engine/src/parser.test.ts
+++ b/packages/danmaku-engine/src/parser.test.ts
@@ -1,0 +1,113 @@
+import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
+import { describe, expect, it } from 'vitest'
+import type { DedupConfig } from './options'
+import { dedupComments } from './parser'
+
+function comment(text: string, time: number): CommentEntity {
+  return { p: `${time},1,16777215,0`, m: text }
+}
+
+const baseConfig: DedupConfig = {
+  enabled: true,
+  tolerance: 0.5,
+  whitelist: [],
+}
+
+describe('dedupComments', () => {
+  it('returns same reference when disabled', () => {
+    const comments = [comment('hello', 1), comment('hello', 1)]
+    const result = dedupComments(comments, { ...baseConfig, enabled: false })
+    expect(result).toBe(comments)
+  })
+
+  it('returns same array for empty input', () => {
+    const comments: CommentEntity[] = []
+    const result = dedupComments(comments, baseConfig)
+    expect(result).toEqual([])
+  })
+
+  it('returns same array for single item', () => {
+    const comments = [comment('hello', 1)]
+    const result = dedupComments(comments, baseConfig)
+    expect(result).toEqual([comment('hello', 1)])
+  })
+
+  it('deduplicates exact text within tolerance', () => {
+    const comments = [comment('hello', 1.0), comment('hello', 1.3)]
+    const result = dedupComments(comments, baseConfig)
+    expect(result).toEqual([comment('hello', 1.0)])
+  })
+
+  it('keeps duplicates outside tolerance', () => {
+    const comments = [comment('hello', 1.0), comment('hello', 2.0)]
+    const result = dedupComments(comments, baseConfig)
+    expect(result).toEqual([comment('hello', 1.0), comment('hello', 2.0)])
+  })
+
+  it('keeps different text at same timestamp', () => {
+    const comments = [comment('hello', 1.0), comment('world', 1.0)]
+    const result = dedupComments(comments, baseConfig)
+    expect(result).toEqual([comment('hello', 1.0), comment('world', 1.0)])
+  })
+
+  it('exempts whitelist text match', () => {
+    const config: DedupConfig = {
+      ...baseConfig,
+      whitelist: [{ type: 'text', value: '666', enabled: true }],
+    }
+    const comments = [comment('666', 1.0), comment('666', 1.0)]
+    const result = dedupComments(comments, config)
+    expect(result).toEqual([comment('666', 1.0), comment('666', 1.0)])
+  })
+
+  it('exempts whitelist regex match', () => {
+    const config: DedupConfig = {
+      ...baseConfig,
+      whitelist: [{ type: 'regex', value: '^w{2,}$', enabled: true }],
+    }
+    const comments = [comment('www', 1.0), comment('www', 1.0)]
+    const result = dedupComments(comments, config)
+    expect(result).toEqual([comment('www', 1.0), comment('www', 1.0)])
+  })
+
+  it('does not exempt disabled whitelist entries', () => {
+    const config: DedupConfig = {
+      ...baseConfig,
+      whitelist: [{ type: 'text', value: '666', enabled: false }],
+    }
+    const comments = [comment('666', 1.0), comment('666', 1.0)]
+    const result = dedupComments(comments, config)
+    expect(result).toEqual([comment('666', 1.0)])
+  })
+
+  it('keeps first occurrence (stability)', () => {
+    const c1 = { p: '1,1,16777215,1', m: 'hello' }
+    const c2 = { p: '1,1,16777215,2', m: 'hello' }
+    const result = dedupComments([c1, c2], baseConfig)
+    expect(result).toEqual([c1])
+  })
+
+  it('handles unsorted input correctly', () => {
+    const comments = [
+      comment('hello', 5.0),
+      comment('hello', 1.0),
+      comment('hello', 1.2),
+    ]
+    const result = dedupComments(comments, baseConfig)
+    // After sorting by time: 1.0, 1.2, 5.0. 1.2 is within tolerance of 1.0, so dropped.
+    expect(result).toHaveLength(2)
+  })
+
+  it('chains of duplicates keep only the first per tolerance window', () => {
+    const comments = [
+      comment('hello', 1.0),
+      comment('hello', 1.3),
+      comment('hello', 1.6),
+      comment('hello', 1.9),
+    ]
+    // 1.0 kept. 1.3 within 0.5 of 1.0 -> dropped. 1.6 > 0.5 from 1.0 -> kept.
+    // 1.9 within 0.5 of 1.6 -> dropped.
+    const result = dedupComments(comments, baseConfig)
+    expect(result).toEqual([comment('hello', 1.0), comment('hello', 1.6)])
+  })
+})

--- a/packages/danmaku-engine/src/parser.ts
+++ b/packages/danmaku-engine/src/parser.ts
@@ -4,7 +4,7 @@ import {
   parseCommentGradient,
 } from '@danmaku-anywhere/danmaku-converter'
 
-import type { DanmakuFilter } from './options'
+import type { DanmakuFilter, DedupConfig } from './options'
 
 // copied from danmaku
 export interface ParsedComment {
@@ -100,4 +100,52 @@ export const filterComments = (
   return comments.filter((comment) => {
     return !applyFilter(comment.m, filters)
   })
+}
+
+export function dedupComments(
+  comments: CommentEntity[],
+  config: DedupConfig
+): CommentEntity[] {
+  if (!config.enabled) {
+    return comments
+  }
+
+  if (comments.length <= 1) {
+    return comments
+  }
+
+  // Create index pairs so we can sort by time but restore to mark kept/dropped
+  const indexed = comments.map((c, i) => ({
+    comment: c,
+    time: parseCommentEntityP(c.p).time,
+    originalIndex: i,
+  }))
+
+  // Stable sort by time
+  indexed.sort((a, b) => a.time - b.time)
+
+  // Track which original indices are kept
+  const kept = new Set<number>()
+  const lastKeptTime = new Map<string, number>()
+
+  for (const { comment, time, originalIndex } of indexed) {
+    // Check if whitelisted (exempt from dedup)
+    if (applyFilter(comment.m, config.whitelist)) {
+      kept.add(originalIndex)
+      continue
+    }
+
+    const prev = lastKeptTime.get(comment.m)
+    if (prev !== undefined && Math.abs(time - prev) <= config.tolerance) {
+      // Duplicate within tolerance — drop
+      continue
+    }
+
+    // Keep this comment
+    kept.add(originalIndex)
+    lastKeptTime.set(comment.m, time)
+  }
+
+  // Preserve original order
+  return comments.filter((_, i) => kept.has(i))
 }

--- a/packages/danmaku-engine/src/parser.ts
+++ b/packages/danmaku-engine/src/parser.ts
@@ -114,23 +114,35 @@ export function dedupComments(
     return comments
   }
 
-  // Create index pairs so we can sort by time but restore to mark kept/dropped
+  // Create index pairs so we can sort by time and break ties by original order
   const indexed = comments.map((c, i) => ({
     comment: c,
     time: parseCommentEntityP(c.p).time,
     originalIndex: i,
   }))
 
-  // Stable sort by time
-  indexed.sort((a, b) => a.time - b.time)
+  // Deterministic sort by time, then original order for equal timestamps
+  indexed.sort((a, b) => a.time - b.time || a.originalIndex - b.originalIndex)
 
   // Track which original indices are kept
   const kept = new Set<number>()
   const lastKeptTime = new Map<string, number>()
 
+  // Cache whitelist results per message text to avoid recompiling regexes
+  const whitelistCache = new Map<string, boolean>()
+  const isWhitelisted = (text: string): boolean => {
+    const cached = whitelistCache.get(text)
+    if (cached !== undefined) {
+      return cached
+    }
+    const matched = applyFilter(text, config.whitelist)
+    whitelistCache.set(text, matched)
+    return matched
+  }
+
   for (const { comment, time, originalIndex } of indexed) {
     // Check if whitelisted (exempt from dedup)
-    if (applyFilter(comment.m, config.whitelist)) {
+    if (isWhitelisted(comment.m)) {
       kept.add(originalIndex)
       continue
     }


### PR DESCRIPTION
## Summary
- Add `dedupComments()` engine utility that hides exact text duplicates within a configurable timestamp tolerance window
- Whitelist (regex/text) exempts common reaction danmaku (哈哈, www, 666, etc.) from deduplication
- New "Dedup" tab in the Filter page with enable toggle, tolerance slider, and whitelist management
- CommentsTable gains a local "Hide duplicates" toggle
- Settings sync + backup automatically via existing DanmakuOptions infrastructure
- Migration v8 seeds defaults for existing installs

## Test plan
- [ ] Engine unit tests for `dedupComments` cover all edge cases (tolerance, whitelist, stability, disabled)
- [ ] Migration test for v8
- [ ] Manual: open dev browser, load danmaku with known duplicates, verify duplicates hidden
- [ ] Manual: toggle dedup off in Filter > Dedup tab, verify duplicates reappear
- [ ] Manual: add whitelist entry, verify matching duplicates are preserved
- [ ] Manual: CommentsTable toggle hides/shows duplicates independently of global setting