### PR TITLE
(extension) e2e fresh-install smoke + console-error fixture [DA-498]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -45,11 +45,19 @@ export class MountPage {
     return item
   }
 
-  // Open the per-item DrilldownMenu and click an action. The menu only
-  // mounts while the item is hovered, so we hover first.
+  // Open the per-item DrilldownMenu and click an action. The drilldown
+  // button only mounts while the tree item's `hovering` React state is
+  // true. item.hover() moves the OS mouse, but on headed CI runners with
+  // parallel workers the resulting mouseenter delegation can be lost,
+  // leaving the button unmounted and the click timing out. React uses
+  // `mouseover` at the root to compute onMouseEnter, so dispatching that
+  // synthetic event flips the state regardless of mouse position; we
+  // then wait for the button to render before clicking.
   async openItemMenu(item: Locator, actionId: string): Promise<void> {
-    await item.hover()
-    await item.locator(SELECTORS.drilldownButton).click()
+    await item.dispatchEvent('mouseover')
+    const button = item.locator(SELECTORS.drilldownButton)
+    await expect(button).toBeVisible({ timeout: 5_000 })
+    await button.click()
     await this.page.locator(SELECTORS.menuItem(actionId)).click()
   }
 

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -58,7 +58,12 @@ export class MountPage {
     const button = item.locator(SELECTORS.drilldownButton)
     await expect(button).toBeVisible({ timeout: 5_000 })
     await button.click()
-    await this.page.locator(SELECTORS.menuItem(actionId)).click()
+    const menuItem = this.page.locator(SELECTORS.menuItem(actionId))
+    await menuItem.click()
+    // Wait for the MUI Popover to finish closing — its backdrop persists
+    // through the fade-out transition and would intercept the next
+    // openItemMenu's click.
+    await expect(menuItem).toBeHidden({ timeout: 5_000 })
   }
 
   // Click the tree item's expand chevron to reveal children. RichTreeView

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -45,25 +45,12 @@ export class MountPage {
     return item
   }
 
-  // Open the per-item DrilldownMenu and click an action. The drilldown
-  // button only mounts while the tree item's `hovering` React state is
-  // true. item.hover() moves the OS mouse, but on headed CI runners with
-  // parallel workers the resulting mouseenter delegation can be lost,
-  // leaving the button unmounted and the click timing out. React uses
-  // `mouseover` at the root to compute onMouseEnter, so dispatching that
-  // synthetic event flips the state regardless of mouse position; we
-  // then wait for the button to render before clicking.
+  // Open the per-item DrilldownMenu and click an action. The menu only
+  // mounts while the item is hovered, so we hover first.
   async openItemMenu(item: Locator, actionId: string): Promise<void> {
-    await item.dispatchEvent('mouseover')
-    const button = item.locator(SELECTORS.drilldownButton)
-    await expect(button).toBeVisible({ timeout: 5_000 })
-    await button.click()
-    const menuItem = this.page.locator(SELECTORS.menuItem(actionId))
-    await menuItem.click()
-    // Wait for the MUI Popover to finish closing — its backdrop persists
-    // through the fade-out transition and would intercept the next
-    // openItemMenu's click.
-    await expect(menuItem).toBeHidden({ timeout: 5_000 })
+    await item.hover()
+    await item.locator(SELECTORS.drilldownButton).click()
+    await this.page.locator(SELECTORS.menuItem(actionId)).click()
   }
 
   // Click the tree item's expand chevron to reveal children. RichTreeView

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -45,12 +45,22 @@ export class MountPage {
     return item
   }
 
-  // Open the per-item DrilldownMenu and click an action. The menu only
-  // mounts while the item is hovered, so we hover first.
+  // Open the per-item action menu by right-click. The tree item renders
+  // two menu variants:
+  //   - DrilldownMenu (anchored to a 3-dot IconButton, MUI Modal/Backdrop)
+  //   - DrilldownContextMenu (Popper, no Modal/Backdrop) on right-click
+  // Both render the same DAMenuItem entries with the same testids. The
+  // Modal path is brittle: the IconButton is conditionally mounted on a
+  // `hovering` React state that races with Playwright's hover() under
+  // xvfb, and the Modal's Backdrop intercepts pointer events during its
+  // close transition. The Popper path has neither footgun.
   async openItemMenu(item: Locator, actionId: string): Promise<void> {
-    await item.hover()
-    await item.locator(SELECTORS.drilldownButton).click()
-    await this.page.locator(SELECTORS.menuItem(actionId)).click()
+    await item.click({ button: 'right' })
+    const menuItem = this.page.locator(SELECTORS.menuItem(actionId))
+    await menuItem.click()
+    // Ensure the menu has fully closed before returning so a follow-up
+    // openItemMenu call doesn't race the close.
+    await expect(menuItem).toBeHidden({ timeout: 5_000 })
   }
 
   // Click the tree item's expand chevron to reveal children. RichTreeView

--- a/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
@@ -6,8 +6,15 @@ export interface ConsoleWatcher {
 
 export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
   const errors: string[] = []
+  // Dedupe so a worker/page that races between context.on(...) firing and
+  // the initial enumeration below isn't double-watched.
+  const watched = new WeakSet<Page | Worker>()
 
   function watchWorker(worker: Worker): void {
+    if (watched.has(worker)) {
+      return
+    }
+    watched.add(worker)
     worker.on('console', (msg) => {
       if (msg.type() === 'error') {
         errors.push(`[sw] ${msg.text()}`)
@@ -16,15 +23,24 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
   }
 
   function watchPage(page: Page): void {
+    if (watched.has(page)) {
+      return
+    }
+    watched.add(page)
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
         errors.push(`[page ${page.url()}] ${msg.text()}`)
       }
     })
     page.on('pageerror', (err) => {
-      errors.push(`[page ${page.url()}] ${err.message}`)
+      errors.push(`[page ${page.url()}] ${err.stack ?? err.message}`)
     })
   }
+
+  // Attach context-level listeners FIRST so any worker/page that registers
+  // mid-enumeration is still captured, then walk the current lists.
+  context.on('serviceworker', watchWorker)
+  context.on('page', watchPage)
 
   for (const w of context.serviceWorkers()) {
     watchWorker(w)
@@ -32,9 +48,6 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
   for (const p of context.pages()) {
     watchPage(p)
   }
-
-  context.on('serviceworker', watchWorker)
-  context.on('page', watchPage)
 
   return { getErrors: () => [...errors] }
 }

--- a/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
@@ -1,4 +1,9 @@
-import type { BrowserContext, Page, Worker } from '@playwright/test'
+import type {
+  BrowserContext,
+  ConsoleMessage,
+  Page,
+  Worker,
+} from '@playwright/test'
 
 export interface ConsoleWatcher {
   getErrors: () => string[]
@@ -10,14 +15,22 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
   // the initial enumeration below isn't double-watched.
   const watched = new WeakSet<Page | Worker>()
 
-  function watchWorker(worker: Worker): void {
+  function formatLocation(msg: ConsoleMessage): string {
+    const loc = msg.location()
+    if (!loc.url) {
+      return ''
+    }
+    return ` (${loc.url}:${loc.lineNumber}:${loc.columnNumber})`
+  }
+
+  function watchWorker(worker: Worker, label = 'sw'): void {
     if (watched.has(worker)) {
       return
     }
     watched.add(worker)
     worker.on('console', (msg) => {
       if (msg.type() === 'error') {
-        errors.push(`[sw] ${msg.text()}`)
+        errors.push(`[${label}] ${msg.text()}${formatLocation(msg)}`)
       }
     })
   }
@@ -29,12 +42,17 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
     watched.add(page)
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
-        errors.push(`[page ${page.url()}] ${msg.text()}`)
+        errors.push(`[page ${page.url()}] ${msg.text()}${formatLocation(msg)}`)
       }
     })
     page.on('pageerror', (err) => {
       errors.push(`[page ${page.url()}] ${err.stack ?? err.message}`)
     })
+    // Web Workers spawned by the page (distinct from extension SWs).
+    page.on('worker', (w) => watchWorker(w, 'page-worker'))
+    for (const w of page.workers()) {
+      watchWorker(w, 'page-worker')
+    }
   }
 
   // Attach context-level listeners FIRST so any worker/page that registers

--- a/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
@@ -23,14 +23,14 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
     return ` (${loc.url}:${loc.lineNumber}:${loc.columnNumber})`
   }
 
-  function watchWorker(worker: Worker, label = 'sw'): void {
+  function watchWorker(worker: Worker): void {
     if (watched.has(worker)) {
       return
     }
     watched.add(worker)
     worker.on('console', (msg) => {
       if (msg.type() === 'error') {
-        errors.push(`[${label}] ${msg.text()}${formatLocation(msg)}`)
+        errors.push(`[sw] ${msg.text()}${formatLocation(msg)}`)
       }
     })
   }
@@ -48,11 +48,6 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
     page.on('pageerror', (err) => {
       errors.push(`[page ${page.url()}] ${err.stack ?? err.message}`)
     })
-    // Web Workers spawned by the page (distinct from extension SWs).
-    page.on('worker', (w) => watchWorker(w, 'page-worker'))
-    for (const w of page.workers()) {
-      watchWorker(w, 'page-worker')
-    }
   }
 
   // Attach context-level listeners FIRST so any worker/page that registers

--- a/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
@@ -1,0 +1,40 @@
+import type { BrowserContext, Page, Worker } from '@playwright/test'
+
+export interface ConsoleWatcher {
+  getErrors: () => string[]
+}
+
+export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
+  const errors: string[] = []
+
+  function watchWorker(worker: Worker): void {
+    worker.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(`[sw] ${msg.text()}`)
+      }
+    })
+  }
+
+  function watchPage(page: Page): void {
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(`[page ${page.url()}] ${msg.text()}`)
+      }
+    })
+    page.on('pageerror', (err) => {
+      errors.push(`[page ${page.url()}] ${err.message}`)
+    })
+  }
+
+  for (const w of context.serviceWorkers()) {
+    watchWorker(w)
+  }
+  for (const p of context.pages()) {
+    watchPage(p)
+  }
+
+  context.on('serviceworker', watchWorker)
+  context.on('page', watchPage)
+
+  return { getErrors: () => [...errors] }
+}

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -1,6 +1,7 @@
 import { type BrowserContext, test as base, chromium } from '@playwright/test'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { attachConsoleWatcher, type ConsoleWatcher } from './console-watcher'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // e2e/setup/fixtures.ts → ../../build
@@ -9,6 +10,7 @@ const pathToExtension = path.join(__dirname, '..', '..', 'build')
 export const test = base.extend<{
   context: BrowserContext
   extensionId: string
+  consoleErrors: () => string[]
 }>({
   // biome-ignore lint: Playwright fixture pattern requires destructuring
   context: async ({}, use) => {
@@ -29,6 +31,10 @@ export const test = base.extend<{
     }
     const extensionId = serviceWorker.url().split('/')[2]
     await use(extensionId)
+  },
+  consoleErrors: async ({ context }, use) => {
+    const watcher: ConsoleWatcher = attachConsoleWatcher(context)
+    await use(watcher.getErrors)
   },
 })
 

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -7,6 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // e2e/setup/fixtures.ts → ../../build
 const pathToExtension = path.join(__dirname, '..', '..', 'build')
 
+// Watchers are attached eagerly inside the context fixture (before the SW
+// has a chance to boot) and looked up later by the consoleErrors fixture.
+// Playwright resolves fixtures in dependency order, so a fixture that
+// depends only on `context` runs after the SW may have already emitted —
+// Playwright doesn't buffer console events for existing workers.
+const watchersByContext = new WeakMap<BrowserContext, ConsoleWatcher>()
+
 export const test = base.extend<{
   context: BrowserContext
   extensionId: string
@@ -21,6 +28,7 @@ export const test = base.extend<{
         `--load-extension=${pathToExtension}`,
       ],
     })
+    watchersByContext.set(context, attachConsoleWatcher(context))
     await use(context)
     await context.close()
   },
@@ -33,7 +41,12 @@ export const test = base.extend<{
     await use(extensionId)
   },
   consoleErrors: async ({ context }, use) => {
-    const watcher: ConsoleWatcher = attachConsoleWatcher(context)
+    const watcher = watchersByContext.get(context)
+    if (!watcher) {
+      throw new Error(
+        'consoleErrors fixture used without a watcher attached to the context'
+      )
+    }
     await use(watcher.getErrors)
   },
 })

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -1,0 +1,42 @@
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+
+/**
+ * Fresh-install smoke for the extension. Asserts the SW registers, the
+ * onInstalled upgrade path seeds default extensionOptions plus the three
+ * built-in provider configs, and no console errors fire during boot.
+ *
+ * A chrome.runtime.reload() variant was intentionally dropped: under
+ * Playwright's --load-extension launch, the extension does not respawn
+ * after runtime.reload(), so the case isn't exercisable here.
+ */
+
+const BUILTIN_PROVIDER_IDS = [
+  'builtin:dandanplay',
+  'builtin:bilibili',
+  'builtin:tencent',
+] as const
+
+test('fresh install: default options seeded, no console errors', async ({
+  context,
+  extensionId,
+  consoleErrors,
+}) => {
+  expect(extensionId).toMatch(/^[a-z]{32}$/)
+
+  const da = await getDaClient(context)
+
+  const options = await da.extensionOptions.get()
+  expect(options.enabled).toBe(true)
+  expect(options.hotkeys).toBeTruthy()
+  expect(options.theme).toBeTruthy()
+
+  const providers = await da.providerConfig.list()
+  const ids = providers.map((p) => p.id).sort()
+  expect(ids).toEqual([...BUILTIN_PROVIDER_IDS].sort())
+  for (const p of providers) {
+    expect(p.isBuiltIn).toBe(true)
+  }
+
+  expect(consoleErrors()).toEqual([])
+})

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -1,3 +1,7 @@
+import {
+  DanmakuSourceType,
+  PROVIDER_TO_BUILTIN_ID,
+} from '@danmaku-anywhere/danmaku-converter'
 import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
@@ -12,9 +16,9 @@ import { expect, test } from '../../setup/fixtures'
  */
 
 const BUILTIN_PROVIDER_IDS = [
-  'builtin:dandanplay',
-  'builtin:bilibili',
-  'builtin:tencent',
+  PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
+  PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
+  PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
 ] as const
 
 test('fresh install: default options seeded, no console errors', async ({

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -22,7 +22,8 @@ test('fresh install: default options seeded, no console errors', async ({
   extensionId,
   consoleErrors,
 }) => {
-  expect(extensionId).toMatch(/^[a-z]{32}$/)
+  // Chrome extension IDs are a 32-char base-16 alphabet of a-p.
+  expect(extensionId).toMatch(/^[a-p]{32}$/)
 
   const da = await getDaClient(context)
 

--- a/packages/danmaku-anywhere/playwright.config.ts
+++ b/packages/danmaku-anywhere/playwright.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
     // Extensions require the full chromium channel and headed mode
     channel: 'chromium',
     headless: false,
+    // Capture a full Playwright trace on failure so CI flakes don't
+    // require re-running with extra instrumentation to diagnose.
+    trace: 'retain-on-failure',
   },
 })


### PR DESCRIPTION
## Summary
- Add `e2e/setup/console-watcher.ts` Playwright helper that collects console errors from every service worker and page in the context, plus `pageerror` events from pages. Exposed via an opt-in `consoleErrors: () => string[]` fixture so specs can `expect(getErrors()).toEqual([])`.
- Add `e2e/specs/lifecycle/install.spec.ts` fresh-install smoke: asserts the SW registers with a valid extensionId, default `extensionOptions` are seeded, the three built-in provider configs (`builtin:dandanplay`/`bilibili`/`tencent`) are present and `isBuiltIn`, and no console errors fire during boot.
- A `chrome.runtime.reload()` smoke variant was intentionally dropped: under Playwright's `--load-extension` launch the extension does not respawn after a runtime reload, so the case isn't exercisable here. The spec's header comment notes this.