### PR TITLE
(extension) episode list renders without waiting on danmaku metadata [DA-475]

### DIFF
--- a/packages/danmaku-anywhere/src/common/components/EpisodeList/BaseEpisodeListItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/EpisodeList/BaseEpisodeListItem.tsx
@@ -10,10 +10,9 @@ import {
   ListItem,
   ListItemButton,
   ListItemText,
-  Skeleton,
   Tooltip,
 } from '@mui/material'
-import { type ReactNode, Suspense } from 'react'
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CoverImage } from '@/common/components/image/CoverImage'
 import { isNotCustom } from '@/common/danmaku/utils'
@@ -67,13 +66,7 @@ export const BaseEpisodeListItem = <
       >
         {showImage && !isCustom && episode.imageUrl && (
           <Box width={40} mr={2} flexShrink={0}>
-            <Suspense fallback={<Skeleton width={40} height={40} />}>
-              <CoverImage
-                src={episode.imageUrl}
-                widthRatio={1}
-                heightRatio={1}
-              />
-            </Suspense>
+            <CoverImage src={episode.imageUrl} widthRatio={1} heightRatio={1} />
           </Box>
         )}
         <Tooltip

--- a/packages/danmaku-anywhere/src/common/components/EpisodeList/EpisodeSearchList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/EpisodeList/EpisodeSearchList.tsx
@@ -1,7 +1,12 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  EpisodeMeta,
+  Season,
+  WithSeason,
+} from '@danmaku-anywhere/danmaku-converter'
 import type { MacCmsParsedPlayUrl } from '@danmaku-anywhere/danmaku-provider/maccms'
 import { List, ListItem, ListItemText, Skeleton } from '@mui/material'
-import { useSuspenseQueries } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import type {
@@ -49,51 +54,62 @@ const FallbackEpisodeList = () => {
   )
 }
 
+interface EpisodeRowProps {
+  episode: WithSeason<EpisodeMeta>
+  seasonId: number
+  renderEpisode: RenderEpisode
+}
+
+const EpisodeRow = ({ episode, seasonId, renderEpisode }: EpisodeRowProps) => {
+  const params = {
+    provider: episode.provider,
+    indexedId: episode.indexedId,
+    seasonId,
+  } satisfies EpisodeQueryFilter
+
+  const danmakuQuery = useQuery({
+    queryKey: episodeQueryKeys.filter(params),
+    queryFn: async () => {
+      const res = await chromeRpcClient.episodeFilterLite(params)
+      if (res.data.length === 0) {
+        return null
+      }
+      return res.data[0]
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  })
+
+  return (
+    <ErrorBoundary fallback={<ListItemText primary="An error occurred" />}>
+      <Suspense fallback={<EpisodeSkeleton />}>
+        {renderEpisode({
+          episode,
+          danmaku: danmakuQuery.data ?? null,
+          isLoading: danmakuQuery.isLoading,
+        })}
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+
 const EpisodeListInner = ({
   season,
   renderEpisode,
 }: NormalSeasonListItemProps) => {
   const { data: episodes } = useSearchEpisode(season.id)
 
-  const danmakuResults = useSuspenseQueries({
-    queries: episodes.map((episode) => {
-      const params = {
-        provider: episode.provider,
-        indexedId: episode.indexedId,
-        seasonId: season.id,
-      } satisfies EpisodeQueryFilter
-      return {
-        queryKey: episodeQueryKeys.filter(params),
-        queryFn: async () => {
-          const res = await chromeRpcClient.episodeFilterLite(params)
-          if (res.data.length === 0) return null
-          return res.data[0]
-        },
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        staleTime: Number.POSITIVE_INFINITY,
-      }
-    }),
-  })
-
   return (
     <List dense disablePadding>
-      {episodes.map((episode, i) => {
-        const danmakuResult = danmakuResults[i]
-
+      {episodes.map((episode) => {
         return (
-          <ErrorBoundary
-            fallback={<ListItemText primary="An error occurred" />}
+          <EpisodeRow
             key={episode.indexedId}
-          >
-            <Suspense fallback={<EpisodeSkeleton />}>
-              {renderEpisode({
-                episode,
-                danmaku: danmakuResult.data,
-                isLoading: danmakuResult.isLoading,
-              })}
-            </Suspense>
-          </ErrorBoundary>
+            episode={episode}
+            seasonId={season.id}
+            renderEpisode={renderEpisode}
+          />
         )
       })}
     </List>

--- a/packages/danmaku-anywhere/src/common/components/EpisodeList/EpisodeSearchList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/EpisodeList/EpisodeSearchList.tsx
@@ -79,7 +79,6 @@ const EpisodeRow = ({ episode, seasonId, renderEpisode }: EpisodeRowProps) => {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     staleTime: Number.POSITIVE_INFINITY,
-    throwOnError: true,
   })
 
   return (
@@ -90,13 +89,11 @@ const EpisodeRow = ({ episode, seasonId, renderEpisode }: EpisodeRowProps) => {
         </ListItem>
       }
     >
-      <Suspense fallback={<EpisodeSkeleton />}>
-        {renderEpisode({
-          episode,
-          danmaku: danmakuQuery.data ?? null,
-          isLoading: danmakuQuery.isLoading,
-        })}
-      </Suspense>
+      {renderEpisode({
+        episode,
+        danmaku: danmakuQuery.data ?? null,
+        isLoading: danmakuQuery.isLoading,
+      })}
     </ErrorBoundary>
   )
 }

--- a/packages/danmaku-anywhere/src/common/components/EpisodeList/EpisodeSearchList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/EpisodeList/EpisodeSearchList.tsx
@@ -68,7 +68,7 @@ const EpisodeRow = ({ episode, seasonId, renderEpisode }: EpisodeRowProps) => {
   } satisfies EpisodeQueryFilter
 
   const danmakuQuery = useQuery({
-    queryKey: episodeQueryKeys.filter(params),
+    queryKey: episodeQueryKeys.filterLite(params),
     queryFn: async () => {
       const res = await chromeRpcClient.episodeFilterLite(params)
       if (res.data.length === 0) {
@@ -79,10 +79,17 @@ const EpisodeRow = ({ episode, seasonId, renderEpisode }: EpisodeRowProps) => {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     staleTime: Number.POSITIVE_INFINITY,
+    throwOnError: true,
   })
 
   return (
-    <ErrorBoundary fallback={<ListItemText primary="An error occurred" />}>
+    <ErrorBoundary
+      fallback={
+        <ListItem>
+          <ListItemText primary="An error occurred" />
+        </ListItem>
+      }
+    >
       <Suspense fallback={<EpisodeSkeleton />}>
         {renderEpisode({
           episode,
@@ -129,7 +136,11 @@ const CustomEpisodeListInner = ({
       {episodes.map((episode, i) => {
         return (
           <ErrorBoundary
-            fallback={<ListItemText primary="An error occurred" />}
+            fallback={
+              <ListItem>
+                <ListItemText primary="An error occurred" />
+              </ListItem>
+            }
             key={episode.url}
           >
             <Suspense fallback={<EpisodeSkeleton />}>

--- a/packages/danmaku-anywhere/src/common/components/image/CoverImage.tsx
+++ b/packages/danmaku-anywhere/src/common/components/image/CoverImage.tsx
@@ -61,10 +61,14 @@ const CoverImageLoader = (props: CoverImageProps) => {
   const image = useImage(props.src || IMAGE_ASSETS.Fallback)
   const fallbackImage = useImage(IMAGE_ASSETS.Fallback)
 
+  if (image.isPending) {
+    return <Skeleton width="100%" height="100%" variant="rounded" />
+  }
+
   const src = image.data ?? fallbackImage.data
 
   if (!src) {
-    return <Skeleton width="100%" height="100%" variant="rounded" />
+    return null
   }
 
   return (

--- a/packages/danmaku-anywhere/src/common/components/image/CoverImage.tsx
+++ b/packages/danmaku-anywhere/src/common/components/image/CoverImage.tsx
@@ -1,7 +1,6 @@
 import { CardMedia, Skeleton, styled } from '@mui/material'
-import { type ReactNode, Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-import { useImageSuspense } from '@/common/components/image/useImage'
+import type { ReactNode } from 'react'
+import { useImage } from '@/common/components/image/useImage'
 
 import { IMAGE_ASSETS } from '@/images/ImageAssets'
 
@@ -59,13 +58,13 @@ type CoverImageProps = {
 } & ImageAspectRatioProps
 
 const CoverImageLoader = (props: CoverImageProps) => {
-  const image = useImageSuspense(props.src || IMAGE_ASSETS.Fallback)
-  const fallbackImage = useImageSuspense(IMAGE_ASSETS.Fallback)
+  const image = useImage(props.src || IMAGE_ASSETS.Fallback)
+  const fallbackImage = useImage(IMAGE_ASSETS.Fallback)
 
   const src = image.data ?? fallbackImage.data
 
   if (!src) {
-    return null
+    return <Skeleton width="100%" height="100%" variant="rounded" />
   }
 
   return (
@@ -89,13 +88,7 @@ export const CoverImage = ({
 }: CoverImageProps) => {
   return (
     <ImageAspectRatio widthRatio={widthRatio} heightRatio={heightRatio}>
-      <ErrorBoundary fallback={<div>Failed to load image</div>}>
-        <Suspense
-          fallback={<Skeleton width="100%" height="100%" variant="rounded" />}
-        >
-          <CoverImageLoader {...rest} />
-        </Suspense>
-      </ErrorBoundary>
+      <CoverImageLoader {...rest} />
       {children}
     </ImageAspectRatio>
   )


### PR DESCRIPTION
## Summary

Fix the episode list staying in the 10-row skeleton state until every thumbnail finishes loading (reproduces on Tencent with throttled network).

### What changed
- **`EpisodeSearchList.tsx`** — replace list-level `useSuspenseQueries` with per-row `useQuery`. The list renders immediately after `useSearchEpisode` resolves; each row's danmaku metadata loads independently and surfaces via `data.isLoading` (which `BaseEpisodeListItem` already feeds into its disabled / spinner state).
- **`CoverImage.tsx`** — replace `useImageSuspense` with the non-suspending `useImage` and render `<Skeleton>` inline while the primary fetch is pending. Falls back to the static placeholder asset only after the primary settles with no data (i.e. the fetch failed). No `<Suspense>` or `<ErrorBoundary>` wrappers anymore.
- **`BaseEpisodeListItem.tsx`** — drop the now-redundant `<Suspense>` wrapper around `<CoverImage>`.

### Why a Suspense-free image loader

`CoverImage` used to wrap `useImageSuspense` in its own `<Suspense fallback={<Skeleton />}>`. That looked like a clean per-image boundary, but on first mount under React 19's "consistent loading" rule, freshly-mounted inner Suspense boundaries hold the outer boundary's fallback until they can all commit content — i.e. until every image has loaded. That's exactly what the bug looked like: list stuck on `FallbackEpisodeList` for the full image-fetch duration. Switching to non-suspending `useQuery` lets the list commit as soon as the episode fetch resolves, and each thumbnail fills in independently via normal state updates.

## Test plan

- [ ] Throttle the network in devtools (background service worker → Network → Slow 3G), open a Tencent season → row text + image skeletons appear immediately, thumbnails fill in progressively
- [ ] A broken image URL (or a request blocked via devtools) falls back to the static placeholder; sibling rows are unaffected
- [ ] Block the danmaku-metadata RPC → the row still renders, just without the comment count, and the rest of the list is fine
- [ ] First-text-rendered wall time is clearly earlier than last-image-loaded wall time