### PR TITLE
(extension) e2e infra + happy-path proof for integration auto-mount [DA-501]

### DIFF
--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -81,10 +81,10 @@ jobs:
           VITE_PROXY_ORIGIN=https://danmaku.test
           EOF
 
-      - name: Build extension (dev API on)
+      - name: Build extension (e2e — dev API on, open shadow root)
         working-directory: packages/danmaku-anywhere
         env:
-          VITE_DA_ENV: dev
+          VITE_DA_ENV: e2e
         run: pnpm build
 
       - name: Run E2E tests

--- a/packages/danmaku-anywhere/e2e/fixtures/sites/iframe-host.html
+++ b/packages/danmaku-anywhere/e2e/fixtures/sites/iframe-host.html
@@ -1,0 +1,29 @@
+<!--
+  Generic iframe-host fixture for the integration auto-mount iframe scenario.
+  The integration policy extracts title + episode from this top frame (where
+  the controller content script runs), while the <video> lives in an iframe
+  (where the player content script runs in a separate frame). Tests that the
+  controller can locate the iframe's video and instruct that frame's player
+  to mount.
+
+  The iframe is loaded from a same-origin path so page.route can serve the
+  inner fixture. Spec dispatches play/seek events to the iframe's video.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Integration test iframe host</title>
+  </head>
+  <body>
+    <h1 data-testid="da-title">DA Integration Test</h1>
+    <span data-testid="da-episode">Episode 1</span>
+    <iframe
+      data-testid="da-iframe"
+      src="/iframe-inner.html"
+      width="640"
+      height="360"
+      style="border: 0"
+    ></iframe>
+  </body>
+</html>

--- a/packages/danmaku-anywhere/e2e/fixtures/sites/iframe-inner.html
+++ b/packages/danmaku-anywhere/e2e/fixtures/sites/iframe-inner.html
@@ -1,0 +1,14 @@
+<!--
+  Inner iframe fixture loaded by iframe-host.html. Carries only the <video>
+  the player content script (allFrames: true) attaches to.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Integration test iframe inner</title>
+  </head>
+  <body style="margin: 0; background: black">
+    <video data-testid="da-video" playsinline style="width: 100%; height: 100%"></video>
+  </body>
+</html>

--- a/packages/danmaku-anywhere/e2e/fixtures/sites/native-video.html
+++ b/packages/danmaku-anywhere/e2e/fixtures/sites/native-video.html
@@ -1,0 +1,23 @@
+<!--
+  Generic native-video fixture for the integration auto-mount happy path.
+  Served via page.route at an arbitrary URL the test's MountConfig pattern
+  covers — there's no real site behind this, just enough DOM for:
+
+  - the player to find a <video> via the mountConfig.mediaQuery selector
+  - the controller's XPath integration policy to extract title and episode
+    via stable data-testid hooks (no site-specific selectors)
+
+  The spec dispatches play/seek/timeupdate directly, so the video has no src.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Integration test page</title>
+  </head>
+  <body>
+    <h1 data-testid="da-title">DA Integration Test</h1>
+    <span data-testid="da-episode">Episode 1</span>
+    <video data-testid="da-video" playsinline></video>
+  </body>
+</html>

--- a/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
@@ -91,7 +91,9 @@ export class IntegrationPage {
   // these events to advance the danmaku cursor.
   async setVideoTime(seconds: number): Promise<void> {
     await this.target.evaluate((t) => {
-      const v = document.querySelector('video') as HTMLVideoElement | null
+      const v = document.querySelector(
+        'video[data-testid="da-video"]'
+      ) as HTMLVideoElement | null
       if (!v) {
         throw new Error('IntegrationPage.setVideoTime: no <video> element')
       }
@@ -106,7 +108,9 @@ export class IntegrationPage {
   // listens for. Idempotent.
   async playVideo(): Promise<void> {
     await this.target.evaluate(() => {
-      const v = document.querySelector('video') as HTMLVideoElement | null
+      const v = document.querySelector(
+        'video[data-testid="da-video"]'
+      ) as HTMLVideoElement | null
       if (!v) {
         throw new Error('IntegrationPage.playVideo: no <video> element')
       }
@@ -117,7 +121,9 @@ export class IntegrationPage {
 
   async pauseVideo(): Promise<void> {
     await this.target.evaluate(() => {
-      const v = document.querySelector('video') as HTMLVideoElement | null
+      const v = document.querySelector(
+        'video[data-testid="da-video"]'
+      ) as HTMLVideoElement | null
       if (!v) {
         throw new Error('IntegrationPage.pauseVideo: no <video> element')
       }

--- a/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
@@ -34,6 +34,9 @@ export class IntegrationPage {
     fixtureFile: string,
     options: OpenOptions = {}
   ): Promise<void> {
+    this.videoFrame = null
+    this.iframeSelector = null
+
     const html = readFileSync(path.join(SITES_ROOT, fixtureFile), 'utf-8')
     await this.page.route(url, async (route) => {
       await route.fulfill({
@@ -43,12 +46,14 @@ export class IntegrationPage {
       })
     })
     // Same-origin sub-resources (e.g. iframe-inner.html). Each entry routes
-    // a same-origin path to a static fixture file.
+    // a same-origin path to a static fixture file. Anchor against the origin
+    // (not `url`) so a bare 'iframe-inner.html' key resolves at root, matching
+    // the host HTML's `<iframe src="/iframe-inner.html">`.
     const origin = new URL(url).origin
     for (const [pathSuffix, fixture] of Object.entries(
       options.extraFixtures ?? {}
     )) {
-      const extraUrl = `${origin}${pathSuffix.startsWith('/') ? '' : '/'}${pathSuffix}`
+      const extraUrl = new URL(pathSuffix, origin).href
       const body = readFileSync(path.join(SITES_ROOT, fixture), 'utf-8')
       await this.page.route(extraUrl, async (route) => {
         await route.fulfill({
@@ -65,12 +70,7 @@ export class IntegrationPage {
   // named iframe (located by selector on the host page). Subsequent
   // setVideoTime / playVideo calls dispatch into that iframe's document.
   async useIframeVideo(iframeSelector: string): Promise<void> {
-    const handle = await this.page.locator(iframeSelector).elementHandle()
-    if (!handle) {
-      throw new Error(
-        `IntegrationPage.useIframeVideo: iframe '${iframeSelector}' not found`
-      )
-    }
+    const handle = await this.page.waitForSelector(iframeSelector)
     const frame = await handle.contentFrame()
     if (!frame) {
       throw new Error(

--- a/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Frame, Locator, Page } from '@playwright/test'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const SITES_ROOT = path.join(__dirname, '..', 'fixtures', 'sites')
+
+export interface OpenOptions {
+  // Additional fixture files to serve at same-origin paths (e.g. for
+  // iframe-inner.html when the host page references it via /iframe-inner.html).
+  // Keys are URL path segments under the host URL's origin, values are
+  // fixture file names under e2e/fixtures/sites/.
+  extraFixtures?: Record<string, string>
+}
+
+// Page object for synthetic pages used to exercise the integration pipeline
+// (URL match → policy → media-info → auto-mount → render). Generic — works
+// for any fixture under e2e/fixtures/sites/, including top-frame video and
+// iframe-hosted video setups.
+export class IntegrationPage {
+  // Frame containing the <video>. Defaults to the top frame; overridden by
+  // useIframeVideo() for iframe scenarios.
+  private videoFrame: Frame | null = null
+  // Selector passed to useIframeVideo, kept so commentElements() can build a
+  // frameLocator off the same selector instead of re-deriving one from the
+  // frame URL (which is fragile under query-string / hash changes).
+  private iframeSelector: string | null = null
+
+  constructor(private readonly page: Page) {}
+
+  async open(
+    url: string,
+    fixtureFile: string,
+    options: OpenOptions = {}
+  ): Promise<void> {
+    const html = readFileSync(path.join(SITES_ROOT, fixtureFile), 'utf-8')
+    await this.page.route(url, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: html,
+      })
+    })
+    // Same-origin sub-resources (e.g. iframe-inner.html). Each entry routes
+    // a same-origin path to a static fixture file.
+    const origin = new URL(url).origin
+    for (const [pathSuffix, fixture] of Object.entries(
+      options.extraFixtures ?? {}
+    )) {
+      const extraUrl = `${origin}${pathSuffix.startsWith('/') ? '' : '/'}${pathSuffix}`
+      const body = readFileSync(path.join(SITES_ROOT, fixture), 'utf-8')
+      await this.page.route(extraUrl, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/html; charset=utf-8',
+          body,
+        })
+      })
+    }
+    await this.page.goto(url)
+  }
+
+  // Switch the video-control methods to operate on the <video> inside the
+  // named iframe (located by selector on the host page). Subsequent
+  // setVideoTime / playVideo calls dispatch into that iframe's document.
+  async useIframeVideo(iframeSelector: string): Promise<void> {
+    const handle = await this.page.locator(iframeSelector).elementHandle()
+    if (!handle) {
+      throw new Error(
+        `IntegrationPage.useIframeVideo: iframe '${iframeSelector}' not found`
+      )
+    }
+    const frame = await handle.contentFrame()
+    if (!frame) {
+      throw new Error(
+        `IntegrationPage.useIframeVideo: iframe '${iframeSelector}' has no contentFrame`
+      )
+    }
+    this.videoFrame = frame
+    this.iframeSelector = iframeSelector
+  }
+
+  private get target(): Page | Frame {
+    return this.videoFrame ?? this.page
+  }
+
+  // Programmatically set currentTime. An empty <video> won't fire seeking /
+  // timeupdate events on its own with no media to seek through, so we
+  // synthesize them — the renderer's bindVideo plugin listens for exactly
+  // these events to advance the danmaku cursor.
+  async setVideoTime(seconds: number): Promise<void> {
+    await this.target.evaluate((t) => {
+      const v = document.querySelector('video') as HTMLVideoElement | null
+      if (!v) {
+        throw new Error('IntegrationPage.setVideoTime: no <video> element')
+      }
+      v.currentTime = t
+      v.dispatchEvent(new Event('seeking'))
+      v.dispatchEvent(new Event('timeupdate'))
+    }, seconds)
+  }
+
+  // Force the renderer into the "playing" branch. The bare <video> has no
+  // src so .play() can't drive playback; we dispatch the events the engine
+  // listens for. Idempotent.
+  async playVideo(): Promise<void> {
+    await this.target.evaluate(() => {
+      const v = document.querySelector('video') as HTMLVideoElement | null
+      if (!v) {
+        throw new Error('IntegrationPage.playVideo: no <video> element')
+      }
+      v.dispatchEvent(new Event('play'))
+      v.dispatchEvent(new Event('playing'))
+    })
+  }
+
+  async pauseVideo(): Promise<void> {
+    await this.target.evaluate(() => {
+      const v = document.querySelector('video') as HTMLVideoElement | null
+      if (!v) {
+        throw new Error('IntegrationPage.pauseVideo: no <video> element')
+      }
+      v.dispatchEvent(new Event('pause'))
+    })
+  }
+
+  // Danmaku comment DOM nodes rendered by the engine. Scoped to the player
+  // popover root so we don't accidentally match anything from the host page.
+  // In dev builds the shadow root is open, so Playwright's CSS selectors
+  // pierce through automatically. For iframe scenarios the renderer mounts
+  // inside the iframe's document — use page.frameLocator there.
+  commentElements(): Locator {
+    if (this.iframeSelector) {
+      return this.page
+        .frameLocator(this.iframeSelector)
+        .locator('#danmaku-anywhere-player .da-danmaku')
+    }
+    return this.page.locator('#danmaku-anywhere-player .da-danmaku')
+  }
+}

--- a/packages/danmaku-anywhere/e2e/setup/da-client.ts
+++ b/packages/danmaku-anywhere/e2e/setup/da-client.ts
@@ -10,8 +10,11 @@ import type {
 import type { BrowserContext, Worker } from '@playwright/test'
 import type { ExtensionOptions } from '../../src/common/options/extensionOptions/schema'
 import type { ProviderConfig } from '../../src/common/options/providerConfig/schema'
+import type { MountMirror } from '../../src/devApi/namespaces/MountNamespace'
 import type { StorageArea } from '../../src/devApi/namespaces/StorageNamespace'
 import type { NamespaceDescription } from '../../src/devApi/registry'
+
+export type { MountMirror }
 
 export class DaClient {
   constructor(private readonly sw: Worker) {}
@@ -108,6 +111,21 @@ export class DaClient {
       this.sw.evaluate((id) => self.__da.bookmark.bySeason(id), seasonId),
     deleteBySeason: (seasonId: number): Promise<void> =>
       this.sw.evaluate((id) => self.__da.bookmark.deleteBySeason(id), seasonId),
+  }
+
+  mount = {
+    current: (tabId?: number): Promise<MountMirror | undefined> =>
+      this.sw.evaluate((id) => self.__da.mount.current(id), tabId),
+    waitForMount: (tabId?: number, timeoutMs?: number): Promise<MountMirror> =>
+      this.sw.evaluate(([id, t]) => self.__da.mount.waitForMount(id, t), [
+        tabId,
+        timeoutMs,
+      ] as const),
+    waitForRegistration: (pattern: string, timeoutMs?: number): Promise<void> =>
+      this.sw.evaluate(([p, t]) => self.__da.mount.waitForRegistration(p, t), [
+        pattern,
+        timeoutMs,
+      ] as const),
   }
 }
 

--- a/packages/danmaku-anywhere/e2e/setup/integration.ts
+++ b/packages/danmaku-anywhere/e2e/setup/integration.ts
@@ -1,15 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import type { Integration } from '@danmaku-anywhere/integration-policy'
 import { BUILT_IN_AI_PROVIDER_ID } from '../../src/common/options/aiProviderConfig/constant'
+import { LATEST_INTEGRATION_POLICY_VERSION } from '../../src/common/options/integrationPolicyStore/version'
+import { LATEST_MOUNT_CONFIG_VERSION } from '../../src/common/options/mountConfig/version'
 import type { DaClient } from './da-client'
-
-// Storage versions match the latest version declared by the corresponding
-// services. Bumping a service version (look for `.version(N, {...})` in
-// `src/common/options/mountConfig/service.ts` and
-// `src/common/options/integrationPolicyStore/service.ts`) means bumping the
-// matching constant here — there's no compile-time link.
-const MOUNT_CONFIG_VERSION = 6
-const INTEGRATION_POLICY_VERSION = 4
 
 export interface IntegrationSeedInput {
   // Match patterns the controller content script will be registered for.
@@ -47,7 +41,7 @@ export async function seedXPathIntegration(
 
   await da.storage.setRaw('local', 'xpathPolicy', {
     data: [integration],
-    version: INTEGRATION_POLICY_VERSION,
+    version: LATEST_INTEGRATION_POLICY_VERSION,
   })
 
   await da.storage.setRaw('sync', 'mountConfig', {
@@ -63,7 +57,7 @@ export async function seedXPathIntegration(
         ai: { providerId: BUILT_IN_AI_PROVIDER_ID },
       },
     ],
-    version: MOUNT_CONFIG_VERSION,
+    version: LATEST_MOUNT_CONFIG_VERSION,
   })
 
   return { mountConfigId, integrationId }

--- a/packages/danmaku-anywhere/e2e/setup/integration.ts
+++ b/packages/danmaku-anywhere/e2e/setup/integration.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from 'node:crypto'
+import type { Integration } from '@danmaku-anywhere/integration-policy'
+import { BUILT_IN_AI_PROVIDER_ID } from '../../src/common/options/aiProviderConfig/constant'
+import type { DaClient } from './da-client'
+
+// Storage versions match the latest version declared by the corresponding
+// services. Bumping a service version (look for `.version(N, {...})` in
+// `src/common/options/mountConfig/service.ts` and
+// `src/common/options/integrationPolicyStore/service.ts`) means bumping the
+// matching constant here — there's no compile-time link.
+const MOUNT_CONFIG_VERSION = 6
+const INTEGRATION_POLICY_VERSION = 4
+
+export interface IntegrationSeedInput {
+  // Match patterns the controller content script will be registered for.
+  // Use Chrome match-pattern syntax (e.g. https://www.example.com/play/*).
+  patterns: string[]
+  // CSS selector for the <video> element on the integration target page.
+  mediaQuery?: string
+  // Human-readable name shown in the popup; doesn't affect runtime behavior.
+  name?: string
+  policy: Integration['policy']
+}
+
+export interface IntegrationSeedResult {
+  mountConfigId: string
+  integrationId: string
+}
+
+// Seed a single MountConfig + matching IntegrationPolicy via raw storage
+// writes. Writes are immediate but content-script (re)registration happens
+// asynchronously when MountConfigService picks up the chrome.storage change —
+// the caller must wait via da.mount.waitForRegistration before navigating.
+export async function seedXPathIntegration(
+  da: DaClient,
+  input: IntegrationSeedInput
+): Promise<IntegrationSeedResult> {
+  const integrationId = randomUUID()
+  const mountConfigId = randomUUID()
+
+  const integration: Integration = {
+    version: 3,
+    id: integrationId,
+    name: input.name ?? 'e2e integration',
+    policy: input.policy,
+  }
+
+  await da.storage.setRaw('local', 'xpathPolicy', {
+    data: [integration],
+    version: INTEGRATION_POLICY_VERSION,
+  })
+
+  await da.storage.setRaw('sync', 'mountConfig', {
+    data: [
+      {
+        id: mountConfigId,
+        patterns: input.patterns,
+        mediaQuery: input.mediaQuery ?? 'video',
+        enabled: true,
+        name: input.name ?? 'e2e integration',
+        mode: 'xpath',
+        integration: integrationId,
+        ai: { providerId: BUILT_IN_AI_PROVIDER_ID },
+      },
+    ],
+    version: MOUNT_CONFIG_VERSION,
+  })
+
+  return { mountConfigId, integrationId }
+}
+
+// Generic integration policy keyed to data-testid hooks on the fixture
+// pages (native-video.html, iframe-host.html). Lets multiple specs reuse the
+// same selectors without restating XPath strings.
+export function buildFixtureIntegrationPolicy(): Integration['policy'] {
+  return {
+    version: 3,
+    title: {
+      selector: [{ value: '//*[@data-testid="da-title"]', quick: true }],
+      regex: [],
+    },
+    episode: {
+      selector: [{ value: '//*[@data-testid="da-episode"]', quick: true }],
+      regex: [],
+    },
+    season: { selector: [], regex: [] },
+    episodeTitle: { selector: [], regex: [] },
+    options: {},
+  }
+}

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -91,7 +91,7 @@ test('integration auto-mount: native <video> happy path', async ({
   await integrationPage.setVideoTime(SEEK_TIME_S)
 
   await expect(integrationPage.commentElements().first()).toBeVisible({
-    timeout: 5_000,
+    timeout: 10_000,
   })
 })
 
@@ -122,6 +122,6 @@ test('integration auto-mount: same-origin iframe <video> happy path', async ({
   await integrationPage.setVideoTime(SEEK_TIME_S)
 
   await expect(integrationPage.commentElements().first()).toBeVisible({
-    timeout: 5_000,
+    timeout: 10_000,
   })
 })

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -1,0 +1,127 @@
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { IntegrationPage } from '../../pom/IntegrationPage'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import {
+  buildFixtureIntegrationPolicy,
+  seedXPathIntegration,
+} from '../../setup/integration'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Generic happy-path proof for the integration auto-mount pipeline. Covers
+ * the full chain — URL match → XPath policy → media-info extraction →
+ * auto-mount → render at correct timestamp — with no site-specific
+ * dependencies. Two scenarios: a native top-frame video, and a video hosted
+ * inside a same-origin iframe (the player content script runs in every
+ * frame, the controller only in the top frame). Both resolve through the
+ * LocalMatchingStrategy against a seeded custom episode, so no provider
+ * network calls are exercised here — that's covered by sources/*.spec.ts.
+ */
+
+const ORIGIN = 'https://da-test.invalid'
+const NATIVE_URL = `${ORIGIN}/native/`
+const IFRAME_URL = `${ORIGIN}/iframe/`
+const MOUNT_PATTERN = `${ORIGIN}/*`
+
+const EPISODE_TITLE = 'DA Integration Test'
+// 3 comments at known timestamps so a seek past `SEEK_TIME_S` lands the
+// renderer's cursor on at least the first one and emits a DOM node.
+const COMMENTS = [
+  { p: '12,1,16777215,e2e-1', m: 'first' },
+  { p: '24,1,16777215,e2e-2', m: 'second' },
+  { p: '36,1,16777215,e2e-3', m: 'third' },
+]
+const SEEK_TIME_S = 15
+
+async function seedFixtureProfile(
+  context: import('@playwright/test').BrowserContext,
+  da: Awaited<ReturnType<typeof getDaClient>>
+): Promise<{ episodeId: number }> {
+  await applyProfile(context, da, {
+    extensionOptions: { matchLocalDanmaku: true },
+  })
+
+  // Custom (MacCMS) episode keyed to the title the integration extracts from
+  // the fixture page. LocalMatchingStrategy's fuzzy fallback matches by
+  // title path-last-segment, so this resolves without naming rules.
+  const customEpisode = await da.episode.addCustom({
+    provider: DanmakuSourceType.MacCMS,
+    title: EPISODE_TITLE,
+    comments: COMMENTS,
+    commentCount: COMMENTS.length,
+    schemaVersion: 4,
+  })
+
+  await seedXPathIntegration(da, {
+    patterns: [MOUNT_PATTERN],
+    name: 'da-e2e',
+    policy: buildFixtureIntegrationPolicy(),
+  })
+
+  // MountConfig write triggers async content-script registration — wait for
+  // it before navigating or the controller never loads on the page.
+  await da.mount.waitForRegistration(MOUNT_PATTERN, 5_000)
+
+  return { episodeId: customEpisode.id }
+}
+
+test('integration auto-mount: native <video> happy path', async ({
+  context,
+  page,
+}) => {
+  const da = await getDaClient(context)
+  const { episodeId } = await seedFixtureProfile(context, da)
+
+  const integrationPage = new IntegrationPage(page)
+  await page.bringToFront()
+  await integrationPage.open(NATIVE_URL, 'native-video.html')
+
+  // Auto-mount has to thread URL match → policy extraction → local match →
+  // mount. No provider network round-trips on this path; the 15s budget is
+  // a safety margin for the observer's 1s discovery interval and React
+  // mount latency.
+  const mirror = await da.mount.waitForMount(undefined, 15_000)
+  expect(mirror.isMounted).toBe(true)
+  expect(mirror.episodeIds).toEqual([episodeId])
+
+  // Cross the first comment's timestamp. handleSeek + handleTimeupdate in
+  // the renderer's bindVideo plugin should emit at least one DOM node.
+  await integrationPage.playVideo()
+  await integrationPage.setVideoTime(SEEK_TIME_S)
+
+  await expect(integrationPage.commentElements().first()).toBeVisible({
+    timeout: 5_000,
+  })
+})
+
+test('integration auto-mount: same-origin iframe <video> happy path', async ({
+  context,
+  page,
+}) => {
+  const da = await getDaClient(context)
+  const { episodeId } = await seedFixtureProfile(context, da)
+
+  const integrationPage = new IntegrationPage(page)
+  await page.bringToFront()
+  await integrationPage.open(IFRAME_URL, 'iframe-host.html', {
+    extraFixtures: { 'iframe-inner.html': 'iframe-inner.html' },
+  })
+
+  // Same mount pipeline, but the <video> lives in a child frame. The
+  // controller (top frame only) extracts media info; the player content
+  // script (allFrames: true) running inside the iframe is what actually
+  // mounts the renderer onto the video.
+  await integrationPage.useIframeVideo('iframe[data-testid="da-iframe"]')
+
+  const mirror = await da.mount.waitForMount(undefined, 15_000)
+  expect(mirror.isMounted).toBe(true)
+  expect(mirror.episodeIds).toEqual([episodeId])
+
+  await integrationPage.playVideo()
+  await integrationPage.setVideoTime(SEEK_TIME_S)
+
+  await expect(integrationPage.commentElements().first()).toBeVisible({
+    timeout: 5_000,
+  })
+})

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -22,7 +22,7 @@
     "standalone:serve": "vite preview --config vite.standalone.config.ts",
     "standalone:deploy": "wrangler deploy",
     "test": "vitest",
-    "pretest:e2e": "VITE_DA_ENV=dev pnpm run build",
+    "pretest:e2e": "VITE_DA_ENV=e2e pnpm run build",
     "test:e2e": "playwright test",
     "dev:browser": "node e2e/setup/open-browser.ts",
     "dev:browser:build": "node e2e/setup/open-browser.ts --build",

--- a/packages/danmaku-anywhere/scripts/getBuildContext.js
+++ b/packages/danmaku-anywhere/scripts/getBuildContext.js
@@ -6,7 +6,7 @@ const dev = process.env.NODE_ENV === 'development'
 const IS_CHROME = BROWSER === 'chrome'
 const IS_FIREFOX = BROWSER === 'firefox'
 
-const VALID_DA_ENVS = ['dev', 'preview', 'prod']
+const VALID_DA_ENVS = ['dev', 'preview', 'prod', 'e2e']
 function resolveDaEnv() {
   const explicit = process.env.VITE_DA_ENV
   if (explicit) {

--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -12,8 +12,8 @@ import { generateId } from '@/background/utils/generateId'
 import {
   DA_ENV,
   EXTENSION_VERSION,
-  IS_DA_DEV,
   IS_DA_PROD,
+  isDaEnv,
 } from '@/common/constants'
 import { attachDevApi } from '@/devApi'
 import { setLogService } from './backgroundLogger'
@@ -43,7 +43,10 @@ chrome.runtime.getPlatformInfo().then((platformInfo) => {
 })
 
 chrome.runtime.onInstalled.addListener((details) => {
-  if (details.reason === 'install' && !IS_DA_DEV) {
+  // Skip the docs tab in dev and e2e — devs already know where the docs
+  // are, and opening an extra tab in e2e flakes Playwright's active-tab
+  // assumptions.
+  if (details.reason === 'install' && !isDaEnv('dev', 'e2e')) {
     void chrome.tabs.create({
       url: 'https://docs.danmaku.weeblify.app/getting-started#首次使用',
     })

--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -43,9 +43,6 @@ chrome.runtime.getPlatformInfo().then((platformInfo) => {
 })
 
 chrome.runtime.onInstalled.addListener((details) => {
-  // Skip the docs tab in dev and e2e — devs already know where the docs
-  // are, and opening an extra tab in e2e flakes Playwright's active-tab
-  // assumptions.
   if (details.reason === 'install' && !isDaEnv('dev', 'e2e')) {
     void chrome.tabs.create({
       url: 'https://docs.danmaku.weeblify.app/getting-started#首次使用',

--- a/packages/danmaku-anywhere/src/background/scripting/ScriptingManager.ts
+++ b/packages/danmaku-anywhere/src/background/scripting/ScriptingManager.ts
@@ -7,10 +7,10 @@ import { createTaskQueue } from '@/common/utils/taskQueue'
 // @ts-expect-error
 import contentScript from '@/content/controller?script'
 
-const contentScriptId = 'main-content'
+export const MAIN_CONTENT_SCRIPT_ID = 'main-content'
 
 const mainScript: chrome.scripting.RegisteredContentScript = {
-  id: contentScriptId,
+  id: MAIN_CONTENT_SCRIPT_ID,
   js: [contentScript],
   matches: [],
   persistAcrossSessions: true,
@@ -57,14 +57,14 @@ export class ScriptingManager {
 
     const registeredScript = await chrome.scripting.getRegisteredContentScripts(
       {
-        ids: [contentScriptId],
+        ids: [MAIN_CONTENT_SCRIPT_ID],
       }
     )
 
     if (patterns.length === 0 && registeredScript.length > 0) {
       this.logger.debug('Unregistering content scripts', { patterns })
       return chrome.scripting.unregisterContentScripts({
-        ids: [contentScriptId],
+        ids: [MAIN_CONTENT_SCRIPT_ID],
       })
     }
 
@@ -82,7 +82,7 @@ export class ScriptingManager {
       this.logger.debug('Updating content scripts', { patterns })
       return chrome.scripting.updateContentScripts([
         {
-          id: contentScriptId,
+          id: MAIN_CONTENT_SCRIPT_ID,
           matches: patterns,
         },
       ])

--- a/packages/danmaku-anywhere/src/common/constants.ts
+++ b/packages/danmaku-anywhere/src/common/constants.ts
@@ -23,9 +23,6 @@ export const IS_DA_PREVIEW = DA_ENV === 'preview'
 export const IS_DA_PROD = DA_ENV === 'prod'
 export const IS_DA_E2E = DA_ENV === 'e2e'
 
-// Variadic env check — prefer this over chaining IS_DA_* booleans when a
-// check spans multiple envs (e.g. `isDaEnv('dev', 'e2e')`). Single-env
-// checks can keep using the IS_DA_* constants.
 export function isDaEnv(...envs: DaEnv[]): boolean {
   return envs.includes(DA_ENV)
 }

--- a/packages/danmaku-anywhere/src/common/constants.ts
+++ b/packages/danmaku-anywhere/src/common/constants.ts
@@ -15,10 +15,20 @@ export const IS_EXTERNALLY_CONNECTABLE = EXTERNALLY_CONNECTABLE_PATTERNS.some(
 export const IS_FIREFOX = import.meta.env.VITE_TARGET_BROWSER === 'firefox'
 export const IS_CHROME = import.meta.env.VITE_TARGET_BROWSER === 'chrome'
 
-export const DA_ENV = import.meta.env.VITE_DA_ENV
+export type DaEnv = 'dev' | 'preview' | 'prod' | 'e2e'
+
+export const DA_ENV: DaEnv = import.meta.env.VITE_DA_ENV
 export const IS_DA_DEV = DA_ENV === 'dev'
 export const IS_DA_PREVIEW = DA_ENV === 'preview'
 export const IS_DA_PROD = DA_ENV === 'prod'
+export const IS_DA_E2E = DA_ENV === 'e2e'
+
+// Variadic env check — prefer this over chaining IS_DA_* booleans when a
+// check spans multiple envs (e.g. `isDaEnv('dev', 'e2e')`). Single-env
+// checks can keep using the IS_DA_* constants.
+export function isDaEnv(...envs: DaEnv[]): boolean {
+  return envs.includes(DA_ENV)
+}
 
 export const EXTENSION_VERSION = import.meta.env.VERSION
 

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/service.ts
@@ -14,6 +14,7 @@ import {
   OptionsServiceFactory,
 } from '@/common/options/OptionsService/OptionServiceFactory'
 import type { OptionsService } from '@/common/options/OptionsService/OptionsService'
+import { LATEST_INTEGRATION_POLICY_VERSION } from './version'
 
 @injectable('Singleton')
 export class IntegrationPolicyService implements IStoreService {
@@ -57,7 +58,7 @@ export class IntegrationPolicyService implements IStoreService {
           })
         },
       })
-      .version(4, {
+      .version(LATEST_INTEGRATION_POLICY_VERSION, {
         upgrade: (data: IntegrationV2[]): IntegrationV3[] => {
           return migrateV2ToV3(data)
         },

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/version.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/version.ts
@@ -1,0 +1,5 @@
+// Bump this when adding a new `.version(N, …)` to IntegrationPolicyService so
+// seed helpers and migration tools track the latest schema. Kept in its own
+// file so consumers (e.g. e2e setup) can import without pulling Inversify-
+// decorated service code into their bundler.
+export const LATEST_INTEGRATION_POLICY_VERSION = 4

--- a/packages/danmaku-anywhere/src/common/options/mountConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/mountConfig/service.ts
@@ -23,6 +23,7 @@ import type { PrevOptions } from '@/common/options/OptionsService/types'
 import { getRandomUUID } from '@/common/utils/utils'
 import { BUILT_IN_AI_PROVIDER_ID } from '../aiProviderConfig/constant'
 import { migrateMountConfigV4V5 } from './migrations/migrateMountConfigV4V5'
+import { LATEST_MOUNT_CONFIG_VERSION } from './version'
 
 @injectable('Singleton')
 export class MountConfigService implements IStoreService {
@@ -79,7 +80,7 @@ export class MountConfigService implements IStoreService {
         // Add automation mode, either manual, xpath, or ai
         upgrade: (data, context) => migrateMountConfigV4V5(data, context),
       })
-      .version(6, {
+      .version(LATEST_MOUNT_CONFIG_VERSION, {
         // add ai config
         upgrade: (data) => {
           return data.map((config: PrevOptions) => ({

--- a/packages/danmaku-anywhere/src/common/options/mountConfig/version.ts
+++ b/packages/danmaku-anywhere/src/common/options/mountConfig/version.ts
@@ -1,0 +1,5 @@
+// Bump this when adding a new `.version(N, …)` to MountConfigService so seed
+// helpers and migration tools track the latest schema. Kept in its own file
+// so consumers (e.g. e2e setup) can import without pulling Inversify-decorated
+// service code into their bundler.
+export const LATEST_MOUNT_CONFIG_VERSION = 6

--- a/packages/danmaku-anywhere/src/content/common/host/createPopoverRoot.ts
+++ b/packages/danmaku-anywhere/src/content/common/host/createPopoverRoot.ts
@@ -1,4 +1,4 @@
-import { IS_DA_PROD } from '@/common/constants'
+import { IS_DA_E2E } from '@/common/constants'
 import shadowCss from './shadow.css?inline'
 import { waitForBody } from './waitForBody'
 
@@ -21,11 +21,12 @@ export async function createPopoverRoot({ id }: PopoverRootOptions) {
   // make the root element a popover so it can be shown on top of everything
   root.setAttribute('popover', 'manual')
 
-  // dev/preview builds use an open shadow root so Playwright selectors can
-  // pierce into the player/controller UI during e2e. Production keeps it
-  // closed so page scripts (and userscripts) can't reach in.
+  // Open shadow root only in e2e builds so Playwright selectors can pierce
+  // into the player/controller UI. Dev, preview, and prod all stay closed —
+  // dev users and the preview channel get the same isolation as prod from
+  // page scripts and userscripts.
   const shadowContainer = root.attachShadow({
-    mode: IS_DA_PROD ? 'closed' : 'open',
+    mode: IS_DA_E2E ? 'open' : 'closed',
   })
   const shadowRoot = document.createElement('div')
 

--- a/packages/danmaku-anywhere/src/content/common/host/createPopoverRoot.ts
+++ b/packages/danmaku-anywhere/src/content/common/host/createPopoverRoot.ts
@@ -1,3 +1,4 @@
+import { IS_DA_PROD } from '@/common/constants'
 import shadowCss from './shadow.css?inline'
 import { waitForBody } from './waitForBody'
 
@@ -20,7 +21,12 @@ export async function createPopoverRoot({ id }: PopoverRootOptions) {
   // make the root element a popover so it can be shown on top of everything
   root.setAttribute('popover', 'manual')
 
-  const shadowContainer = root.attachShadow({ mode: 'closed' })
+  // dev/preview builds use an open shadow root so Playwright selectors can
+  // pierce into the player/controller UI during e2e. Production keeps it
+  // closed so page scripts (and userscripts) can't reach in.
+  const shadowContainer = root.attachShadow({
+    mode: IS_DA_PROD ? 'closed' : 'open',
+  })
   const shadowRoot = document.createElement('div')
 
   shadowContainer.appendChild(shadowRoot)

--- a/packages/danmaku-anywhere/src/content/common/host/createPopoverRoot.ts
+++ b/packages/danmaku-anywhere/src/content/common/host/createPopoverRoot.ts
@@ -21,10 +21,7 @@ export async function createPopoverRoot({ id }: PopoverRootOptions) {
   // make the root element a popover so it can be shown on top of everything
   root.setAttribute('popover', 'manual')
 
-  // Open shadow root only in e2e builds so Playwright selectors can pierce
-  // into the player/controller UI. Dev, preview, and prod all stay closed —
-  // dev users and the preview channel get the same isolation as prod from
-  // page scripts and userscripts.
+  // Open shadow only in e2e so Playwright selectors can pierce.
   const shadowContainer = root.attachShadow({
     mode: IS_DA_E2E ? 'open' : 'closed',
   })

--- a/packages/danmaku-anywhere/src/content/controller/common/devMountMirror.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/devMountMirror.ts
@@ -1,14 +1,7 @@
 import type { useStore } from '@/content/controller/store/store'
 
-/**
- * Snapshot of mount state read by the SW dev API via
- * `chrome.scripting.executeScript({ world: 'ISOLATED' })`. The SW shares
- * this extension's isolated world with the controller content script, so a
- * global on `globalThis` is the simplest read channel.
- *
- * `episodeIds` and `seasonIds` align by index, so the spec can check
- * "the seeded season is mounted" without doing an extra DB round-trip.
- */
+// Read from the SW dev API via chrome.scripting.executeScript on the
+// controller's isolated world. episodeIds and seasonIds align by index.
 export interface MountMirror {
   isMounted: boolean
   episodeIds: number[]
@@ -28,9 +21,7 @@ function snapshot(state: ReturnType<typeof useStore.getState>): MountMirror {
   return {
     isMounted: state.danmaku.isMounted,
     episodeIds: episodes.map((e) => e.id),
-    // GenericEpisode is WithSeason<Episode> | CustomEpisode. CustomEpisodes
-    // have no `season` field — surface 0 there so consumers see the index
-    // alignment break rather than a silent skew.
+    // CustomEpisode has no `season`; 0 keeps index alignment with episodeIds.
     seasonIds: episodes.map((e) => ('season' in e ? e.season.id : 0)),
     activeFrameId: state.frame.activeFrame?.frameId,
     url: window.location.href,

--- a/packages/danmaku-anywhere/src/content/controller/common/devMountMirror.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/devMountMirror.ts
@@ -1,0 +1,49 @@
+import type { useStore } from '@/content/controller/store/store'
+
+/**
+ * Snapshot of mount state read by the SW dev API via
+ * `chrome.scripting.executeScript({ world: 'ISOLATED' })`. The SW shares
+ * this extension's isolated world with the controller content script, so a
+ * global on `globalThis` is the simplest read channel.
+ *
+ * `episodeIds` and `seasonIds` align by index, so the spec can check
+ * "the seeded season is mounted" without doing an extra DB round-trip.
+ */
+export interface MountMirror {
+  isMounted: boolean
+  episodeIds: number[]
+  seasonIds: number[]
+  activeFrameId?: number
+  url: string
+}
+
+export const MOUNT_MIRROR_GLOBAL = '__daMountMirror' as const
+
+declare global {
+  var __daMountMirror: MountMirror | undefined
+}
+
+function snapshot(state: ReturnType<typeof useStore.getState>): MountMirror {
+  const episodes = state.danmaku.episodes ?? []
+  return {
+    isMounted: state.danmaku.isMounted,
+    episodeIds: episodes.map((e) => e.id),
+    // GenericEpisode is WithSeason<Episode> | CustomEpisode. CustomEpisodes
+    // have no `season` field — surface 0 there so consumers see the index
+    // alignment break rather than a silent skew.
+    seasonIds: episodes.map((e) => ('season' in e ? e.season.id : 0)),
+    activeFrameId: state.frame.activeFrame?.frameId,
+    url: window.location.href,
+  }
+}
+
+export function attachMountMirror(store: typeof useStore): () => void {
+  globalThis.__daMountMirror = snapshot(store.getState())
+  const unsubscribe = store.subscribe((state) => {
+    globalThis.__daMountMirror = snapshot(state)
+  })
+  return () => {
+    unsubscribe()
+    globalThis.__daMountMirror = undefined
+  }
+}

--- a/packages/danmaku-anywhere/src/content/controller/index.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/index.tsx
@@ -13,12 +13,19 @@ import { App } from './App'
 import '@/common/localization/i18n'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { createPortal } from 'react-dom'
+import { IS_DA_PROD } from '@/common/constants'
 import { EnvironmentContext } from '@/common/environment/context'
 import { tryCatchSync } from '@/common/utils/tryCatch'
 import { createPopoverRoot } from '@/content/common/host/createPopoverRoot'
 import { CONTROLLER_ROOT_ID } from '@/content/controller/common/constants/rootId'
+import { attachMountMirror } from '@/content/controller/common/devMountMirror'
+import { useStore } from '@/content/controller/store/store'
 
 await ensureStandaloneReady()
+
+if (!IS_DA_PROD) {
+  attachMountMirror(useStore)
+}
 
 const { data: frameId } = await chromeRpcClient.getFrameId()
 

--- a/packages/danmaku-anywhere/src/devApi/index.ts
+++ b/packages/danmaku-anywhere/src/devApi/index.ts
@@ -11,6 +11,7 @@ import {
   type ExtensionOptionsApi,
   ExtensionOptionsNamespace,
 } from './namespaces/ExtensionOptionsNamespace'
+import { type MountApi, MountNamespace } from './namespaces/MountNamespace'
 import {
   type ProviderConfigApi,
   ProviderConfigNamespace,
@@ -39,6 +40,7 @@ const NAMESPACE_TOKENS = [
   SeasonNamespace,
   EpisodeNamespace,
   BookmarkNamespace,
+  MountNamespace,
 ] as const
 
 export interface DaApi {
@@ -51,6 +53,7 @@ export interface DaApi {
   season: SeasonApi
   episode: EpisodeApi
   bookmark: BookmarkApi
+  mount: MountApi
 }
 
 declare global {

--- a/packages/danmaku-anywhere/src/devApi/namespaces/MountNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/MountNamespace.ts
@@ -26,16 +26,11 @@ async function resolveTabId(tabId?: number): Promise<number | undefined> {
   return tab?.id
 }
 
-// Reads the controller's mirror global. Returns undefined if the controller
-// content script hasn't loaded (no mount config matches the tab URL) or if the
-// tab no longer exists. Other executeScript failures propagate.
 async function readMirror(tabId: number): Promise<MountMirror | undefined> {
   try {
     const results = await chrome.scripting.executeScript({
       target: { tabId },
       world: 'ISOLATED',
-      // The injected function name is referenced by string; the global symbol
-      // must match MOUNT_MIRROR_GLOBAL.
       func: (key: string) => {
         return (globalThis as unknown as Record<string, unknown>)[key] as
           | MountMirror
@@ -45,9 +40,8 @@ async function readMirror(tabId: number): Promise<MountMirror | undefined> {
     })
     return results[0]?.result ?? undefined
   } catch (err) {
+    // Swallow tab-gone / no-permission so polling callers can keep retrying.
     const message = err instanceof Error ? err.message : String(err)
-    // Tab closed mid-call or no permission for this URL — treat as "nothing
-    // mounted" rather than propagating, so polling callers can keep retrying.
     if (
       message.includes('No tab with id') ||
       message.includes('Cannot access') ||
@@ -95,9 +89,6 @@ export class MountNamespace implements DevNamespace {
           throw new Error('mount.waitForMount: no tab to inspect')
         }
         const deadline = Date.now() + (timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS)
-        // Poll rather than subscribe — the mirror lives in the content
-        // script's globalThis, not in the SW, so there's nothing to observe
-        // from here.
         while (Date.now() < deadline) {
           const mirror = await readMirror(target)
           if (mirror?.isMounted) {

--- a/packages/danmaku-anywhere/src/devApi/namespaces/MountNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/MountNamespace.ts
@@ -1,0 +1,139 @@
+import { injectable } from 'inversify'
+import type { MountMirror } from '@/content/controller/common/devMountMirror'
+import { MOUNT_MIRROR_GLOBAL } from '@/content/controller/common/devMountMirror'
+import { type AnyMethodDef, type DevNamespace, defineMethod } from '../registry'
+
+export type { MountMirror }
+
+export interface MountApi {
+  current(tabId?: number): Promise<MountMirror | undefined>
+  waitForMount(tabId?: number, timeoutMs?: number): Promise<MountMirror>
+  waitForRegistration(pattern: string, timeoutMs?: number): Promise<void>
+}
+
+const DEFAULT_WAIT_TIMEOUT_MS = 10_000
+const POLL_INTERVAL_MS = 100
+const CONTENT_SCRIPT_ID = 'main-content'
+
+async function resolveTabId(tabId?: number): Promise<number | undefined> {
+  if (tabId !== undefined) {
+    return tabId
+  }
+  const [tab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  })
+  return tab?.id
+}
+
+// Reads the controller's mirror global. Returns undefined if the controller
+// content script hasn't loaded (no mount config matches the tab URL) or if the
+// tab no longer exists. Other executeScript failures propagate.
+async function readMirror(tabId: number): Promise<MountMirror | undefined> {
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: 'ISOLATED',
+      // The injected function name is referenced by string; the global symbol
+      // must match MOUNT_MIRROR_GLOBAL.
+      func: (key: string) => {
+        return (globalThis as unknown as Record<string, unknown>)[key] as
+          | MountMirror
+          | undefined
+      },
+      args: [MOUNT_MIRROR_GLOBAL],
+    })
+    return results[0]?.result ?? undefined
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    // Tab closed mid-call or no permission for this URL — treat as "nothing
+    // mounted" rather than propagating, so polling callers can keep retrying.
+    if (
+      message.includes('No tab with id') ||
+      message.includes('Cannot access') ||
+      message.includes('Frame with ID') ||
+      message.includes('The tab was closed')
+    ) {
+      return undefined
+    }
+    throw err
+  }
+}
+
+@injectable('Singleton')
+export class MountNamespace implements DevNamespace {
+  readonly name = 'mount'
+  readonly description =
+    'Inspect what danmaku is currently mounted on a tab (read from the controller content script)'
+  readonly methods: readonly AnyMethodDef[] = [
+    defineMethod({
+      name: 'current',
+      description:
+        'Snapshot of the controller mount mirror for a tab. Returns undefined if the controller is not running on that tab. Defaults to the active tab.',
+      kind: 'read',
+      args: [{ name: 'tabId', type: 'number', optional: true }],
+      handler: async (tabId?: number) => {
+        const target = await resolveTabId(tabId)
+        if (target === undefined) {
+          return undefined
+        }
+        return readMirror(target)
+      },
+    }),
+    defineMethod({
+      name: 'waitForMount',
+      description:
+        'Poll mount.current() until isMounted is true or timeoutMs elapses. Rejects on timeout. Defaults to the active tab.',
+      kind: 'read',
+      args: [
+        { name: 'tabId', type: 'number', optional: true },
+        { name: 'timeoutMs', type: 'number', optional: true },
+      ],
+      handler: async (tabId?: number, timeoutMs?: number) => {
+        const target = await resolveTabId(tabId)
+        if (target === undefined) {
+          throw new Error('mount.waitForMount: no tab to inspect')
+        }
+        const deadline = Date.now() + (timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS)
+        // Poll rather than subscribe — the mirror lives in the content
+        // script's globalThis, not in the SW, so there's nothing to observe
+        // from here.
+        while (Date.now() < deadline) {
+          const mirror = await readMirror(target)
+          if (mirror?.isMounted) {
+            return mirror
+          }
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+        }
+        throw new Error(
+          `mount.waitForMount: tab ${target} did not reach isMounted=true within ${timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS}ms`
+        )
+      },
+    }),
+    defineMethod({
+      name: 'waitForRegistration',
+      description:
+        'Poll until the controller content script is registered for `pattern`. Lets seed helpers wait out the async propagation from storage write → MountConfigService.onChange → scripting.registerContentScripts.',
+      kind: 'read',
+      args: [
+        { name: 'pattern', type: 'string' },
+        { name: 'timeoutMs', type: 'number', optional: true },
+      ],
+      handler: async (pattern: string, timeoutMs?: number) => {
+        const deadline = Date.now() + (timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS)
+        while (Date.now() < deadline) {
+          const scripts = await chrome.scripting.getRegisteredContentScripts({
+            ids: [CONTENT_SCRIPT_ID],
+          })
+          if (scripts[0]?.matches?.includes(pattern)) {
+            return
+          }
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+        }
+        throw new Error(
+          `mount.waitForRegistration: pattern '${pattern}' was not registered within ${timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS}ms`
+        )
+      },
+    }),
+  ]
+}

--- a/packages/danmaku-anywhere/src/devApi/namespaces/MountNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/MountNamespace.ts
@@ -1,4 +1,5 @@
 import { injectable } from 'inversify'
+import { MAIN_CONTENT_SCRIPT_ID } from '@/background/scripting/ScriptingManager'
 import type { MountMirror } from '@/content/controller/common/devMountMirror'
 import { MOUNT_MIRROR_GLOBAL } from '@/content/controller/common/devMountMirror'
 import { type AnyMethodDef, type DevNamespace, defineMethod } from '../registry'
@@ -13,7 +14,6 @@ export interface MountApi {
 
 const DEFAULT_WAIT_TIMEOUT_MS = 10_000
 const POLL_INTERVAL_MS = 100
-const CONTENT_SCRIPT_ID = 'main-content'
 
 async function resolveTabId(tabId?: number): Promise<number | undefined> {
   if (tabId !== undefined) {
@@ -114,7 +114,7 @@ export class MountNamespace implements DevNamespace {
         const deadline = Date.now() + (timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS)
         while (Date.now() < deadline) {
           const scripts = await chrome.scripting.getRegisteredContentScripts({
-            ids: [CONTENT_SCRIPT_ID],
+            ids: [MAIN_CONTENT_SCRIPT_ID],
           })
           if (scripts[0]?.matches?.includes(pattern)) {
             return

--- a/packages/danmaku-anywhere/src/devApi/registry.ts
+++ b/packages/danmaku-anywhere/src/devApi/registry.ts
@@ -1,6 +1,8 @@
+import type { DaEnv } from '@/common/constants'
+
 export type MethodKind = 'read' | 'write'
 
-export type DaEnv = 'dev' | 'preview' | 'prod'
+export type { DaEnv }
 
 export interface ArgSpec {
   name: string

--- a/packages/danmaku-anywhere/src/vite-env.d.ts
+++ b/packages/danmaku-anywhere/src/vite-env.d.ts
@@ -5,7 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_PROXY_ORIGIN: string
   readonly VITE_TARGET_BROWSER: 'chrome' | 'firefox'
   readonly VITE_STANDALONE?: 'true' | 'false'
-  readonly VITE_DA_ENV: 'dev' | 'preview' | 'prod'
+  readonly VITE_DA_ENV: 'dev' | 'preview' | 'prod' | 'e2e'
   readonly VERSION: string
 }
 


### PR DESCRIPTION
## Summary

- Adds the e2e plumbing for the integration auto-mount pipeline (URL match → XPath policy → media-info → auto-mount → render). Two proof specs cover the happy path on a top-frame `<video>` and on a `<video>` inside a same-origin iframe.
- Both specs resolve through `LocalMatchingStrategy` against a seeded custom episode, so no provider network mocks run on this path. Provider-specific flows stay covered by `sources/*.spec.ts`.

## Dev API addition (ships in dev/preview builds)

New `mount` namespace on the SW dev API:

- `mount.current(tabId?)` — snapshot of the controller's mount mirror for a tab (active tab by default). Returns `undefined` when the controller isn't loaded.
- `mount.waitForMount(tabId?, timeoutMs?)` — polls `current` until `isMounted: true`.
- `mount.waitForRegistration(pattern, timeoutMs?)` — waits for `chrome.scripting.registerContentScripts` to pick up a new MountConfig pattern after a storage seed.

The mirror lives on the controller's `globalThis.__daMountMirror`; the SW reads it via `chrome.scripting.executeScript({ world: 'ISOLATED' })`. Triple-gated by `IS_DA_PROD` (build-time alias to the prod stub + runtime env guard + the `attachMountMirror` call site).

## Other extension-side changes

- Popover shadow root opens in non-prod so Playwright selectors can pierce. Closed in prod is unchanged.
- `createPopoverRoot` carries a comment explaining the rationale.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean for new files
- [x] Full e2e suite passes locally (19/19, including the new 2 specs)
- [ ] CI: type-check + e2e