### PR TITLE
(extension) match bilibili episodes when show_title is a bare number [DA-464]

### DIFF
--- a/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.test.ts
@@ -4,7 +4,7 @@ import { BilibiliMapper } from './BilibiliMapper'
 
 type BilibiliEpisode = BilibiliBangumiInfo['episodes'][number]
 
-function makeBilibiliEpisode(show_title: string): BilibiliEpisode {
+function makeBilibiliEpisode(show_title: string) {
   return {
     aid: 1,
     cid: 1,

--- a/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.test.ts
@@ -1,0 +1,46 @@
+import type { BilibiliBangumiInfo } from '@danmaku-anywhere/danmaku-provider/bilibili'
+import { describe, expect, it } from 'vitest'
+import { BilibiliMapper } from './BilibiliMapper'
+
+type BilibiliEpisode = BilibiliBangumiInfo['episodes'][number]
+
+function makeBilibiliEpisode(show_title: string): BilibiliEpisode {
+  return {
+    aid: 1,
+    cid: 1,
+    cover: '',
+    long_title: '',
+    share_copy: '',
+    link: '',
+    show_title,
+  } as BilibiliEpisode
+}
+
+describe('BilibiliMapper.toEpisode', () => {
+  it('sets episodeNumber when show_title is a bare ASCII number', () => {
+    const result = BilibiliMapper.toEpisode(makeBilibiliEpisode('2'))
+    expect(result.episodeNumber).toBe(2)
+  })
+
+  it('sets episodeNumber when show_title is a bare number with whitespace', () => {
+    const result = BilibiliMapper.toEpisode(makeBilibiliEpisode(' 10 '))
+    expect(result.episodeNumber).toBe(10)
+  })
+
+  it('leaves episodeNumber undefined when show_title has a 第N话 prefix', () => {
+    const result = BilibiliMapper.toEpisode(
+      makeBilibiliEpisode('第1话 小埋、再一次！')
+    )
+    expect(result.episodeNumber).toBeUndefined()
+  })
+
+  it('leaves episodeNumber undefined when show_title is non-numeric', () => {
+    const result = BilibiliMapper.toEpisode(makeBilibiliEpisode('正片'))
+    expect(result.episodeNumber).toBeUndefined()
+  })
+
+  it('leaves episodeNumber undefined when show_title is empty', () => {
+    const result = BilibiliMapper.toEpisode(makeBilibiliEpisode(''))
+    expect(result.episodeNumber).toBeUndefined()
+  })
+})

--- a/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.test.ts
@@ -27,6 +27,11 @@ describe('BilibiliMapper.toEpisode', () => {
     expect(result.episodeNumber).toBe(10)
   })
 
+  it('sets episodeNumber to 0 when show_title is "0"', () => {
+    const result = BilibiliMapper.toEpisode(makeBilibiliEpisode('0'))
+    expect(result.episodeNumber).toBe(0)
+  })
+
   it('leaves episodeNumber undefined when show_title has a 第N话 prefix', () => {
     const result = BilibiliMapper.toEpisode(
       makeBilibiliEpisode('第1话 小埋、再一次！')

--- a/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/bilibili/BilibiliMapper.ts
@@ -12,14 +12,23 @@ import type {
 import { DanmakuSourceType } from '@/common/danmaku/enums'
 import type { OmitSeasonId } from '../IDanmakuProvider'
 
+const BARE_NUMERIC_TITLE_RE = /^\d+$/
+
 export class BilibiliMapper {
   static toEpisode(
     data: BilibiliBangumiInfo['episodes'][number]
   ): OmitSeasonId<BilibiliOf<EpisodeMeta>> {
+    const title = stripHtml(data.show_title).trim()
+    // if title is a bare number, treat it as episode number
+    const episodeNumber = BARE_NUMERIC_TITLE_RE.test(title)
+      ? Number.parseInt(title, 10)
+      : undefined
+
     return {
       provider: DanmakuSourceType.Bilibili,
       imageUrl: data.cover,
-      title: stripHtml(data.show_title),
+      title,
+      episodeNumber,
       alternativeTitle: [data.long_title, data.share_copy],
       externalLink: data.link,
       providerIds: {


### PR DESCRIPTION
## Summary

- Bilibili `show_title` is the episode number when bare-numeric (`"1"`, `"2"`, `"10"`); existing matcher in `findEpisodeByNumber` only handled prefixed titles (`第N话`, `EpN`, `S\dE\d`), so episode lookups failed for shows like 邪神与厨二病少女 with `Episode N not found in season: ...`.
- `BilibiliMapper.toEpisode` now sets `episodeNumber` from a numeric `show_title`. Other providers untouched.
- 6 unit tests in new `BilibiliMapper.test.ts`.

closes #370 