### PR TITLE
(extension) e2e coverage for mount tree delete, multi-select, folder, export [DA-499]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -6,6 +6,10 @@ const SELECTORS = {
   treeItemExpand: (id: string) => `[data-testid="tree-item-expand-${id}"]`,
   drilldownButton: '[data-testid="drilldown-menu-button"]',
   menuItem: (id: string) => `[data-testid="drilldown-menu-item-${id}"]`,
+  dialogConfirm: '[data-testid="dialog-confirm"]',
+  multiselectToggle: '[data-testid="multiselect-toggle"]',
+  multiselectSelectAll: '[data-testid="multiselect-select-all"]',
+  bulkDelete: '[data-testid="mount-bulk-delete"]',
 }
 
 // Page object for the popup's default /mount route — the DanmakuTree
@@ -61,5 +65,49 @@ export class MountPage {
     await expect(item).toHaveAttribute('aria-expanded', 'true', {
       timeout: 2_000,
     })
+  }
+
+  // Expand any tree item by its full itemId (e.g. 'season-custom',
+  // 'folder-MyFolder'). No-op if already expanded.
+  async expandItem(itemId: string): Promise<void> {
+    const item = this.page.locator(SELECTORS.treeItem(itemId))
+    if ((await item.getAttribute('aria-expanded')) === 'true') {
+      return
+    }
+    await this.page.locator(SELECTORS.treeItemExpand(itemId)).click()
+    await expect(item).toHaveAttribute('aria-expanded', 'true', {
+      timeout: 2_000,
+    })
+  }
+
+  folderItem(folderPath: string): Locator {
+    return this.page.locator(SELECTORS.treeItem(`folder-${folderPath}`))
+  }
+
+  customEpisodeItem(episodeId: number): Locator {
+    return this.page.locator(SELECTORS.treeItem(`custom-episode-${episodeId}`))
+  }
+
+  // Confirm the active MUI delete/confirm dialog. The Dialog renders in a
+  // portal, so the testid is looked up at the page level (not scoped to a
+  // tree item).
+  async confirmDialog(): Promise<void> {
+    const confirm = this.page.locator(SELECTORS.dialogConfirm)
+    await confirm.click()
+  }
+
+  async enterMultiSelect(): Promise<void> {
+    await this.page.locator(SELECTORS.multiselectToggle).click()
+    await expect(this.page.locator(SELECTORS.multiselectSelectAll)).toBeVisible(
+      { timeout: 2_000 }
+    )
+  }
+
+  async selectAll(): Promise<void> {
+    await this.page.locator(SELECTORS.multiselectSelectAll).click()
+  }
+
+  async bulkDelete(): Promise<void> {
+    await this.page.locator(SELECTORS.bulkDelete).click()
   }
 }

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -90,9 +90,12 @@ export class MountPage {
 
   // Confirm the active MUI delete/confirm dialog. The Dialog renders in a
   // portal, so the testid is looked up at the page level (not scoped to a
-  // tree item).
-  async confirmDialog(): Promise<void> {
+  // tree item). Waits for the button to be visible first — without the
+  // explicit wait, a regression that no longer opens a dialog hangs on
+  // Playwright's default 30s auto-wait instead of failing fast.
+  async confirmDialog(timeout = 5_000): Promise<void> {
     const confirm = this.page.locator(SELECTORS.dialogConfirm)
+    await expect(confirm).toBeVisible({ timeout })
     await confirm.click()
   }
 

--- a/packages/danmaku-anywhere/e2e/setup/da-client.ts
+++ b/packages/danmaku-anywhere/e2e/setup/da-client.ts
@@ -1,5 +1,7 @@
 import type {
   Bookmark,
+  CustomEpisode,
+  CustomEpisodeInsert,
   Episode,
   EpisodeInsert,
   Season,
@@ -93,6 +95,10 @@ export class DaClient {
       this.sw.evaluate((e) => self.__da.episode.add(e), insert),
     get: (id: number): Promise<Episode | undefined> =>
       this.sw.evaluate((id) => self.__da.episode.get(id), id),
+    addCustom: (insert: CustomEpisodeInsert): Promise<CustomEpisode> =>
+      this.sw.evaluate((e) => self.__da.episode.addCustom(e), insert),
+    listCustom: (): Promise<CustomEpisode[]> =>
+      this.sw.evaluate(() => self.__da.episode.listCustom()),
   }
 
   bookmark = {

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -111,7 +111,10 @@ test('mount tree: delete single episode keeps season + siblings', async ({
     .poll(() => da.episode.get(ep1.id), { timeout: 10_000 })
     .toBeUndefined()
 
-  // Sibling + parent intact.
+  // Sibling + parent intact — checked in both UI and DB so a regression
+  // that wipes more than intended (or only updates one layer) is caught.
+  await expect(popup.mount.episodeItem(ep2.id)).toBeVisible()
+  await expect(popup.mount.seasonItem(season.id)).toBeVisible()
   const survivor = await da.episode.get(ep2.id)
   expect(survivor?.id).toBe(ep2.id)
   const survivingSeason = await da.season.get(season.id)

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -1,0 +1,113 @@
+import {
+  DanmakuSourceType,
+  type EpisodeInsert,
+  type SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Per-item delete on the DanmakuTree (/mount). Two paths:
+ *   - Season delete via the season's context menu — cascades to its
+ *     episodes; the season row disappears and `da.season.get` returns
+ *     undefined.
+ *   - Episode delete via the episode's context menu — removes a single
+ *     row, leaving the parent season intact (still has another episode).
+ *
+ * Both delete actions open a shared confirmation Dialog rendered in a
+ * portal; the spec clicks `[data-testid="dialog-confirm"]` to commit.
+ */
+
+const SEASON: SeasonInsert = {
+  provider: DanmakuSourceType.Bilibili,
+  providerIds: { seasonId: 41410, mediaId: 28219412 },
+  providerConfigId: 'builtin:bilibili',
+  indexedId: '41410',
+  title: '葬送的芙莉莲',
+  type: '番剧',
+  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
+  episodeCount: 28,
+  year: 2023,
+  schemaVersion: 1,
+}
+
+function makeEpisode(
+  seasonId: number,
+  cid: number,
+  episodeNumber: string
+): EpisodeInsert {
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { cid, aid: 100000 + cid, bvid: `BV${cid}` },
+    indexedId: String(cid),
+    title: `Ep${episodeNumber}`,
+    episodeNumber,
+    seasonId,
+    comments: [],
+    commentCount: 0,
+    schemaVersion: 4,
+    lastChecked: 0,
+  }
+}
+
+test('mount tree: delete season removes it + cascades episodes', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+  })
+
+  const season = await da.season.add(SEASON)
+  const ep = await da.episode.add(makeEpisode(season.id, 1300001, '1'))
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  const seasonItem = await popup.mount.waitForSeason(season.id)
+
+  await popup.mount.openItemMenu(seasonItem, 'delete')
+  await popup.mount.confirmDialog()
+
+  await expect(seasonItem).toBeHidden({ timeout: 10_000 })
+
+  await expect.poll(() => da.season.get(season.id)).toBeUndefined()
+  await expect.poll(() => da.episode.get(ep.id)).toBeUndefined()
+})
+
+test('mount tree: delete single episode keeps season + siblings', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+  })
+
+  const season = await da.season.add(SEASON)
+  const ep1 = await da.episode.add(makeEpisode(season.id, 1300001, '1'))
+  const ep2 = await da.episode.add(makeEpisode(season.id, 1300002, '2'))
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  await popup.mount.waitForSeason(season.id)
+  await popup.mount.expandSeason(season.id)
+
+  const ep1Item = popup.mount.episodeItem(ep1.id).first()
+  await expect(ep1Item).toBeVisible({ timeout: 10_000 })
+
+  await popup.mount.openItemMenu(ep1Item, 'delete')
+  await popup.mount.confirmDialog()
+
+  await expect(ep1Item).toBeHidden({ timeout: 10_000 })
+
+  await expect.poll(() => da.episode.get(ep1.id)).toBeUndefined()
+
+  // Sibling + parent intact.
+  const survivor = await da.episode.get(ep2.id)
+  expect(survivor?.id).toBe(ep2.id)
+  const survivingSeason = await da.season.get(season.id)
+  expect(survivingSeason?.id).toBe(season.id)
+})

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -95,7 +95,7 @@ test('mount tree: delete single episode keeps season + siblings', async ({
   await popup.mount.waitForSeason(season.id)
   await popup.mount.expandSeason(season.id)
 
-  const ep1Item = popup.mount.episodeItem(ep1.id).first()
+  const ep1Item = popup.mount.episodeItem(ep1.id)
   await expect(ep1Item).toBeVisible({ timeout: 10_000 })
 
   await popup.mount.openItemMenu(ep1Item, 'delete')

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -73,8 +73,12 @@ test('mount tree: delete season removes it + cascades episodes', async ({
 
   await expect(seasonItem).toBeHidden({ timeout: 10_000 })
 
-  await expect.poll(() => da.season.get(season.id)).toBeUndefined()
-  await expect.poll(() => da.episode.get(ep.id)).toBeUndefined()
+  await expect
+    .poll(() => da.season.get(season.id), { timeout: 10_000 })
+    .toBeUndefined()
+  await expect
+    .poll(() => da.episode.get(ep.id), { timeout: 10_000 })
+    .toBeUndefined()
 })
 
 test('mount tree: delete single episode keeps season + siblings', async ({
@@ -103,7 +107,9 @@ test('mount tree: delete single episode keeps season + siblings', async ({
 
   await expect(ep1Item).toBeHidden({ timeout: 10_000 })
 
-  await expect.poll(() => da.episode.get(ep1.id)).toBeUndefined()
+  await expect
+    .poll(() => da.episode.get(ep1.id), { timeout: 10_000 })
+    .toBeUndefined()
 
   // Sibling + parent intact.
   const survivor = await da.episode.get(ep2.id)

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -72,9 +72,11 @@ test('mount tree: season export downloads an XML payload', async ({
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)
 
-  // waitForEvent must be armed before the click that triggers the
-  // download.
-  const downloadPromise = page.waitForEvent('download', { timeout: 10_000 })
+  // waitForEvent must be armed before the click that triggers it. 20s
+  // (vs the usual 10) gives slack for slow CI runners: the export
+  // mutation fetches via RPC, serializes, then triggers a programmatic
+  // <a download> click.
+  const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'export')
   const download = await downloadPromise
 
@@ -105,7 +107,7 @@ test('mount tree: season exportBackup downloads a JSON payload', async ({
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)
 
-  const downloadPromise = page.waitForEvent('download', { timeout: 10_000 })
+  const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'exportBackup')
   const download = await downloadPromise
 

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -4,8 +4,6 @@ import {
   type SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
 import { readFile } from 'fs/promises'
-import { tmpdir } from 'os'
-import { join } from 'path'
 import { Popup } from '../../pom/Popup'
 import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
@@ -22,8 +20,9 @@ import { applyProfile } from '../../setup/profile'
  *
  * Each test seeds a season + exactly one episode so the export emits a
  * single-file download (multi-episode exports zip; out of scope here).
- * Downloads are captured via Playwright's `page.waitForEvent('download')`,
- * saved to a tmp path, read back, and asserted.
+ * Downloads are captured via Playwright's `page.waitForEvent('download')`
+ * and read from `download.path()` — Playwright auto-manages the temp file
+ * and cleans it up when the browser context closes.
  */
 
 const SEASON: SeasonInsert = {
@@ -81,9 +80,8 @@ test('mount tree: season export downloads an XML payload', async ({
 
   expect(download.suggestedFilename()).toMatch(/\.xml$/i)
 
-  const dest = join(tmpdir(), `da-export-${Date.now()}.xml`)
-  await download.saveAs(dest)
-  const content = await readFile(dest, 'utf-8')
+  const path = await download.path()
+  const content = await readFile(path, 'utf-8')
 
   expect(content).toContain('<i>')
   expect(content).toContain('</i>')
@@ -113,9 +111,8 @@ test('mount tree: season exportBackup downloads a JSON payload', async ({
 
   expect(download.suggestedFilename()).toMatch(/\.json$/i)
 
-  const dest = join(tmpdir(), `da-export-${Date.now()}.json`)
-  await download.saveAs(dest)
-  const content = await readFile(dest, 'utf-8')
+  const path = await download.path()
+  const content = await readFile(path, 'utf-8')
 
   const parsed = JSON.parse(content) as {
     title?: string

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -1,0 +1,129 @@
+import {
+  DanmakuSourceType,
+  type EpisodeInsert,
+  type SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
+import { readFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Export actions on the DanmakuTree (/mount). Two paths exercised
+ * through the season context menu:
+ *   - `export` (XML) — downloads a `.xml` payload starting with the
+ *     `<i>` root element produced by `commentsToXml`.
+ *   - `exportBackup` (JSON) — downloads a `.json` payload that round-
+ *     trips through JSON.parse and carries the seeded episode's title
+ *     + commentCount.
+ *
+ * Each test seeds a season + exactly one episode so the export emits a
+ * single-file download (multi-episode exports zip; out of scope here).
+ * Downloads are captured via Playwright's `page.waitForEvent('download')`,
+ * saved to a tmp path, read back, and asserted.
+ */
+
+const SEASON: SeasonInsert = {
+  provider: DanmakuSourceType.Bilibili,
+  providerIds: { seasonId: 41410, mediaId: 28219412 },
+  providerConfigId: 'builtin:bilibili',
+  indexedId: '41410',
+  title: '葬送的芙莉莲',
+  type: '番剧',
+  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
+  episodeCount: 28,
+  year: 2023,
+  schemaVersion: 1,
+}
+
+function makeEpisode(seasonId: number): EpisodeInsert {
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
+    indexedId: '1300001',
+    title: 'Ep1',
+    episodeNumber: '1',
+    seasonId,
+    comments: [
+      { p: '0.00,1,25,16777215,0,0,0,0', m: 'hello' },
+      { p: '1.00,1,25,16777215,0,0,0,0', m: 'world' },
+    ],
+    commentCount: 2,
+    schemaVersion: 4,
+    lastChecked: 0,
+  }
+}
+
+test('mount tree: season export downloads an XML payload', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+  })
+
+  const season = await da.season.add(SEASON)
+  await da.episode.add(makeEpisode(season.id))
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  const seasonItem = await popup.mount.waitForSeason(season.id)
+
+  // waitForEvent must be armed before the click that triggers the
+  // download.
+  const downloadPromise = page.waitForEvent('download', { timeout: 10_000 })
+  await popup.mount.openItemMenu(seasonItem, 'export')
+  const download = await downloadPromise
+
+  expect(download.suggestedFilename()).toMatch(/\.xml$/i)
+
+  const dest = join(tmpdir(), `da-export-${Date.now()}.xml`)
+  await download.saveAs(dest)
+  const content = await readFile(dest, 'utf-8')
+
+  expect(content).toContain('<i>')
+  expect(content).toContain('</i>')
+  expect(content).toContain('hello')
+  expect(content).toContain('world')
+})
+
+test('mount tree: season exportBackup downloads a JSON payload', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+  })
+
+  const season = await da.season.add(SEASON)
+  const ep = await da.episode.add(makeEpisode(season.id))
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  const seasonItem = await popup.mount.waitForSeason(season.id)
+
+  const downloadPromise = page.waitForEvent('download', { timeout: 10_000 })
+  await popup.mount.openItemMenu(seasonItem, 'exportBackup')
+  const download = await downloadPromise
+
+  expect(download.suggestedFilename()).toMatch(/\.json$/i)
+
+  const dest = join(tmpdir(), `da-export-${Date.now()}.json`)
+  await download.saveAs(dest)
+  const content = await readFile(dest, 'utf-8')
+
+  const parsed = JSON.parse(content) as {
+    title?: string
+    commentCount?: number
+    comments?: unknown[]
+  }
+  expect(parsed.title).toBe(ep.title)
+  expect(parsed.commentCount).toBe(2)
+  expect(Array.isArray(parsed.comments)).toBe(true)
+  expect(parsed.comments).toHaveLength(2)
+})

--- a/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
@@ -1,0 +1,61 @@
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Folder rendering in the DanmakuTree (/mount). Folders are derived from
+ * custom episode titles split on '/': a title like
+ * `MyFolder/ep1.xml` produces a `folder-MyFolder` node grouping the
+ * matching `custom-episode-{id}` rows under the "Local Danmaku" root.
+ *
+ * The spec seeds two custom episodes sharing a folder prefix via the
+ * dev API (no drag/drop, since folders are emergent from titles —
+ * there is no separate "create folder" call), then walks the tree:
+ * Local Danmaku → folder → child episodes.
+ */
+
+const FOLDER = 'MyFolder'
+
+test('mount tree: custom episodes with shared path render under a folder node', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {})
+
+  const ep1 = await da.episode.addCustom({
+    provider: DanmakuSourceType.MacCMS,
+    title: `${FOLDER}/ep1.xml`,
+    comments: [],
+    commentCount: 0,
+    schemaVersion: 4,
+  })
+  const ep2 = await da.episode.addCustom({
+    provider: DanmakuSourceType.MacCMS,
+    title: `${FOLDER}/ep2.xml`,
+    comments: [],
+    commentCount: 0,
+    schemaVersion: 4,
+  })
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+
+  // The custom-episode root uses a synthetic `season-custom` id rather
+  // than a DB season id.
+  await popup.mount.expandItem('season-custom')
+
+  const folder = popup.mount.folderItem(FOLDER)
+  await expect(folder).toBeVisible({ timeout: 10_000 })
+
+  await popup.mount.expandItem(`folder-${FOLDER}`)
+
+  await expect(popup.mount.customEpisodeItem(ep1.id)).toBeVisible({
+    timeout: 10_000,
+  })
+  await expect(popup.mount.customEpisodeItem(ep2.id)).toBeVisible({
+    timeout: 10_000,
+  })
+})

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -74,7 +74,7 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   // Episodes must be in the DOM before "select all" — selectAll() walks
   // the rendered tree and picks every `kind === 'episode'` node.
   for (const ep of seeded) {
-    await expect(popup.mount.episodeItem(ep.id).first()).toBeVisible({
+    await expect(popup.mount.episodeItem(ep.id)).toBeVisible({
       timeout: 10_000,
     })
   }

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -1,0 +1,92 @@
+import {
+  DanmakuSourceType,
+  type EpisodeInsert,
+  type SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Multi-select bulk delete from the DanmakuTree (/mount). Seeds a season
+ * with three episodes, toggles multi-select via the toolbar chip, uses
+ * the toolbar's "select all" checkbox to mark every visible episode,
+ * then clicks the bottom-bar Delete and confirms the dialog. Asserts
+ * all three episode rows are gone from the DB. The parent season has
+ * no remaining episodes, so the parent tree row disappears too — this
+ * doubles as coverage that bulk delete fires once for the whole batch.
+ */
+
+const SEASON: SeasonInsert = {
+  provider: DanmakuSourceType.Bilibili,
+  providerIds: { seasonId: 41410, mediaId: 28219412 },
+  providerConfigId: 'builtin:bilibili',
+  indexedId: '41410',
+  title: '葬送的芙莉莲',
+  type: '番剧',
+  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
+  episodeCount: 28,
+  year: 2023,
+  schemaVersion: 1,
+}
+
+function makeEpisode(
+  seasonId: number,
+  cid: number,
+  episodeNumber: string
+): EpisodeInsert {
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { cid, aid: 100000 + cid, bvid: `BV${cid}` },
+    indexedId: String(cid),
+    title: `Ep${episodeNumber}`,
+    episodeNumber,
+    seasonId,
+    comments: [],
+    commentCount: 0,
+    schemaVersion: 4,
+    lastChecked: 0,
+  }
+}
+
+test('mount tree: multi-select bulk delete removes every selected episode', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+  })
+
+  const season = await da.season.add(SEASON)
+  const seeded = await Promise.all([
+    da.episode.add(makeEpisode(season.id, 1300001, '1')),
+    da.episode.add(makeEpisode(season.id, 1300002, '2')),
+    da.episode.add(makeEpisode(season.id, 1300003, '3')),
+  ])
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  await popup.mount.waitForSeason(season.id)
+  await popup.mount.expandSeason(season.id)
+
+  // Episodes must be in the DOM before "select all" — selectAll() walks
+  // the rendered tree and picks every `kind === 'episode'` node.
+  for (const ep of seeded) {
+    await expect(popup.mount.episodeItem(ep.id).first()).toBeVisible({
+      timeout: 10_000,
+    })
+  }
+
+  await popup.mount.enterMultiSelect()
+  await popup.mount.selectAll()
+  await popup.mount.bulkDelete()
+  await popup.mount.confirmDialog()
+
+  for (const ep of seeded) {
+    await expect
+      .poll(() => da.episode.get(ep.id), { timeout: 10_000 })
+      .toBeUndefined()
+  }
+})

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -85,6 +85,9 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   await popup.mount.confirmDialog()
 
   for (const ep of seeded) {
+    await expect(popup.mount.episodeItem(ep.id)).toBeHidden({
+      timeout: 10_000,
+    })
     await expect
       .poll(() => da.episode.get(ep.id), { timeout: 10_000 })
       .toBeUndefined()

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/MountPageBottomBar.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/MountPageBottomBar.tsx
@@ -112,6 +112,7 @@ export const MountPageBottomBar = ({
                 onClick={onDelete}
                 size="small"
                 disabled={selectionCount === 0}
+                data-testid="mount-bulk-delete"
               >
                 {t('common.delete', 'Delete')}
               </Button>

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/MountPageToolbar.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/MountPageToolbar.tsx
@@ -60,6 +60,7 @@ export const MountPageToolbar = ({
             onChange={handleSelection}
             size="small"
             edge="start"
+            data-testid="multiselect-select-all"
           />
         </Collapse>
       }

--- a/packages/danmaku-anywhere/src/common/components/Dialog/DialogRender.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Dialog/DialogRender.tsx
@@ -141,6 +141,7 @@ export const DialogRender = ({
         onClick={handleClose}
         disabled={isLoading}
         {...cancelButtonProps}
+        data-testid="dialog-cancel"
         key="cancel"
       >
         {cancelText || t('common.cancel', 'Cancel')}
@@ -154,6 +155,7 @@ export const DialogRender = ({
         loading={isLoading}
         autoFocus
         {...confirmButtonProps}
+        data-testid="dialog-confirm"
         key="confirm"
       >
         {confirmText || t('common.confirm', 'Confirm')}

--- a/packages/danmaku-anywhere/src/common/components/MultiselectChip.tsx
+++ b/packages/danmaku-anywhere/src/common/components/MultiselectChip.tsx
@@ -13,6 +13,7 @@ export const MultiselectChip = ({ active, onToggle }: MultiselectChipProps) => {
   return (
     <Chip
       variant="outlined"
+      data-testid="multiselect-toggle"
       label={
         <Stack direction="row" alignItems="center" gap={0.5}>
           {active ? (

--- a/packages/danmaku-anywhere/src/devApi/namespaces/EpisodeNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/EpisodeNamespace.ts
@@ -1,4 +1,6 @@
 import type {
+  CustomEpisode,
+  CustomEpisodeInsert,
   Episode,
   EpisodeInsert,
 } from '@danmaku-anywhere/danmaku-converter'
@@ -9,6 +11,8 @@ import { type AnyMethodDef, type DevNamespace, defineMethod } from '../registry'
 export interface EpisodeApi {
   add(insert: EpisodeInsert): Promise<Episode>
   get(id: number): Promise<Episode | undefined>
+  addCustom(insert: CustomEpisodeInsert): Promise<CustomEpisode>
+  listCustom(): Promise<CustomEpisode[]>
 }
 
 @injectable('Singleton')
@@ -38,6 +42,20 @@ export class EpisodeNamespace implements DevNamespace {
           const res = await this.service.filter({ ids: [id] })
           return res[0]
         },
+      }),
+      defineMethod({
+        name: 'addCustom',
+        description: 'Insert a custom (local) episode directly',
+        kind: 'write',
+        args: [{ name: 'insert', type: 'CustomEpisodeInsert' }],
+        handler: (insert: CustomEpisodeInsert) =>
+          this.service.addCustom(insert),
+      }),
+      defineMethod({
+        name: 'listCustom',
+        description: 'List all persisted custom (local) episodes',
+        kind: 'read',
+        handler: () => this.service.filterCustom({ all: true }),
       }),
     ]
   }


### PR DESCRIPTION
## Summary
- Adds 4 e2e Playwright specs rounding out mount-tree per-item drilldown actions left uncovered by DA-497: season/episode `delete` (with confirmation dialog), `multi-select` bulk delete via toolbar + bottom-bar, `folder` rendering from custom-episode path prefixes, and `export` / `exportBackup` (single-file XML + JSON downloads captured via `page.waitForEvent(download)`).
- Extends the `MountPage` POM (`confirmDialog`, `enterMultiSelect`, `selectAll`, `bulkDelete`, `expandItem`, `folderItem`, `customEpisodeItem`) and the dev API (`episode.addCustom`, `episode.listCustom`) so the folder spec can seed custom episodes without driving the import UI.
- Adds minimal `data-testid` anchors on the confirm dialog buttons, multiselect chip, toolbar select-all checkbox, and bulk-delete button — no behavior changes to production code.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint` (no new warnings)
- [x] All 9 mount e2e specs pass on Windows (6 new + 3 pre-existing not regressed)
- [x] Full vitest suite (273 tests) passes