### PR TITLE
(extension) e2e fail-on-console-error by default [DA-502]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -26,7 +26,10 @@ export const test = base.extend<{
   // Per-test opt-out: override with `test.use({ expectedConsoleErrors: [...] })`
   // (or pass an array via `test('name', { expectedConsoleErrors: [...] })`)
   // to allow specific errors. Entries match by `includes` (string) or `.test`
-  // (RegExp) against the formatted watcher entry.
+  // (RegExp) against the formatted watcher entry — the line includes a
+  // `[sw]`/`[page <url>]` prefix and a trailing `(<url>:<line>:<col>)`
+  // location, not just the raw console message text. Patterns can target
+  // any of those parts.
   expectedConsoleErrors: [[], { option: true }],
 
   // biome-ignore lint: Playwright fixture pattern requires destructuring

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -14,11 +14,21 @@ const pathToExtension = path.join(__dirname, '..', '..', 'build')
 // Playwright doesn't buffer console events for existing workers.
 const watchersByContext = new WeakMap<BrowserContext, ConsoleWatcher>()
 
+export type ExpectedConsoleErrorPattern = string | RegExp
+
 export const test = base.extend<{
   context: BrowserContext
   extensionId: string
   consoleErrors: () => string[]
+  expectedConsoleErrors: ExpectedConsoleErrorPattern[]
+  _assertNoUnexpectedConsoleErrors: void
 }>({
+  // Per-test opt-out: override with `test.use({ expectedConsoleErrors: [...] })`
+  // (or pass an array via `test('name', { expectedConsoleErrors: [...] })`)
+  // to allow specific errors. Entries match by `includes` (string) or `.test`
+  // (RegExp) against the formatted watcher entry.
+  expectedConsoleErrors: [[], { option: true }],
+
   // biome-ignore lint: Playwright fixture pattern requires destructuring
   context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
@@ -49,6 +59,38 @@ export const test = base.extend<{
     }
     await use(watcher.getErrors)
   },
+
+  // Auto fixture: after every test, fail if any console errors slipped
+  // through that weren't allow-listed via `expectedConsoleErrors`. Depends
+  // on `context` so teardown runs before the context closes — keeping the
+  // watcher reachable. Skipped when the test already failed so the real
+  // failure isn't drowned out.
+  _assertNoUnexpectedConsoleErrors: [
+    async ({ context, expectedConsoleErrors }, use, testInfo) => {
+      await use()
+      if (testInfo.status === 'failed' || testInfo.status === 'timedOut') {
+        return
+      }
+      const watcher = watchersByContext.get(context)
+      if (!watcher) {
+        return
+      }
+      const unexpected = watcher.getErrors().filter((err) => {
+        return !expectedConsoleErrors.some((pattern) => {
+          return typeof pattern === 'string'
+            ? err.includes(pattern)
+            : pattern.test(err)
+        })
+      })
+      if (unexpected.length > 0) {
+        const lines = unexpected.map((e) => `  - ${e}`).join('\n')
+        throw new Error(
+          `Unexpected console errors during test (${unexpected.length}):\n${lines}\n\nIf these are expected, allow them via test.use({ expectedConsoleErrors: [...] }).`
+        )
+      }
+    },
+    { auto: true },
+  ],
 })
 
 export const expect = test.expect

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -24,7 +24,6 @@ const BUILTIN_PROVIDER_IDS = [
 test('fresh install: default options seeded, no console errors', async ({
   context,
   extensionId,
-  consoleErrors,
 }) => {
   // Chrome extension IDs are a 32-char base-16 alphabet of a-p.
   expect(extensionId).toMatch(/^[a-p]{32}$/)
@@ -42,6 +41,4 @@ test('fresh install: default options seeded, no console errors', async ({
   for (const p of providers) {
     expect(p.isBuiltIn).toBe(true)
   }
-
-  expect(consoleErrors()).toEqual([])
 })


### PR DESCRIPTION
## Summary
- Promote the e2e console-error watcher from opt-in to default-on in `packages/danmaku-anywhere/e2e/setup/fixtures.ts`. An auto fixture now fails any spec whose `BrowserContext` emitted unmatched console errors during the test body.
- Per-test opt-out: `test.use({ expectedConsoleErrors: [string | RegExp, ...] })`. Strings match by `includes`, RegExps by `.test`, against the formatted watcher line (includes `[sw]` / `[page <url>]` prefix and trailing `(<url>:<line>:<col>)` location).
- Existing `consoleErrors()` accessor remains for tests that want to inspect mid-flight.
- Dropped the now-redundant `expect(consoleErrors()).toEqual([])` from `e2e/specs/lifecycle/install.spec.ts`.
- Full e2e suite (18 tests / 8 workers) green with the new default — no latent regressions surfaced.