### PR TITLE
(chore) comment preview build link on PR and linked issues [DA-461]

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -96,3 +96,25 @@ jobs:
           script: |
             const script = require('./scripts/update-nightly-tag.cjs');
             await script({github, context});
+
+  comment-preview-pr:
+    needs: [ check-changes, publish-preview ]
+    if: needs.check-changes.outputs.is_pr == 'true' && success()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Comment release link on PR and linked issues
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./scripts/preview-build-comment.cjs');
+            await script({
+              github,
+              context,
+              prNumber: '${{ needs.check-changes.outputs.pr_number }}',
+              ref: '${{ needs.check-changes.outputs.ref }}',
+              runNumber: '${{ github.run_number }}',
+            });

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -102,6 +102,7 @@ jobs:
     if: needs.check-changes.outputs.is_pr == 'true' && success()
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     steps:

--- a/scripts/preview-build-comment.cjs
+++ b/scripts/preview-build-comment.cjs
@@ -1,0 +1,66 @@
+module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
+  const MARKER = '<!-- danmaku-anywhere:preview-build-comment -->'
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+
+  const tag = `preview-pr-${prNumber}`
+  const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${tag}`
+  const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`
+  const shortSha = String(ref).substring(0, 7)
+
+  const body = [
+    MARKER,
+    '### 🚀 Preview build ready',
+    '',
+    `Built from \`${shortSha}\` (run #${runNumber}).`,
+    '',
+    `📦 [Download from the release page](${releaseUrl}) · [Workflow run](${runUrl})`,
+  ].join('\n')
+
+  async function upsertComment(issueNumber) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: 100,
+    })
+    const existing = comments.find((c) => c.body && c.body.includes(MARKER))
+    if (existing) {
+      await github.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: existing.id,
+        body,
+      })
+      console.log(`Updated comment on #${issueNumber} (id ${existing.id})`)
+    } else {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body,
+      })
+      console.log(`Created comment on #${issueNumber}`)
+    }
+  }
+
+  await upsertComment(Number(prNumber))
+
+  const linked = await github.graphql(
+    `query($owner:String!,$repo:String!,$pr:Int!) {
+       repository(owner:$owner, name:$repo) {
+         pullRequest(number:$pr) {
+           closingIssuesReferences(first: 50) { nodes { number } }
+         }
+       }
+     }`,
+    { owner, repo, pr: Number(prNumber) }
+  )
+  const issueNumbers = (
+    linked?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? []
+  ).map((n) => n.number)
+
+  for (const num of issueNumbers) {
+    await upsertComment(num)
+  }
+}

--- a/scripts/preview-build-comment.cjs
+++ b/scripts/preview-build-comment.cjs
@@ -18,13 +18,21 @@ module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
   ].join('\n')
 
   async function upsertComment(issueNumber) {
-    const comments = await github.paginate(github.rest.issues.listComments, {
-      owner,
-      repo,
-      issue_number: issueNumber,
-      per_page: 100,
-    })
-    const existing = comments.find((c) => c.body && c.body.includes(MARKER))
+    let existing = null
+    for await (const { data: comments } of github.paginate.iterator(
+      github.rest.issues.listComments,
+      {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        per_page: 100,
+      }
+    )) {
+      existing = comments.find((c) => c.body && c.body.includes(MARKER))
+      if (existing) {
+        break
+      }
+    }
     if (existing) {
       await github.rest.issues.updateComment({
         owner,
@@ -52,15 +60,27 @@ module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
       `query($owner:String!,$repo:String!,$pr:Int!) {
          repository(owner:$owner, name:$repo) {
            pullRequest(number:$pr) {
-             closingIssuesReferences(first: 50) { nodes { number } }
+             closingIssuesReferences(first: 50) {
+               nodes {
+                 number
+                 repository { nameWithOwner }
+               }
+             }
            }
          }
        }`,
       { owner, repo, pr: Number(prNumber) }
     )
-    issueNumbers = (
+    const currentRepo = `${owner}/${repo}`
+    const nodes =
       linked?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? []
-    ).map((n) => n.number)
+    issueNumbers = [
+      ...new Set(
+        nodes
+          .filter((n) => n?.repository?.nameWithOwner === currentRepo)
+          .map((n) => n.number)
+      ),
+    ]
   } catch (error) {
     console.warn(
       `Failed to fetch linked issues for PR #${prNumber}: ${error.message}`
@@ -68,6 +88,12 @@ module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
   }
 
   for (const num of issueNumbers) {
-    await upsertComment(num)
+    try {
+      await upsertComment(num)
+    } catch (error) {
+      console.warn(
+        `Failed to comment on linked issue #${num}: ${error.message}`
+      )
+    }
   }
 }

--- a/scripts/preview-build-comment.cjs
+++ b/scripts/preview-build-comment.cjs
@@ -46,19 +46,26 @@ module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
 
   await upsertComment(Number(prNumber))
 
-  const linked = await github.graphql(
-    `query($owner:String!,$repo:String!,$pr:Int!) {
-       repository(owner:$owner, name:$repo) {
-         pullRequest(number:$pr) {
-           closingIssuesReferences(first: 50) { nodes { number } }
+  let issueNumbers = []
+  try {
+    const linked = await github.graphql(
+      `query($owner:String!,$repo:String!,$pr:Int!) {
+         repository(owner:$owner, name:$repo) {
+           pullRequest(number:$pr) {
+             closingIssuesReferences(first: 50) { nodes { number } }
+           }
          }
-       }
-     }`,
-    { owner, repo, pr: Number(prNumber) }
-  )
-  const issueNumbers = (
-    linked?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? []
-  ).map((n) => n.number)
+       }`,
+      { owner, repo, pr: Number(prNumber) }
+    )
+    issueNumbers = (
+      linked?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? []
+    ).map((n) => n.number)
+  } catch (error) {
+    console.warn(
+      `Failed to fetch linked issues for PR #${prNumber}: ${error.message}`
+    )
+  }
 
   for (const num of issueNumbers) {
     await upsertComment(num)


### PR DESCRIPTION
## Summary
- After a preview build is published for a PR (preview release label), post or update an idempotent comment on the PR and any linked issues with the release page link, short SHA, and workflow run link.
- New job `comment-preview-pr` in `preview-build.yml` runs after `publish-preview` for PR-triggered builds, calling `scripts/preview-build-comment.cjs` via `actions/github-script`.
- Comment uses an HTML marker so subsequent builds update the same comment instead of creating new ones.
- Linked issues are discovered via the GraphQL `closingIssuesReferences` field; the query is guarded so an unexpected failure won't break the PR comment path.

closes #373 