### PR TITLE
(extension) e2e strict-mode network: fail on unmocked requests [DA-503]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -2,26 +2,48 @@ import { type BrowserContext, test as base, chromium } from '@playwright/test'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { attachConsoleWatcher, type ConsoleWatcher } from './console-watcher'
+import {
+  type AllowedNetworkPattern,
+  attachNetworkWatcher,
+  type NetworkWatcher,
+} from './network-watcher'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // e2e/setup/fixtures.ts → ../../build
 const pathToExtension = path.join(__dirname, '..', '..', 'build')
 
+interface ContextWatchers {
+  console: ConsoleWatcher
+  network: NetworkWatcher
+}
+
 // Watchers are attached eagerly inside the context fixture (before the SW
-// has a chance to boot) and looked up later by the consoleErrors fixture.
+// has a chance to boot) and looked up later by per-test fixtures.
 // Playwright resolves fixtures in dependency order, so a fixture that
 // depends only on `context` runs after the SW may have already emitted —
 // Playwright doesn't buffer console events for existing workers.
-const watchersByContext = new WeakMap<BrowserContext, ConsoleWatcher>()
+const watchersByContext = new WeakMap<BrowserContext, ContextWatchers>()
+
+// The network watcher needs to read the per-test `allowedNetworkOrigins`
+// at request time (it's installed once, during context setup, but each
+// test can supply its own list). The fixture below populates this map
+// before the test body runs.
+const allowedByContext = new WeakMap<
+  BrowserContext,
+  readonly AllowedNetworkPattern[]
+>()
 
 export type ExpectedConsoleErrorPattern = string | RegExp
+export type { AllowedNetworkPattern } from './network-watcher'
 
 export const test = base.extend<{
   context: BrowserContext
   extensionId: string
   consoleErrors: () => string[]
   expectedConsoleErrors: ExpectedConsoleErrorPattern[]
+  allowedNetworkOrigins: AllowedNetworkPattern[]
   _assertNoUnexpectedConsoleErrors: void
+  _assertNoUnmockedNetwork: void
 }>({
   // Per-test opt-out: override with `test.use({ expectedConsoleErrors: [...] })`
   // (or pass an array via `test('name', { expectedConsoleErrors: [...] })`)
@@ -32,6 +54,14 @@ export const test = base.extend<{
   // any of those parts.
   expectedConsoleErrors: [[], { option: true }],
 
+  // Per-test opt-in: override with `test.use({ allowedNetworkOrigins: [...] })`
+  // to whitelist extra origins beyond the project defaults (extension://,
+  // data:/blob:/about:, *.invalid hosts). Entries match by `includes`
+  // (string) or `.test` (RegExp) against the full request URL. Use this
+  // sparingly — the goal is to catch leaked traffic, so prefer adding a
+  // per-spec mock over widening the allowlist.
+  allowedNetworkOrigins: [[], { option: true }],
+
   // biome-ignore lint: Playwright fixture pattern requires destructuring
   context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
@@ -41,7 +71,15 @@ export const test = base.extend<{
         `--load-extension=${pathToExtension}`,
       ],
     })
-    watchersByContext.set(context, attachConsoleWatcher(context))
+    const consoleWatcher = attachConsoleWatcher(context)
+    const networkWatcher = await attachNetworkWatcher(
+      context,
+      () => allowedByContext.get(context) ?? []
+    )
+    watchersByContext.set(context, {
+      console: consoleWatcher,
+      network: networkWatcher,
+    })
     await use(context)
     await context.close()
   },
@@ -54,13 +92,13 @@ export const test = base.extend<{
     await use(extensionId)
   },
   consoleErrors: async ({ context }, use) => {
-    const watcher = watchersByContext.get(context)
-    if (!watcher) {
+    const watchers = watchersByContext.get(context)
+    if (!watchers) {
       throw new Error(
         'consoleErrors fixture used without a watcher attached to the context'
       )
     }
-    await use(watcher.getErrors)
+    await use(watchers.console.getErrors)
   },
 
   // Auto fixture: after every test, fail if any console errors slipped
@@ -74,11 +112,11 @@ export const test = base.extend<{
       if (testInfo.status === 'failed' || testInfo.status === 'timedOut') {
         return
       }
-      const watcher = watchersByContext.get(context)
-      if (!watcher) {
+      const watchers = watchersByContext.get(context)
+      if (!watchers) {
         return
       }
-      const unexpected = watcher.getErrors().filter((err) => {
+      const unexpected = watchers.console.getErrors().filter((err) => {
         return !expectedConsoleErrors.some((pattern) => {
           return typeof pattern === 'string'
             ? err.includes(pattern)
@@ -89,6 +127,33 @@ export const test = base.extend<{
         const lines = unexpected.map((e) => `  - ${e}`).join('\n')
         throw new Error(
           `Unexpected console errors during test (${unexpected.length}):\n${lines}\n\nIf these are expected, allow them via test.use({ expectedConsoleErrors: [...] }).`
+        )
+      }
+    },
+    { auto: true },
+  ],
+
+  // Auto fixture: populate the per-context allowlist before the test body
+  // runs (the network watcher reads it on each unmocked request), then
+  // after the test fail if any unmocked-and-not-allowlisted request was
+  // intercepted. Mirrors the `_assertNoUnexpectedConsoleErrors` shape —
+  // skipped on prior failure so the real cause isn't drowned out.
+  _assertNoUnmockedNetwork: [
+    async ({ context, allowedNetworkOrigins }, use, testInfo) => {
+      allowedByContext.set(context, allowedNetworkOrigins)
+      await use()
+      if (testInfo.status === 'failed' || testInfo.status === 'timedOut') {
+        return
+      }
+      const watchers = watchersByContext.get(context)
+      if (!watchers) {
+        return
+      }
+      const entries = watchers.network.getEntries()
+      if (entries.length > 0) {
+        const lines = entries.map((e) => `  - ${e}`).join('\n')
+        throw new Error(
+          `Unmocked network requests during test (${entries.length}):\n${lines}\n\nIf these are expected, allow them via test.use({ allowedNetworkOrigins: [...] }) — but prefer adding a per-spec mock so the request's response is asserted, not just its origin.`
         )
       }
     },

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -24,12 +24,6 @@ interface ContextWatchers {
 // Playwright doesn't buffer console events for existing workers.
 const watchersByContext = new WeakMap<BrowserContext, ContextWatchers>()
 
-// Per-test allowlist, read lazily by the network watcher at request time.
-const allowedByContext = new WeakMap<
-  BrowserContext,
-  readonly AllowedNetworkPattern[]
->()
-
 export type ExpectedConsoleErrorPattern = string | RegExp
 export type { AllowedNetworkPattern } from './network-watcher'
 
@@ -56,8 +50,7 @@ export const test = base.extend<{
   // *.invalid) are always allowed. Prefer a per-spec mock over widening this.
   allowedNetworkOrigins: [[], { option: true }],
 
-  // biome-ignore lint: Playwright fixture pattern requires destructuring
-  context: async ({}, use) => {
+  context: async ({ allowedNetworkOrigins }, use) => {
     const context = await chromium.launchPersistentContext('', {
       channel: 'chromium',
       args: [
@@ -68,7 +61,7 @@ export const test = base.extend<{
     const consoleWatcher = attachConsoleWatcher(context)
     const networkWatcher = await attachNetworkWatcher(
       context,
-      () => allowedByContext.get(context) ?? []
+      () => allowedNetworkOrigins
     )
     watchersByContext.set(context, {
       console: consoleWatcher,
@@ -128,8 +121,7 @@ export const test = base.extend<{
   ],
 
   _assertNoUnmockedNetwork: [
-    async ({ context, allowedNetworkOrigins }, use, testInfo) => {
-      allowedByContext.set(context, allowedNetworkOrigins)
+    async ({ context }, use, testInfo) => {
       await use()
       if (testInfo.status === 'failed' || testInfo.status === 'timedOut') {
         return

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -24,10 +24,7 @@ interface ContextWatchers {
 // Playwright doesn't buffer console events for existing workers.
 const watchersByContext = new WeakMap<BrowserContext, ContextWatchers>()
 
-// The network watcher needs to read the per-test `allowedNetworkOrigins`
-// at request time (it's installed once, during context setup, but each
-// test can supply its own list). The fixture below populates this map
-// before the test body runs.
+// Per-test allowlist, read lazily by the network watcher at request time.
 const allowedByContext = new WeakMap<
   BrowserContext,
   readonly AllowedNetworkPattern[]
@@ -54,12 +51,9 @@ export const test = base.extend<{
   // any of those parts.
   expectedConsoleErrors: [[], { option: true }],
 
-  // Per-test opt-in: override with `test.use({ allowedNetworkOrigins: [...] })`
-  // to whitelist extra origins beyond the project defaults (extension://,
-  // data:/blob:/about:, *.invalid hosts). Entries match by `includes`
-  // (string) or `.test` (RegExp) against the full request URL. Use this
-  // sparingly — the goal is to catch leaked traffic, so prefer adding a
-  // per-spec mock over widening the allowlist.
+  // Per-test opt-in for extra origins; matched by `includes` (string) or
+  // `.test` (RegExp). Project defaults (extension://, data:, blob:, about:,
+  // *.invalid) are always allowed. Prefer a per-spec mock over widening this.
   allowedNetworkOrigins: [[], { option: true }],
 
   // biome-ignore lint: Playwright fixture pattern requires destructuring
@@ -133,11 +127,6 @@ export const test = base.extend<{
     { auto: true },
   ],
 
-  // Auto fixture: populate the per-context allowlist before the test body
-  // runs (the network watcher reads it on each unmocked request), then
-  // after the test fail if any unmocked-and-not-allowlisted request was
-  // intercepted. Mirrors the `_assertNoUnexpectedConsoleErrors` shape —
-  // skipped on prior failure so the real cause isn't drowned out.
   _assertNoUnmockedNetwork: [
     async ({ context, allowedNetworkOrigins }, use, testInfo) => {
       allowedByContext.set(context, allowedNetworkOrigins)
@@ -153,7 +142,7 @@ export const test = base.extend<{
       if (entries.length > 0) {
         const lines = entries.map((e) => `  - ${e}`).join('\n')
         throw new Error(
-          `Unmocked network requests during test (${entries.length}):\n${lines}\n\nIf these are expected, allow them via test.use({ allowedNetworkOrigins: [...] }) — but prefer adding a per-spec mock so the request's response is asserted, not just its origin.`
+          `Unmocked network requests (${entries.length}):\n${lines}\n\nAdd a per-spec mock, or allow via test.use({ allowedNetworkOrigins: [...] }).`
         )
       }
     },

--- a/packages/danmaku-anywhere/e2e/setup/network-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/network-watcher.ts
@@ -1,0 +1,78 @@
+import type { BrowserContext, Route } from '@playwright/test'
+
+export type AllowedNetworkPattern = string | RegExp
+
+export interface NetworkWatcher {
+  getEntries: () => string[]
+}
+
+// Schemes / hosts the e2e harness always allows without spec opt-in:
+// - chrome-extension:// — extension's own pages and bundled assets
+// - data:/blob:/about: — inert schemes that don't reach a remote
+// - *.invalid hosts — project convention for fixture data (image URLs,
+//   integration-page origins). RFC 6761 reserves `.invalid`; DNS fails by
+//   design, so allowing them through doesn't leak.
+const PROJECT_ALLOWED_SCHEMES = [
+  'chrome-extension:',
+  'data:',
+  'blob:',
+  'about:',
+] as const
+
+function isProjectAllowed(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    if (
+      PROJECT_ALLOWED_SCHEMES.includes(
+        parsed.protocol as (typeof PROJECT_ALLOWED_SCHEMES)[number]
+      )
+    ) {
+      return true
+    }
+    const host = parsed.hostname
+    return host === 'invalid' || host.endsWith('.invalid')
+  } catch {
+    return false
+  }
+}
+
+function matchesAllowed(
+  url: string,
+  patterns: readonly AllowedNetworkPattern[]
+): boolean {
+  return patterns.some((pattern) => {
+    return typeof pattern === 'string'
+      ? url.includes(pattern)
+      : pattern.test(url)
+  })
+}
+
+// Install a deny-all fallback that records and aborts any request not
+// covered by an explicit per-spec mock or the project/spec allowlist. The
+// fallback is registered early (during context fixture setup) so per-spec
+// `context.route()` calls registered later in applyProfile() are newer in
+// Playwright's handler chain and intercept matching URLs first; this
+// handler only fires when no specific route claimed the request.
+export async function attachNetworkWatcher(
+  context: BrowserContext,
+  getAllowed: () => readonly AllowedNetworkPattern[]
+): Promise<NetworkWatcher> {
+  const entries: string[] = []
+
+  await context.route('**/*', async (route: Route) => {
+    const req = route.request()
+    const url = req.url()
+    if (isProjectAllowed(url) || matchesAllowed(url, getAllowed())) {
+      // Pass through to per-spec mocks (older registrations in the chain)
+      // or, failing that, the live network. For project-allowed URLs the
+      // "live network" is either inert (chrome-extension://, data:, blob:)
+      // or a guaranteed DNS failure (*.invalid) — neither leaks meaningfully.
+      await route.fallback()
+      return
+    }
+    entries.push(`${req.method()} ${url}`)
+    await route.abort('failed')
+  })
+
+  return { getEntries: () => [...entries] }
+}

--- a/packages/danmaku-anywhere/e2e/setup/network-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/network-watcher.ts
@@ -6,12 +6,6 @@ export interface NetworkWatcher {
   getEntries: () => string[]
 }
 
-// Schemes / hosts the e2e harness always allows without spec opt-in:
-// - chrome-extension:// — extension's own pages and bundled assets
-// - data:/blob:/about: — inert schemes that don't reach a remote
-// - *.invalid hosts — project convention for fixture data (image URLs,
-//   integration-page origins). RFC 6761 reserves `.invalid`; DNS fails by
-//   design, so allowing them through doesn't leak.
 const PROJECT_ALLOWED_SCHEMES = [
   'chrome-extension:',
   'data:',
@@ -29,6 +23,8 @@ function isProjectAllowed(url: string): boolean {
     ) {
       return true
     }
+    // `.invalid` is a project-wide fixture convention (image URLs, the
+    // da-test.invalid integration origin); RFC 6761 reserves it.
     const host = parsed.hostname
     return host === 'invalid' || host.endsWith('.invalid')
   } catch {
@@ -47,12 +43,9 @@ function matchesAllowed(
   })
 }
 
-// Install a deny-all fallback that records and aborts any request not
-// covered by an explicit per-spec mock or the project/spec allowlist. The
-// fallback is registered early (during context fixture setup) so per-spec
-// `context.route()` calls registered later in applyProfile() are newer in
-// Playwright's handler chain and intercept matching URLs first; this
-// handler only fires when no specific route claimed the request.
+// Registered before per-spec routes so it lands older in Playwright's
+// handler chain (newest fires first) — only fires when nothing specific
+// matched.
 export async function attachNetworkWatcher(
   context: BrowserContext,
   getAllowed: () => readonly AllowedNetworkPattern[]
@@ -63,10 +56,6 @@ export async function attachNetworkWatcher(
     const req = route.request()
     const url = req.url()
     if (isProjectAllowed(url) || matchesAllowed(url, getAllowed())) {
-      // Pass through to per-spec mocks (older registrations in the chain)
-      // or, failing that, the live network. For project-allowed URLs the
-      // "live network" is either inert (chrome-extension://, data:, blob:)
-      // or a guaranteed DNS failure (*.invalid) — neither leaks meaningfully.
       await route.fallback()
       return
     }

--- a/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
@@ -1,4 +1,4 @@
-import { EXTENSION_VERSION } from '@/common/constants'
+import { EXTENSION_VERSION, IS_DA_E2E } from '@/common/constants'
 import type { EnvironmentType } from '@/common/environment/context'
 import {
   CombinedTrackingService,
@@ -19,7 +19,9 @@ export const createTrackingService = (
   environment: string,
   type: EnvironmentType
 ) => {
-  if (trackingService !== null || IS_STANDALONE_RUNTIME) {
+  // Skip in e2e builds so strict-mode network checks don't catch clarity
+  // upload calls — telemetry shouldn't fire under test anyway.
+  if (trackingService !== null || IS_STANDALONE_RUNTIME || IS_DA_E2E) {
     return trackingService
   }
 

--- a/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
@@ -20,7 +20,7 @@ export const createTrackingService = (
   type: EnvironmentType
 ) => {
   if (trackingService !== null || IS_STANDALONE_RUNTIME || IS_DA_E2E) {
-    return trackingService
+    return trackingService ?? new NoopTrackingService()
   }
 
   const isPopup = type === 'popup'

--- a/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
@@ -19,8 +19,6 @@ export const createTrackingService = (
   environment: string,
   type: EnvironmentType
 ) => {
-  // Skip in e2e builds so strict-mode network checks don't catch clarity
-  // upload calls — telemetry shouldn't fire under test anyway.
   if (trackingService !== null || IS_STANDALONE_RUNTIME || IS_DA_E2E) {
     return trackingService
   }


### PR DESCRIPTION
## Summary
- Install a deny-all `context.route('**/*', ...)` fallback that records + aborts any request not matched by a per-spec mock or the project/spec allowlist (`chrome-extension://`, `data:`/`blob:`/`about:`, `*.invalid` hosts, plus opt-in `allowedNetworkOrigins`).
- Add `allowedNetworkOrigins` Playwright option fixture and `_assertNoUnmockedNetwork` auto fixture — mirrors DA-502's `expectedConsoleErrors` ergonomics.
- Gate clarity telemetry on `!IS_DA_E2E` so popup/dashboard tests don't leak to `m.clarity.ms`.

## Design notes
- Deny-all is registered FIRST in the `context` fixture; per-spec routes from `applyProfile()` register later, are newer in Playwright's chain, and intercept matching URLs first. The deny-all only fires when nothing specific matched.
- `page.route()` used by `IntegrationPage.open()` takes precedence over `context.route()` regardless of order, so fixture HTML still serves.
- `*.invalid` is project-allowed (already the convention for image URLs and the `da-test.invalid` integration origin), so no spec opt-in was needed.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] Full e2e suite: **20/20 pass** with strict mode on, no spec needed `allowedNetworkOrigins`
- [x] Self-test (temp, deleted): an intentional unmocked `fetch()` from the popup was aborted and surfaced as the expected teardown failure (`Unmocked network requests during test (1): GET https://...`)