### PR TITLE
(extension) stop persisting search results to seasons table [DA-480]

### DIFF
--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -100,6 +100,9 @@ export class RpcManager {
         seasonSearch: async (input) => {
           return this.providerService.searchSeason(input)
         },
+        seasonUpsert: async (input) => {
+          return this.providerService.upsertSeason(input)
+        },
         mediaParseUrl: async (input) => {
           return this.providerService.parseUrl(input.url)
         },

--- a/packages/danmaku-anywhere/src/background/services/persistence/SeasonService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/SeasonService.ts
@@ -20,7 +20,7 @@ export class SeasonService {
     return results
   }
 
-  async findByNaturalKey<T extends SeasonInsert>(
+  async findExisting<T extends SeasonInsert>(
     data: T
   ): Promise<DbEntity<T> | undefined> {
     return this.db.season.get({

--- a/packages/danmaku-anywhere/src/background/services/persistence/SeasonService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/SeasonService.ts
@@ -20,6 +20,15 @@ export class SeasonService {
     return results
   }
 
+  async findByNaturalKey<T extends SeasonInsert>(
+    data: T
+  ): Promise<DbEntity<T> | undefined> {
+    return this.db.season.get({
+      providerConfigId: data.providerConfigId,
+      indexedId: data.indexedId,
+    }) as Promise<DbEntity<T> | undefined>
+  }
+
   async upsert<T extends SeasonInsert>(data: T): Promise<DbEntity<T>> {
     return this.db.transaction('rw', this.db.season, async () => {
       const existing = await this.db.season.get({

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -76,7 +76,7 @@ export class ProviderService {
 
   async searchSeason(
     params: SeasonSearchRequest
-  ): Promise<Season[] | CustomSeason[]> {
+  ): Promise<(Season | SeasonInsert)[] | CustomSeason[]> {
     const providerConfig = await this.providerConfigService.mustGet(
       params.providerConfigId
     )
@@ -91,7 +91,22 @@ export class ProviderService {
     ) {
       return seasonInserts as CustomSeason[]
     }
-    return this.seasonService.bulkUpsert(seasonInserts as SeasonInsert[])
+    // Do not persist search results — that inflates the seasons table with
+    // entries the user may never act on. Read-enrich with existing DB rows so
+    // bookmark/cache indicators still resolve for seasons the user has already
+    // interacted with. New results stay in-memory until the user picks an
+    // episode, bookmarks, or otherwise acts on them.
+    const inserts = seasonInserts as SeasonInsert[]
+    return Promise.all(
+      inserts.map(async (insert) => {
+        const existing = await this.seasonService.findByNaturalKey(insert)
+        return existing ?? insert
+      })
+    )
+  }
+
+  async upsertSeason(data: SeasonInsert): Promise<Season> {
+    return this.seasonService.upsert(data)
   }
 
   async fetchEpisodesBySeason(

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -91,15 +91,11 @@ export class ProviderService {
     ) {
       return seasonInserts as CustomSeason[]
     }
-    // Do not persist search results — that inflates the seasons table with
-    // entries the user may never act on. Read-enrich with existing DB rows so
-    // bookmark/cache indicators still resolve for seasons the user has already
-    // interacted with. New results stay in-memory until the user picks an
-    // episode, bookmarks, or otherwise acts on them.
+    // Surface existing ids so bookmark / cache indicators still resolve.
     const inserts = seasonInserts as SeasonInsert[]
     return Promise.all(
       inserts.map(async (insert) => {
-        const existing = await this.seasonService.findByNaturalKey(insert)
+        const existing = await this.seasonService.findExisting(insert)
         return existing ?? insert
       })
     )

--- a/packages/danmaku-anywhere/src/common/anime/queries/useSeasonSearchSuspense.ts
+++ b/packages/danmaku-anywhere/src/common/anime/queries/useSeasonSearchSuspense.ts
@@ -1,4 +1,8 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -7,6 +11,8 @@ import { Logger } from '@/common/Logger'
 import { seasonQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { getTrackingService } from '@/common/telemetry/getTrackingService'
+
+export type SeasonSearchResultItem = Season | SeasonInsert | CustomSeason
 
 export const useSeasonSearchSuspense = (
   providerConfigId: string,
@@ -26,7 +32,7 @@ export const useSeasonSearchSuspense = (
     queryFn: async (): Promise<
       | {
           success: true
-          data: (Season | CustomSeason)[]
+          data: SeasonSearchResultItem[]
           params: SeasonSearchRequest
           providerConfigId: string
         }

--- a/packages/danmaku-anywhere/src/common/anime/queries/useUpsertSeason.ts
+++ b/packages/danmaku-anywhere/src/common/anime/queries/useUpsertSeason.ts
@@ -1,17 +1,31 @@
-import type { SeasonInsert } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import { useMutation } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '@/common/components/Toast/toastStore'
+import { DanmakuSourceType } from '@/common/danmaku/enums'
+import { isProvider } from '@/common/danmaku/utils'
 import { seasonQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+
+type SeasonOrInsert = Season | SeasonInsert | CustomSeason
 
 export function useUpsertSeason() {
   const { t } = useTranslation()
   const toast = useToast.use.toast()
 
   return useMutation({
-    mutationFn: async (insert: SeasonInsert) => {
-      const res = await chromeRpcClient.seasonUpsert(insert)
+    mutationFn: async (
+      input: SeasonOrInsert
+    ): Promise<Season | CustomSeason> => {
+      // Custom seasons live in customEpisode, not the seasons table.
+      if (isProvider(input, DanmakuSourceType.MacCMS)) {
+        return input
+      }
+      const res = await chromeRpcClient.seasonUpsert(input)
       return res.data
     },
     meta: {

--- a/packages/danmaku-anywhere/src/common/anime/queries/useUpsertSeason.ts
+++ b/packages/danmaku-anywhere/src/common/anime/queries/useUpsertSeason.ts
@@ -1,0 +1,24 @@
+import type { SeasonInsert } from '@danmaku-anywhere/danmaku-converter'
+import { useMutation } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { useToast } from '@/common/components/Toast/toastStore'
+import { seasonQueryKeys } from '@/common/queries/queryKeys'
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
+
+export function useUpsertSeason() {
+  const { t } = useTranslation()
+  const toast = useToast.use.toast()
+
+  return useMutation({
+    mutationFn: async (insert: SeasonInsert) => {
+      const res = await chromeRpcClient.seasonUpsert(insert)
+      return res.data
+    },
+    meta: {
+      invalidates: [seasonQueryKeys.all()],
+    },
+    onError: (error) => {
+      toast.error(error.message || t('common.failed', 'Failed'))
+    },
+  })
+}

--- a/packages/danmaku-anywhere/src/common/anime/utils.ts
+++ b/packages/danmaku-anywhere/src/common/anime/utils.ts
@@ -4,6 +4,8 @@ import type {
   SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
 
-export type HandleSeasonClick = (
+export function isPersistedSeason(
   season: Season | SeasonInsert | CustomSeason
-) => void
+): season is Season | CustomSeason {
+  return 'id' in season && season.id !== undefined
+}

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/ProviderResultsList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/ProviderResultsList.tsx
@@ -1,4 +1,8 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import { ExpandMore } from '@mui/icons-material'
 import {
   AccordionDetails,
@@ -35,7 +39,7 @@ const SearchResultAccordian = styled(OutlineAccordion)(({ theme }) => {
 interface ProviderResultsListProps {
   searchTerm: string
   onSeasonClick: (
-    season: Season | CustomSeason,
+    season: Season | SeasonInsert | CustomSeason,
     provider: ProviderConfig
   ) => void
 }

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -1,4 +1,8 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import { Close, Search } from '@mui/icons-material'
 import type { TextFieldProps } from '@mui/material'
 import {
@@ -29,7 +33,7 @@ interface SearchFormProps {
   onSearchTermChange: (searchTerm: string) => void
   textFieldProps?: TextFieldProps
   onSeasonClick: (
-    season: Season | CustomSeason,
+    season: Season | SeasonInsert | CustomSeason,
     provider: ProviderConfig
   ) => void
 }

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchPageCore.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchPageCore.tsx
@@ -2,6 +2,7 @@ import type {
   CustomSeason,
   Episode,
   Season,
+  SeasonInsert,
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Settings } from '@mui/icons-material'
@@ -25,7 +26,7 @@ import { SearchSettings } from './SearchSettings'
 
 export interface SearchPageCoreProps {
   onSeasonClick: (
-    season: Season | CustomSeason,
+    season: Season | SeasonInsert | CustomSeason,
     provider: ProviderConfig
   ) => void
   onImportSuccess?: (episode: WithSeason<Episode>) => void

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SeasonSearchResult.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SeasonSearchResult.tsx
@@ -1,4 +1,8 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import type { SearchEpisodesQuery } from '@danmaku-anywhere/danmaku-provider/ddp'
 import { Box, Button } from '@mui/material'
 import { Suspense } from 'react'
@@ -16,7 +20,7 @@ interface SeasonSearchResultProps {
   searchParams: SearchEpisodesQuery
   provider: ProviderConfig
   onSeasonClick: (
-    season: Season | CustomSeason,
+    season: Season | SeasonInsert | CustomSeason,
     provider: ProviderConfig
   ) => void
   stale: boolean

--- a/packages/danmaku-anywhere/src/common/components/Season/SeasonGrid.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Season/SeasonGrid.tsx
@@ -1,4 +1,8 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import {
   type BoxProps,
   type Breakpoint,
@@ -9,12 +13,22 @@ import {
 } from '@mui/material'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { type RefObject, useRef, useState } from 'react'
+import { isPersistedSeason } from '@/common/anime/utils'
 import {
   SeasonCard,
   SeasonCardSkeleton,
 } from '@/common/components/Season/components/SeasonCard/SeasonCard'
 import { useMergeRefs } from '@/common/hooks/useMergeRefs'
 import { ScrollBox } from '../layout/ScrollBox'
+
+type SeasonOrInsert = Season | SeasonInsert | CustomSeason
+
+function itemKey(season: SeasonOrInsert): string | number {
+  if (isPersistedSeason(season)) {
+    return season.id
+  }
+  return `${season.provider}-${season.indexedId}`
+}
 
 const useBreakpointValue = <T,>(values: Partial<Record<Breakpoint, T>>) => {
   const theme = useTheme()
@@ -50,10 +64,10 @@ const SeasonGridLayout = (props: GridProps) => {
 }
 
 interface SeasonGridProps {
-  data: (Season | CustomSeason)[]
-  onSeasonClick?: (season: Season | CustomSeason) => void
-  onSelectionChange?: (selection: (Season | CustomSeason)[]) => void
-  selectionModel?: (Season | CustomSeason)[]
+  data: SeasonOrInsert[]
+  onSeasonClick?: (season: SeasonOrInsert) => void
+  onSelectionChange?: (selection: SeasonOrInsert[]) => void
+  selectionModel?: SeasonOrInsert[]
   singleSelect?: boolean
   virtualize?: boolean
   disableMenu?: boolean
@@ -74,9 +88,9 @@ export const SeasonGrid = ({
   boxProps,
   ref: refProp,
 }: SeasonGridProps) => {
-  const [selectionModel, setSelectionModel] = useState<
-    (Season | CustomSeason)[]
-  >(selectionModelProp ?? [])
+  const [selectionModel, setSelectionModel] = useState<SeasonOrInsert[]>(
+    selectionModelProp ?? []
+  )
 
   const ref = useRef<HTMLDivElement>(null)
 
@@ -102,7 +116,7 @@ export const SeasonGrid = ({
     getScrollElement: () => ref.current || null,
     estimateSize: () => 250,
     getItemKey: (index) => {
-      return data[index].id
+      return itemKey(data[index])
     },
     gap: Number.parseInt(spacing),
     lanes,
@@ -111,7 +125,7 @@ export const SeasonGrid = ({
 
   const gridSize = { xs: 2, sm: 4, md: 4 }
 
-  const handleSelect = (season: Season | CustomSeason) => {
+  const handleSelect = (season: SeasonOrInsert) => {
     if (selectionModel.includes(season)) {
       const selection = singleSelect
         ? []
@@ -130,7 +144,7 @@ export const SeasonGrid = ({
       <SeasonGridLayout>
         {data.map((season) => {
           return (
-            <Grid size={gridSize} key={season.id}>
+            <Grid size={gridSize} key={itemKey(season)}>
               <SeasonCard
                 season={season}
                 onClick={onSeasonClick}
@@ -165,7 +179,7 @@ export const SeasonGrid = ({
                 top: 0,
                 transform: `translateY(${virtualItem.start}px) translateX(calc(${virtualItem.lane * 100}% + ${virtualItem.lane * Number.parseInt(spacing)}px))`,
               }}
-              key={season.id}
+              key={itemKey(season)}
               data-index={virtualItem.index}
               ref={virtualizer.measureElement}
             >

--- a/packages/danmaku-anywhere/src/common/components/Season/components/SeasonCard/SeasonCard.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Season/components/SeasonCard/SeasonCard.tsx
@@ -173,9 +173,6 @@ export const SeasonCard = ({
     if (disableMenu || enableSelection) {
       return null
     }
-    // The menu only makes sense for persisted seasons (it operates on season.id).
-    // Search results that haven't been persisted yet pass disableMenu, so this
-    // branch is effectively a type narrow for the saved-seasons usage.
     if (!isPersistedSeason(season)) {
       return null
     }

--- a/packages/danmaku-anywhere/src/common/components/Season/components/SeasonCard/SeasonCard.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Season/components/SeasonCard/SeasonCard.tsx
@@ -2,6 +2,7 @@ import {
   type CustomSeason,
   DanmakuSourceType,
   type Season,
+  type SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
 import {
   BookmarkBorder,
@@ -27,6 +28,7 @@ import type { MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDeleteSeason } from '@/common/anime/queries/useDeleteSeason'
 import { useRefreshSeason } from '@/common/anime/queries/useRefreshSeason'
+import { isPersistedSeason } from '@/common/anime/utils'
 import { useBookmarkAdd } from '@/common/bookmark/queries/useBookmarkAdd'
 import { useBookmarkDeleteBySeason } from '@/common/bookmark/queries/useBookmarkDelete'
 import { useBookmarkedSeasonIds } from '@/common/bookmark/queries/useBookmarks'
@@ -98,12 +100,15 @@ const Logo = styled('div')(({ theme }) => {
 })
 
 type SeasonCardProps = {
-  season: Season | CustomSeason
+  season: Season | SeasonInsert | CustomSeason
   onClick?: HandleSeasonClick
   disableMenu?: boolean
   enableSelection?: boolean
   isSelected?: boolean
-  onSelect?: (season: Season | CustomSeason, selected: boolean) => void
+  onSelect?: (
+    season: Season | SeasonInsert | CustomSeason,
+    selected: boolean
+  ) => void
 }
 
 const SelectionOverlay = styled('div')(() => ({
@@ -135,7 +140,8 @@ export const SeasonCard = ({
 
   const { data: bookmarkedSeasonIds } = useBookmarkedSeasonIds()
 
-  const isBookmarked = bookmarkedSeasonIds?.has(season.id) ?? false
+  const isBookmarked =
+    (isPersistedSeason(season) && bookmarkedSeasonIds?.has(season.id)) ?? false
 
   const bookmarkAddMutation = useBookmarkAdd()
   const bookmarkDeleteMutation = useBookmarkDeleteBySeason()
@@ -165,6 +171,12 @@ export const SeasonCard = ({
 
   const renderMenu = () => {
     if (disableMenu || enableSelection) {
+      return null
+    }
+    // The menu only makes sense for persisted seasons (it operates on season.id).
+    // Search results that haven't been persisted yet pass disableMenu, so this
+    // branch is effectively a type narrow for the saved-seasons usage.
+    if (!isPersistedSeason(season)) {
       return null
     }
     if (isProvider(season, DanmakuSourceType.MacCMS)) {

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -8,6 +8,7 @@ import type {
   EpisodeLite,
   EpisodeMeta,
   Season,
+  SeasonInsert,
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import type { BilibiliUserInfo } from '@danmaku-anywhere/danmaku-provider/bilibili'
@@ -100,7 +101,11 @@ export type BackgroundMethods = {
   authSignOut: RPCDef<void, AuthSignOutResult>
   authDeleteAccount: RPCDef<void, AuthSignOutResult>
   mediaParseUrl: RPCDef<{ url: string }, WithSeason<EpisodeMeta>>
-  seasonSearch: RPCDef<SeasonSearchRequest, (Season | CustomSeason)[]>
+  seasonSearch: RPCDef<
+    SeasonSearchRequest,
+    (Season | SeasonInsert | CustomSeason)[]
+  >
+  seasonUpsert: RPCDef<SeasonInsert, Season>
   seasonFilter: RPCDef<SeasonQueryFilter, Season[]>
   seasonGetAll: RPCDef<SeasonGetAllRequest, Season[]>
   seasonDelete: RPCDef<SeasonQueryFilter, void>

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/SelectorPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/SelectorPage.tsx
@@ -106,8 +106,6 @@ export const SelectorPage = () => {
         <SeasonGrid
           data={animes}
           onSelectionChange={([season]) => {
-            // Disambiguation results come from auto-match, which already
-            // persists, so season is always a real Season with id here.
             if (isNotCustom(season) && isPersistedSeason(season)) {
               handleAnimeSelect(season)
             }

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/SelectorPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/SelectorPage.tsx
@@ -5,6 +5,7 @@ import {
 import { Box, Button, Divider, Stack, Typography } from '@mui/material'
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { isPersistedSeason } from '@/common/anime/utils'
 import { SeasonGrid } from '@/common/components/Season/SeasonGrid'
 import { useToast } from '@/common/components/Toast/toastStore'
 import { isNotCustom } from '@/common/danmaku/utils'
@@ -105,7 +106,9 @@ export const SelectorPage = () => {
         <SeasonGrid
           data={animes}
           onSelectionChange={([season]) => {
-            if (isNotCustom(season)) {
+            // Disambiguation results come from auto-match, which already
+            // persists, so season is always a real Season with id here.
+            if (isNotCustom(season) && isPersistedSeason(season)) {
               handleAnimeSelect(season)
             }
           }}

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/SelectorPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/SelectorPage.tsx
@@ -106,6 +106,10 @@ export const SelectorPage = () => {
         <SeasonGrid
           data={animes}
           onSelectionChange={([season]) => {
+            if (!season) {
+              setSelectedSeason(undefined)
+              return
+            }
             if (isNotCustom(season) && isPersistedSeason(season)) {
               handleAnimeSelect(season)
             }

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
@@ -7,7 +7,6 @@ import { Box, Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useUpsertSeason } from '@/common/anime/queries/useUpsertSeason'
-import { isPersistedSeason } from '@/common/anime/utils'
 import { Center } from '@/common/components/Center'
 import { SearchPageCore } from '@/common/components/SearchPageCore/SearchPageCore'
 import { isNotCustom } from '@/common/danmaku/utils'
@@ -46,47 +45,36 @@ export const SearchPage = (): React.ReactElement | null => {
     setSearchTitle(mediaInfo.title)
   }, [mediaInfo])
 
-  const handleSeasonClick = async (
+  const handleSeasonClick = (
     season: Season | SeasonInsert | CustomSeason,
     provider: ProviderConfig
   ) => {
-    // Search results are not persisted; the user picking one is the signal to
-    // commit it to the seasons table so downstream APIs (season map, bookmark,
-    // episode list) have a real seasonId.
-    let persisted
-    if (isPersistedSeason(season)) {
-      persisted = season
-    } else {
-      try {
-        persisted = await upsertSeason.mutateAsync(season)
-      } catch {
-        // useUpsertSeason surfaces the error via toast; stop here so we don't
-        // open the season map dialog or detail page for an unpersisted season.
-        return
-      }
-    }
-    if (
-      isNotCustom(persisted) &&
-      mediaInfo &&
-      !SeasonMap.hasMapping(
-        seasonMaps,
-        mediaInfo.getKey(),
-        persisted.providerConfigId,
-        persisted.id
-      )
-    ) {
-      showAddSeasonMapDialog({
-        season: persisted,
-        mapKey: mediaInfo.getKey(),
-        onProceed: (s) => {
-          setSelectedSeason(s)
+    upsertSeason.mutate(season, {
+      onSuccess: (persisted) => {
+        if (
+          isNotCustom(persisted) &&
+          mediaInfo &&
+          !SeasonMap.hasMapping(
+            seasonMaps,
+            mediaInfo.getKey(),
+            persisted.providerConfigId,
+            persisted.id
+          )
+        ) {
+          showAddSeasonMapDialog({
+            season: persisted,
+            mapKey: mediaInfo.getKey(),
+            onProceed: (s) => {
+              setSelectedSeason(s)
+              setSelectedProvider(provider)
+            },
+          })
+        } else {
+          setSelectedSeason(persisted)
           setSelectedProvider(provider)
-        },
-      })
-    } else {
-      setSelectedSeason(persisted)
-      setSelectedProvider(provider)
-    }
+        }
+      },
+    })
   }
 
   if (!enabledProviders.length) {

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
@@ -1,7 +1,13 @@
-import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
+import type {
+  CustomSeason,
+  Season,
+  SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
 import { Box, Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useUpsertSeason } from '@/common/anime/queries/useUpsertSeason'
+import { isPersistedSeason } from '@/common/anime/utils'
 import { Center } from '@/common/components/Center'
 import { SearchPageCore } from '@/common/components/SearchPageCore/SearchPageCore'
 import { isNotCustom } from '@/common/danmaku/utils'
@@ -22,6 +28,7 @@ export const SearchPage = (): React.ReactElement | null => {
   const { enabledProviders } = useProviderConfig()
   const { mountDanmaku } = useLoadDanmaku()
   const { data: seasonMaps } = useAllSeasonMap()
+  const upsertSeason = useUpsertSeason()
 
   const [selectedSeason, setSelectedSeason] = useState<
     Season | CustomSeason | undefined
@@ -39,22 +46,37 @@ export const SearchPage = (): React.ReactElement | null => {
     setSearchTitle(mediaInfo.title)
   }, [mediaInfo])
 
-  const handleSeasonClick = (
-    season: Season | CustomSeason,
+  const handleSeasonClick = async (
+    season: Season | SeasonInsert | CustomSeason,
     provider: ProviderConfig
   ) => {
+    // Search results are not persisted; the user picking one is the signal to
+    // commit it to the seasons table so downstream APIs (season map, bookmark,
+    // episode list) have a real seasonId.
+    let persisted
+    if (isPersistedSeason(season)) {
+      persisted = season
+    } else {
+      try {
+        persisted = await upsertSeason.mutateAsync(season)
+      } catch {
+        // useUpsertSeason surfaces the error via toast; stop here so we don't
+        // open the season map dialog or detail page for an unpersisted season.
+        return
+      }
+    }
     if (
-      isNotCustom(season) &&
+      isNotCustom(persisted) &&
       mediaInfo &&
       !SeasonMap.hasMapping(
         seasonMaps,
         mediaInfo.getKey(),
-        season.providerConfigId,
-        season.id
+        persisted.providerConfigId,
+        persisted.id
       )
     ) {
       showAddSeasonMapDialog({
-        season,
+        season: persisted,
         mapKey: mediaInfo.getKey(),
         onProceed: (s) => {
           setSelectedSeason(s)
@@ -62,7 +84,7 @@ export const SearchPage = (): React.ReactElement | null => {
         },
       })
     } else {
-      setSelectedSeason(season)
+      setSelectedSeason(persisted)
       setSelectedProvider(provider)
     }
   }

--- a/packages/danmaku-anywhere/src/popup/pages/danmaku/pages/season/SeasonList.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/danmaku/pages/season/SeasonList.tsx
@@ -7,6 +7,7 @@ import { memo, Suspense, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createSearchParams, useNavigate } from 'react-router'
 import { useGetAllSeasonsSuspense } from '@/common/anime/queries/useGetAllSeasonsSuspense'
+import { isPersistedSeason } from '@/common/anime/utils'
 import { NothingHere } from '@/common/components/NothingHere'
 import {
   SeasonGrid,
@@ -83,6 +84,11 @@ const SeasonListSuspense = () => {
       boxProps={{ p: 2 }}
       data={filteredSeasons}
       onSeasonClick={(season) => {
+        // SeasonList only renders persisted seasons (from getAllSeasons) plus a
+        // synthetic local-danmaku entry, so id is always present here.
+        if (!isPersistedSeason(season)) {
+          return
+        }
         navigate({
           pathname: `${season.id}`,
           search: createSearchParams({

--- a/packages/danmaku-anywhere/src/popup/pages/danmaku/pages/season/SeasonList.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/danmaku/pages/season/SeasonList.tsx
@@ -84,8 +84,6 @@ const SeasonListSuspense = () => {
       boxProps={{ p: 2 }}
       data={filteredSeasons}
       onSeasonClick={(season) => {
-        // SeasonList only renders persisted seasons (from getAllSeasons) plus a
-        // synthetic local-danmaku entry, so id is always present here.
         if (!isPersistedSeason(season)) {
           return
         }

--- a/packages/danmaku-anywhere/src/popup/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/search/SearchPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router'
 import { useUpsertSeason } from '@/common/anime/queries/useUpsertSeason'
-import { isPersistedSeason } from '@/common/anime/utils'
 import { SearchPageCore } from '@/common/components/SearchPageCore/SearchPageCore'
 import { useStoreScrollPosition } from '@/common/hooks/useStoreScrollPosition'
 import { useStore } from '@/popup/store'
@@ -18,25 +17,14 @@ export const SearchPage = () => {
       ref={layoutRef}
       searchTerm={search.keyword}
       onSearchTermChange={search.setKeyword}
-      onSeasonClick={async (season, provider) => {
-        // Search results are not persisted; the user picking one is the signal
-        // to commit it to the seasons table so downstream APIs (bookmark,
-        // episode-list lookup, season map) have a real seasonId.
-        let persisted
-        if (isPersistedSeason(season)) {
-          persisted = season
-        } else {
-          try {
-            persisted = await upsertSeason.mutateAsync(season)
-          } catch {
-            // useUpsertSeason surfaces the error via toast; stop here so we
-            // don't navigate to a detail page with an unpersisted season.
-            return
-          }
-        }
-        search.setSeason(persisted)
-        search.setProvider(provider)
-        navigate('season')
+      onSeasonClick={(season, provider) => {
+        upsertSeason.mutate(season, {
+          onSuccess: (persisted) => {
+            search.setSeason(persisted)
+            search.setProvider(provider)
+            navigate('season')
+          },
+        })
       }}
     />
   )

--- a/packages/danmaku-anywhere/src/popup/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/search/SearchPage.tsx
@@ -1,4 +1,6 @@
 import { useNavigate } from 'react-router'
+import { useUpsertSeason } from '@/common/anime/queries/useUpsertSeason'
+import { isPersistedSeason } from '@/common/anime/utils'
 import { SearchPageCore } from '@/common/components/SearchPageCore/SearchPageCore'
 import { useStoreScrollPosition } from '@/common/hooks/useStoreScrollPosition'
 import { useStore } from '@/popup/store'
@@ -7,6 +9,7 @@ export const SearchPage = () => {
   const navigate = useNavigate()
 
   const search = useStore.use.search()
+  const upsertSeason = useUpsertSeason()
 
   const layoutRef = useStoreScrollPosition<HTMLDivElement>('searchPage')
 
@@ -15,8 +18,23 @@ export const SearchPage = () => {
       ref={layoutRef}
       searchTerm={search.keyword}
       onSearchTermChange={search.setKeyword}
-      onSeasonClick={(season, provider) => {
-        search.setSeason(season)
+      onSeasonClick={async (season, provider) => {
+        // Search results are not persisted; the user picking one is the signal
+        // to commit it to the seasons table so downstream APIs (bookmark,
+        // episode-list lookup, season map) have a real seasonId.
+        let persisted
+        if (isPersistedSeason(season)) {
+          persisted = season
+        } else {
+          try {
+            persisted = await upsertSeason.mutateAsync(season)
+          } catch {
+            // useUpsertSeason surfaces the error via toast; stop here so we
+            // don't navigate to a detail page with an unpersisted season.
+            return
+          }
+        }
+        search.setSeason(persisted)
         search.setProvider(provider)
         navigate('season')
       }}


### PR DESCRIPTION
## Summary

- `ProviderService.searchSeason()` no longer writes to the local IndexedDB seasons table. It still does a read-only natural-key lookup so that results that match a previously-saved season come back with their real `id`, preserving bookmark indicators and cached-danmaku resolution.
- Persistence now happens lazily, when the user picks a search result: both the popup and the content-script search pages call a new `seasonUpsert` RPC on click before navigating. Only seasons the user actively investigates land in the DB.
- Adds a shared `isPersistedSeason` type guard so call sites that mix `SeasonInsert` (search) with `Season` / `CustomSeason` (saved) narrow consistently.

## Out of scope

- The auto-match disambiguation path in `SearchMatchingStrategy` still bulk-upserts; that has its own UX shape (selector tab) and is left for a follow-up.
- One-time cleanup of already-inflated season rows from prior search activity will ship separately.

## Test plan

- [ ] Run several searches in the popup; confirm the seasons table doesn't grow (DevTools → Application → IndexedDB).
- [ ] Pick an episode from a search result; verify the season persists with the episode FK.
- [ ] Bookmark a season from search results detail page; verify it appears in bookmarks.
- [ ] Search for an anime that already exists in the DB; verify bookmark indicators still resolve correctly.
- [ ] Content-script search: confirm season-map dialog still fires for new (unmapped) titles.
- [ ] Auto-match flow on a tracked video still works (verifies disambiguation path unaffected).