### PR TITLE
(extension) inject e2e proxy env defaults at build time [DA-504]

### DIFF
--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -71,16 +71,6 @@ jobs:
         working-directory: packages/danmaku-anywhere
         run: pnpm exec playwright install --with-deps chromium
 
-      # .env is gitignored, so write a synthetic one for the build. The
-      # hosts are intercepted by Playwright routes; nothing reaches them.
-      - name: Write .env for build
-        working-directory: packages/danmaku-anywhere
-        run: |
-          cat > .env <<'EOF'
-          VITE_PROXY_URL=https://api.danmaku.test
-          VITE_PROXY_ORIGIN=https://danmaku.test
-          EOF
-
       - name: Build extension (e2e — dev API on, open shadow root)
         working-directory: packages/danmaku-anywhere
         env:

--- a/docs/src/content/docs/development/structure.mdx
+++ b/docs/src/content/docs/development/structure.mdx
@@ -62,6 +62,21 @@ https://github.com/Mr-Quin/danmaku-anywhere
 
 扩展位于 `packages/danmaku-anywhere`
 
+#### 环境变量
+
+扩展构建需要以下环境变量（用于 Vite 在构建时内联到代码中）：
+
+- `VITE_PROXY_URL` — 后端代理地址，用于鉴权客户端以及弹弹play等代理路由
+- `VITE_PROXY_ORIGIN` — `Origin` 请求头的值，由 `declarativeNetRequest` 动态规则使用。若构建时为空，Chrome 会拒绝该规则，导致经过代理的弹幕源无法工作
+
+复制模板文件并按需修改：
+
+```bash
+cp packages/danmaku-anywhere/.env.example packages/danmaku-anywhere/.env
+```
+
+E2E 构建（`pnpm test:e2e`）无需真实值——`vite.config.ts` 会在 `daEnv === 'e2e'` 时注入占位主机，由 Playwright 路由拦截，不会发送到外网。
+
 <Tabs>
   <TabItem label="Chrome">
 

--- a/packages/danmaku-anywhere/vite.config.ts
+++ b/packages/danmaku-anywhere/vite.config.ts
@@ -52,6 +52,19 @@ export default defineConfig({
     'import.meta.env.VERSION': JSON.stringify(appVersion),
     'import.meta.env.VITE_STANDALONE': JSON.stringify(false),
     'import.meta.env.VITE_DA_ENV': JSON.stringify(daEnv),
+    // E2E builds run without a developer .env (CI and fresh checkouts).
+    // The DNR rule that sets the Origin header rejects undefined values,
+    // so inject placeholder hosts that Playwright routes intercept.
+    ...(daEnv === 'e2e'
+      ? {
+          'import.meta.env.VITE_PROXY_URL': JSON.stringify(
+            process.env.VITE_PROXY_URL ?? 'https://api.danmaku.test'
+          ),
+          'import.meta.env.VITE_PROXY_ORIGIN': JSON.stringify(
+            process.env.VITE_PROXY_ORIGIN ?? 'https://danmaku.test'
+          ),
+        }
+      : {}),
   },
   build: {
     emptyOutDir: true,

--- a/packages/danmaku-anywhere/vite.config.ts
+++ b/packages/danmaku-anywhere/vite.config.ts
@@ -57,11 +57,13 @@ export default defineConfig({
     // so inject placeholder hosts that Playwright routes intercept.
     ...(daEnv === 'e2e'
       ? {
+          // Use `||` so an empty-string env var still falls back to the
+          // placeholder — Chrome rejects empty DNR header values.
           'import.meta.env.VITE_PROXY_URL': JSON.stringify(
-            process.env.VITE_PROXY_URL ?? 'https://api.danmaku.test'
+            process.env.VITE_PROXY_URL || 'https://api.danmaku.test'
           ),
           'import.meta.env.VITE_PROXY_ORIGIN': JSON.stringify(
-            process.env.VITE_PROXY_ORIGIN ?? 'https://danmaku.test'
+            process.env.VITE_PROXY_ORIGIN || 'https://danmaku.test'
           ),
         }
       : {}),


### PR DESCRIPTION
## Summary
- Move synthetic `VITE_PROXY_URL`/`VITE_PROXY_ORIGIN` values from the CI workflow into `vite.config.ts` so any e2e build (CI or fresh local checkout without a `.env`) produces an extension whose `NetRequestManager` DNR rule registers cleanly. Defaults match the prior CI-written values; `process.env` overrides still win, so developers can point e2e builds at their own backend.
- Drop the now-redundant "Write .env for build" step from `quality-e2e.yml`.
- Document `VITE_PROXY_URL` and `VITE_PROXY_ORIGIN` in the dev structure docs (Chinese), pointing readers at `.env.example` and noting that `pnpm test:e2e` does not need real values.

## Verification
- `pnpm type-check` and `pnpm lint` (no new warnings)
- Removed `.env`/`.env.local`, ran `VITE_DA_ENV=e2e pnpm build`, grepped the bundle and confirmed both `danmaku.test` placeholders were inlined
- `pnpm exec playwright test e2e/specs/baseline/extension.spec.ts` (3/3 pass)
- `pnpm exec playwright test e2e/specs/lifecycle/install.spec.ts` (1/1 pass — this spec asserts no console errors, which would catch the original NetRequestManager rejection)