### PR TITLE
(extension) suppress release notes auto-show in dev mode [DA-493]

### DIFF
--- a/packages/danmaku-anywhere/src/background/syncOptions/OptionsManager.ts
+++ b/packages/danmaku-anywhere/src/background/syncOptions/OptionsManager.ts
@@ -27,7 +27,9 @@ export class OptionsManager {
       this.tryUpgradeOptions()
 
       if (details.reason === 'update') {
-        await this.extensionOptionsService.update({ showReleaseNotes: true })
+        if (!import.meta.env.DEV) {
+          await this.extensionOptionsService.update({ showReleaseNotes: true })
+        }
         this.logger.info('Danmaku Anywhere Updated')
       } else {
         this.logger.info('Danmaku Anywhere Installed')


### PR DESCRIPTION
## Summary
- Guard the `showReleaseNotes: true` write in `OptionsManager.onInstalled` behind `!import.meta.env.DEV` so HMR/CRX rebuilds in dev no longer constantly re-pop the release notes modal.
- Production behavior unchanged — `import.meta.env.DEV` is compile-time replaced by Vite, so the guard disappears in shipped builds.
- The modal and query remain wired up; devs can still test by flipping `showReleaseNotes` manually via the BG service worker console.

## Verification
- `pnpm type-check`, `pnpm lint` clean.
- Not exercised via dev browser — the install/update listener doesn't fire during HMR sessions, so behavioral verification needs an uninstall/reinstall cycle. Please verify on next packaged update.