### PR TITLE
(chore) add ai-rereview label workflow [DA-492]

### DIFF
--- a/.github/workflows/ai-rereview.yml
+++ b/.github/workflows/ai-rereview.yml
@@ -1,4 +1,4 @@
-name: AI Re-review
+name: Gemini Re-review
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   re-request:
-    name: Re-request AI reviewers
+    name: Re-request Gemini review
     if: |
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ai-rereview'))
       || (github.event.action == 'labeled' && github.event.label.name == 'ai-rereview')
@@ -19,12 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Re-request reviewers
+      - name: Re-request review
         uses: actions/github-script@v7
         with:
-          # AI_REREVIEW_PAT is required: GITHUB_TOKEN cannot request Copilot
-          # as a reviewer ("not a collaborator"), and Gemini ignores /gemini
-          # review comments posted by github-actions[bot].
+          # AI_REREVIEW_PAT is required: Gemini ignores /gemini review
+          # comments posted by github-actions[bot].
           github-token: ${{ secrets.AI_REREVIEW_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const { run } = require('./scripts/ai-rereview.cjs');

--- a/.github/workflows/ai-rereview.yml
+++ b/.github/workflows/ai-rereview.yml
@@ -12,6 +12,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ai-rereview')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout

--- a/.github/workflows/ai-rereview.yml
+++ b/.github/workflows/ai-rereview.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Re-request reviewers
         uses: actions/github-script@v7
         with:
+          # AI_REREVIEW_PAT is required: GITHUB_TOKEN cannot request Copilot
+          # as a reviewer ("not a collaborator"), and Gemini ignores /gemini
+          # review comments posted by github-actions[bot].
+          github-token: ${{ secrets.AI_REREVIEW_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const { run } = require('./scripts/ai-rereview.cjs');
             await run({ core, github, context });

--- a/.github/workflows/ai-rereview.yml
+++ b/.github/workflows/ai-rereview.yml
@@ -1,4 +1,4 @@
-name: Gemini Re-review
+name: AI Re-review
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   re-request:
-    name: Re-request Gemini review
+    name: Re-request AI reviewers
     if: |
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ai-rereview'))
       || (github.event.action == 'labeled' && github.event.label.name == 'ai-rereview')
@@ -19,11 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Re-request review
+      - name: Re-request reviewers
         uses: actions/github-script@v7
         with:
-          # AI_REREVIEW_PAT is required: Gemini ignores /gemini review
-          # comments posted by github-actions[bot].
+          # AI_REREVIEW_PAT is required: bots ignore comments posted
+          # by github-actions[bot].
           github-token: ${{ secrets.AI_REREVIEW_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const { run } = require('./scripts/ai-rereview.cjs');

--- a/.github/workflows/ai-rereview.yml
+++ b/.github/workflows/ai-rereview.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   re-request:
     name: Re-request AI reviewers
-    if: contains(github.event.pull_request.labels.*.name, 'ai-rereview')
+    if: |
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ai-rereview'))
+      || (github.event.action == 'labeled' && github.event.label.name == 'ai-rereview')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ai-rereview.yml
+++ b/.github/workflows/ai-rereview.yml
@@ -1,0 +1,24 @@
+name: AI Re-review
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+
+jobs:
+  re-request:
+    name: Re-request AI reviewers
+    if: contains(github.event.pull_request.labels.*.name, 'ai-rereview')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Re-request reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { run } = require('./scripts/ai-rereview.cjs');
+            await run({ core, github, context });

--- a/scripts/ai-rereview.cjs
+++ b/scripts/ai-rereview.cjs
@@ -1,33 +1,6 @@
 const RE_REVIEW_LABEL = 'ai-rereview'
-
-const BOTS = [
-  {
-    name: 'copilot',
-    reviewLogin: 'copilot-pull-request-reviewer[bot]',
-    requestedReviewerLogins: ['Copilot', 'copilot-pull-request-reviewer'],
-    trigger: async ({ github, owner, repo, pull_number }) => {
-      await github.rest.pulls.requestReviewers({
-        owner,
-        repo,
-        pull_number,
-        reviewers: ['copilot-pull-request-reviewer'],
-      })
-    },
-  },
-  {
-    name: 'gemini',
-    reviewLogin: 'gemini-code-assist[bot]',
-    requestedReviewerLogins: [],
-    trigger: async ({ github, owner, repo, pull_number }) => {
-      await github.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: pull_number,
-        body: '/gemini review',
-      })
-    },
-  },
-]
+const GEMINI_LOGIN = 'gemini-code-assist[bot]'
+const GEMINI_REVIEW_COMMAND = '/gemini review'
 
 const hasLabel = (pullRequest, labelName) => {
   const labels = pullRequest?.labels ?? []
@@ -35,28 +8,13 @@ const hasLabel = (pullRequest, labelName) => {
 }
 
 const hasReviewedHead = (reviews, botLogin, headSha) => {
+  const target = botLogin.toLowerCase()
   return reviews.some(
     (review) =>
-      review?.user?.login === botLogin &&
+      review?.user?.login?.toLowerCase() === target &&
       review?.state !== 'PENDING' &&
       review?.commit_id === headSha
   )
-}
-
-const hasPendingRequest = (requestedReviewers, candidateLogins) => {
-  if (candidateLogins.length === 0) {
-    return false
-  }
-  return requestedReviewers.some((reviewer) => {
-    const login = reviewer?.login
-    if (!login) {
-      return false
-    }
-    const normalized = login.replace(/\[bot\]$/, '')
-    return (
-      candidateLogins.includes(login) || candidateLogins.includes(normalized)
-    )
-  })
 }
 
 const run = async ({ core, github, context }) => {
@@ -86,31 +44,19 @@ const run = async ({ core, github, context }) => {
     per_page: 100,
   })
 
-  const requestedReviewers = pullRequest.requested_reviewers ?? []
-
-  for (const bot of BOTS) {
-    if (hasReviewedHead(reviews, bot.reviewLogin, headSha)) {
-      core.info(
-        `${bot.name} (${bot.reviewLogin}) already reviewed head ${headSha}; skipping.`
-      )
-      continue
-    }
-
-    if (hasPendingRequest(requestedReviewers, bot.requestedReviewerLogins)) {
-      core.info(`${bot.name} already has a pending review request; skipping.`)
-      continue
-    }
-
-    core.info(`Triggering re-review for ${bot.name}.`)
-    try {
-      await bot.trigger({ github, owner, repo, pull_number })
-      core.info(`Re-review triggered for ${bot.name}.`)
-    } catch (error) {
-      core.warning(
-        `Failed to trigger re-review for ${bot.name}: ${error.message}`
-      )
-    }
+  if (hasReviewedHead(reviews, GEMINI_LOGIN, headSha)) {
+    core.info(`Gemini already reviewed head ${headSha}; skipping.`)
+    return
   }
+
+  core.info('Posting /gemini review comment.')
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pull_number,
+    body: GEMINI_REVIEW_COMMAND,
+  })
+  core.info('Re-review triggered for Gemini.')
 }
 
 module.exports = { run }

--- a/scripts/ai-rereview.cjs
+++ b/scripts/ai-rereview.cjs
@@ -1,6 +1,17 @@
 const RE_REVIEW_LABEL = 'ai-rereview'
-const GEMINI_LOGIN = 'gemini-code-assist[bot]'
-const GEMINI_REVIEW_COMMAND = '/gemini review'
+
+const BOTS = [
+  {
+    name: 'gemini',
+    reviewLogin: 'gemini-code-assist[bot]',
+    command: '/gemini review',
+  },
+  {
+    name: 'copilot',
+    reviewLogin: 'copilot-pull-request-reviewer[bot]',
+    command: '@copilot review',
+  },
+]
 
 const hasLabel = (pullRequest, labelName) => {
   const labels = pullRequest?.labels ?? []
@@ -44,19 +55,27 @@ const run = async ({ core, github, context }) => {
     per_page: 100,
   })
 
-  if (hasReviewedHead(reviews, GEMINI_LOGIN, headSha)) {
-    core.info(`Gemini already reviewed head ${headSha}; skipping.`)
-    return
-  }
+  for (const bot of BOTS) {
+    if (hasReviewedHead(reviews, bot.reviewLogin, headSha)) {
+      core.info(`${bot.name} already reviewed head ${headSha}; skipping.`)
+      continue
+    }
 
-  core.info('Posting /gemini review comment.')
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: pull_number,
-    body: GEMINI_REVIEW_COMMAND,
-  })
-  core.info('Re-review triggered for Gemini.')
+    core.info(`Posting "${bot.command}" for ${bot.name}.`)
+    try {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: pull_number,
+        body: bot.command,
+      })
+      core.info(`Re-review triggered for ${bot.name}.`)
+    } catch (error) {
+      core.warning(
+        `Failed to trigger re-review for ${bot.name}: ${error.message}`
+      )
+    }
+  }
 }
 
 module.exports = { run }

--- a/scripts/ai-rereview.cjs
+++ b/scripts/ai-rereview.cjs
@@ -47,9 +47,16 @@ const hasPendingRequest = (requestedReviewers, candidateLogins) => {
   if (candidateLogins.length === 0) {
     return false
   }
-  return requestedReviewers.some((reviewer) =>
-    candidateLogins.includes(reviewer?.login)
-  )
+  return requestedReviewers.some((reviewer) => {
+    const login = reviewer?.login
+    if (!login) {
+      return false
+    }
+    const normalized = login.replace(/\[bot\]$/, '')
+    return (
+      candidateLogins.includes(login) || candidateLogins.includes(normalized)
+    )
+  })
 }
 
 const run = async ({ core, github, context }) => {

--- a/scripts/ai-rereview.cjs
+++ b/scripts/ai-rereview.cjs
@@ -3,7 +3,8 @@ const RE_REVIEW_LABEL = 'ai-rereview'
 const BOTS = [
   {
     name: 'copilot',
-    login: 'copilot-pull-request-reviewer[bot]',
+    reviewLogin: 'copilot-pull-request-reviewer[bot]',
+    requestedReviewerLogins: ['Copilot', 'copilot-pull-request-reviewer'],
     trigger: async ({ github, owner, repo, pull_number }) => {
       await github.rest.pulls.requestReviewers({
         owner,
@@ -15,7 +16,8 @@ const BOTS = [
   },
   {
     name: 'gemini',
-    login: 'gemini-code-assist[bot]',
+    reviewLogin: 'gemini-code-assist[bot]',
+    requestedReviewerLogins: [],
     trigger: async ({ github, owner, repo, pull_number }) => {
       await github.rest.issues.createComment({
         owner,
@@ -41,10 +43,12 @@ const hasReviewedHead = (reviews, botLogin, headSha) => {
   )
 }
 
-const hasPendingRequest = (requestedReviewers, botLogin) => {
-  const baseLogin = botLogin.replace(/\[bot\]$/, '')
-  return requestedReviewers.some(
-    (reviewer) => reviewer?.login === botLogin || reviewer?.login === baseLogin
+const hasPendingRequest = (requestedReviewers, candidateLogins) => {
+  if (candidateLogins.length === 0) {
+    return false
+  }
+  return requestedReviewers.some((reviewer) =>
+    candidateLogins.includes(reviewer?.login)
   )
 }
 
@@ -78,21 +82,19 @@ const run = async ({ core, github, context }) => {
   const requestedReviewers = pullRequest.requested_reviewers ?? []
 
   for (const bot of BOTS) {
-    if (hasReviewedHead(reviews, bot.login, headSha)) {
+    if (hasReviewedHead(reviews, bot.reviewLogin, headSha)) {
       core.info(
-        `${bot.name} (${bot.login}) already reviewed head ${headSha}; skipping.`
+        `${bot.name} (${bot.reviewLogin}) already reviewed head ${headSha}; skipping.`
       )
       continue
     }
 
-    if (hasPendingRequest(requestedReviewers, bot.login)) {
-      core.info(
-        `${bot.name} (${bot.login}) already has a pending review request; skipping.`
-      )
+    if (hasPendingRequest(requestedReviewers, bot.requestedReviewerLogins)) {
+      core.info(`${bot.name} already has a pending review request; skipping.`)
       continue
     }
 
-    core.info(`Triggering re-review for ${bot.name} (${bot.login}).`)
+    core.info(`Triggering re-review for ${bot.name}.`)
     try {
       await bot.trigger({ github, owner, repo, pull_number })
       core.info(`Re-review triggered for ${bot.name}.`)

--- a/scripts/ai-rereview.cjs
+++ b/scripts/ai-rereview.cjs
@@ -1,0 +1,107 @@
+const RE_REVIEW_LABEL = 'ai-rereview'
+
+const BOTS = [
+  {
+    name: 'copilot',
+    login: 'copilot-pull-request-reviewer[bot]',
+    trigger: async ({ github, owner, repo, pull_number }) => {
+      await github.rest.pulls.requestReviewers({
+        owner,
+        repo,
+        pull_number,
+        reviewers: ['copilot-pull-request-reviewer'],
+      })
+    },
+  },
+  {
+    name: 'gemini',
+    login: 'gemini-code-assist[bot]',
+    trigger: async ({ github, owner, repo, pull_number }) => {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: pull_number,
+        body: '/gemini review',
+      })
+    },
+  },
+]
+
+const hasLabel = (pullRequest, labelName) => {
+  const labels = pullRequest?.labels ?? []
+  return labels.some((label) => label?.name === labelName)
+}
+
+const hasReviewedHead = (reviews, botLogin, headSha) => {
+  return reviews.some(
+    (review) =>
+      review?.user?.login === botLogin &&
+      review?.state !== 'PENDING' &&
+      review?.commit_id === headSha
+  )
+}
+
+const hasPendingRequest = (requestedReviewers, botLogin) => {
+  const baseLogin = botLogin.replace(/\[bot\]$/, '')
+  return requestedReviewers.some(
+    (reviewer) => reviewer?.login === botLogin || reviewer?.login === baseLogin
+  )
+}
+
+const run = async ({ core, github, context }) => {
+  const pullRequest = context.payload.pull_request
+
+  if (!pullRequest) {
+    core.info('No pull_request payload; skipping.')
+    return
+  }
+
+  if (!hasLabel(pullRequest, RE_REVIEW_LABEL)) {
+    core.info(
+      `Label "${RE_REVIEW_LABEL}" not present on PR #${pullRequest.number}; skipping.`
+    )
+    return
+  }
+
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+  const pull_number = pullRequest.number
+  const headSha = pullRequest.head.sha
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner,
+    repo,
+    pull_number,
+    per_page: 100,
+  })
+
+  const requestedReviewers = pullRequest.requested_reviewers ?? []
+
+  for (const bot of BOTS) {
+    if (hasReviewedHead(reviews, bot.login, headSha)) {
+      core.info(
+        `${bot.name} (${bot.login}) already reviewed head ${headSha}; skipping.`
+      )
+      continue
+    }
+
+    if (hasPendingRequest(requestedReviewers, bot.login)) {
+      core.info(
+        `${bot.name} (${bot.login}) already has a pending review request; skipping.`
+      )
+      continue
+    }
+
+    core.info(`Triggering re-review for ${bot.name} (${bot.login}).`)
+    try {
+      await bot.trigger({ github, owner, repo, pull_number })
+      core.info(`Re-review triggered for ${bot.name}.`)
+    } catch (error) {
+      core.warning(
+        `Failed to trigger re-review for ${bot.name}: ${error.message}`
+      )
+    }
+  }
+}
+
+module.exports = { run }

--- a/scripts/ai-rereview.cjs
+++ b/scripts/ai-rereview.cjs
@@ -1,15 +1,13 @@
 const RE_REVIEW_LABEL = 'ai-rereview'
 
+// Add a new entry to register a comment-triggered AI reviewer (e.g. Cursor,
+// Claude). Each bot needs its own response to a comment posted as a real
+// user — most bots ignore comments authored by github-actions[bot].
 const BOTS = [
   {
     name: 'gemini',
     reviewLogin: 'gemini-code-assist[bot]',
     command: '/gemini review',
-  },
-  {
-    name: 'copilot',
-    reviewLogin: 'copilot-pull-request-reviewer[bot]',
-    command: '@copilot review',
   },
 ]
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ai-rereview.yml` triggered on `pull_request: [labeled, synchronize]`, gated by the `ai-rereview` label
- Adds `scripts/ai-rereview.cjs` that re-requests Copilot (`requestReviewers`) and Gemini (`/gemini review` comment) when the label is on the PR
- Skips a bot if it already has a non-PENDING review for the current `head.sha`, or if it's already in `requested_reviewers` (with `[bot]` suffix normalization)
- Label sticks across pushes so subsequent commits on a labeled PR re-fire the workflow

## Test plan
- [ ] Create the `ai-rereview` label in repo settings (`gh label create ai-rereview`)
- [ ] Apply the label to this PR as a smoke test; verify the workflow runs, identifies bot states correctly, and fires re-reviews only where needed
- [ ] Push a follow-up commit while the label is on; verify `synchronize` re-triggers