### PR TITLE
(extension) e2e doctrine + Toast/ConfirmDialog POMs + comment cleanup [DA-505]

### DIFF
--- a/packages/danmaku-anywhere/AGENTS.md
+++ b/packages/danmaku-anywhere/AGENTS.md
@@ -35,8 +35,9 @@ Inversify IoC container (`src/common/ioc/`) wires up dependencies across these c
 
 ## Testing conventions
 
-- **Every test file gets a header JSDoc block** (3-6 lines) describing what the test exercises and what it asserts. Place it immediately after imports, before the first `test()`. Treat it as the spec a future reader sees first.
+- **Every test file gets a header JSDoc block** (3-6 lines) describing what the test exercises and what it asserts. Place it immediately after imports, before the first `test()`. Treat it as the spec a future reader sees first. **No narration inside the test body** — default to no comments; add one only when removing it would mislead the next reader (footguns, races, library quirks). Well-named identifiers do the WHAT.
 - e2e specs live under `e2e/specs/<area>/<source>.spec.ts`. Use the `Popup` POM in `e2e/pom/` and the `applyProfile` helper in `e2e/setup/` instead of touching selectors or chrome.storage directly. Per-source mock builders live in `e2e/network/<source>.ts`.
+- e2e has its own doctrine — read `e2e/AGENTS.md` before adding or modifying specs. It covers test taxonomy (unit vs package-integration vs e2e), the "user-visible signal required" rule, network strict-mode and console-error opt-outs, and what hacks to avoid.
 
 ## Gotchas
 

--- a/packages/danmaku-anywhere/e2e/AGENTS.md
+++ b/packages/danmaku-anywhere/e2e/AGENTS.md
@@ -1,0 +1,92 @@
+# Agent context: packages/danmaku-anywhere/e2e
+
+This is the **baseline doctrine** for end-to-end tests. Future e2e PRs are reviewed against it.
+
+## Test taxonomy
+
+Three layers, in increasing cost and fragility:
+
+- **unit** — `*.test.ts` next to the source. In-process, no browser. Pure logic, single class/function.
+- **package-integration** — `__tests__/*.test.ts`. Still in-process. Multi-class flows inside one package (service + repo + store).
+- **e2e** — `e2e/specs/**`, Playwright, real extension loaded into Chromium. Answers exactly one question: **"did the user see X in the UI?"**
+
+The deciding question for any spec: **if you removed every UI assertion, would the test still pass on data alone?** If yes, it isn't e2e — move it down a layer. State-only assertions wearing a Playwright costume cost ~100× a unit test and catch less.
+
+## Every e2e spec asserts at least one user-visible signal
+
+User-visible means observable from the rendered DOM, a download, or a navigation. Concretely:
+
+- toast text + severity (via `popup.toast`)
+- dialog title/body (via `popup.dialog`)
+- rendered DOM: `commentElements()`, tree-item visibility, count text, list item presence
+- download payload (`page.waitForEvent('download')`)
+- URL / page transition
+
+State assertions (`da.season.get(...)`, `da.episode.get(...)`, mount mirror) **complement** UI assertions — they pin down ground truth so a UI bug can't mask a data bug. They do not replace UI assertions. A regression that breaks the toast but leaves the DB correct should fail an e2e test, not pass it.
+
+The standard shape:
+
+```
+1. Seed the DB / profile (via dev API)
+2. Drive the UI (popup click, search submit, video event)
+3. Assert UI: at least one user-visible signal
+4. Assert state: ground truth in DB / chrome.storage (optional but encouraged)
+```
+
+## Comment rules
+
+### Header JSDoc
+3–6 lines, placed immediately after imports, before the first `test()` / `describe()`. Name what's exercised and what's asserted. No design-doc essays. No restating the test body step by step.
+
+### Inside the test body / POMs / setup files
+Default: **no comments.** Add one only when removing it would lead the next reader to file a wrong PR. The bar is "this would cost an hour of debugging if you didn't know." Examples that earn their keep:
+
+- `fixtures.ts` eager watcher attach — explains a Playwright timing footgun (workers register before fixtures resolve).
+- Anything that documents a known race, a library bug, a CDP delivery quirk, or an envelope constraint (MUI portal behavior, structuredClone limits, etc.).
+
+Examples that do NOT earn their keep — delete on sight:
+
+- Narration of what the next line does: `// Click the menu item` above `menu.click()`.
+- Explanations of Playwright auto-wait, locator chaining, or `dispatchEvent` mechanics. Readers know.
+- "We do X because Y is broken" without naming what Y is or when it can be removed.
+
+### Don't restate WHAT
+Well-named identifiers are the WHAT. Comment only the WHY, and only when WHY is non-obvious.
+
+## Hacks to avoid
+
+- **Dev-API methods that exist only to paper over a production race.** Fix the chain instead. The current `da.mount.waitForRegistration` is grandfathered; new equivalents need an explicit justification in the PR.
+- **Parallel test-only mirror state** (e.g. `__daMountMirror`) must justify itself against asserting on the UI signal directly. Prefer the UI signal. Mirrors are acceptable when the UI signal is genuinely unobservable from Playwright (e.g. cross-frame state not reflected in DOM), but the burden of proof is on the mirror.
+- **`IS_DA_E2E` branches in source.** The flag stays — `e2e` is another runtime env alongside `dev`/`preview`/`prod`, and using it sparingly is fine. But every branch in source needs a one-line comment naming why the e2e path differs.
+
+## Baselines
+
+These are enforced by `e2e/setup/fixtures.ts` and apply to every spec by default.
+
+### Network strict-mode (DA-503)
+Any HTTP request that isn't mocked by a per-spec route or covered by the project allow-list **fails the test**. Project allow-list covers `chrome-extension:`, `data:`, `blob:`, `about:`, and `*.invalid` hostnames.
+
+To opt extra origins in:
+
+```ts
+test.use({ allowedNetworkOrigins: ['accounts.google.com'] }) // OAuth redirect — covered by separate auth test
+```
+
+One-line justification per entry. Prefer a per-spec mock over widening the allow-list.
+
+### Console-error default-fail (DA-502)
+Any `console.error` during the test body fails it. Patterns match by `includes` (string) or `.test` (RegExp) against the formatted line — the entry includes a `[sw]` / `[page <url>]` prefix and a trailing `(<url>:<line>:<col>)`, so patterns can target any of those parts.
+
+To opt out:
+
+```ts
+test.use({ expectedConsoleErrors: [/SchemaValidationError: known stale fixture/] })
+```
+
+One-line justification per entry. Treat opt-outs as tech debt — leaving them unjustified means a real regression hides behind a "we always saw that one."
+
+## Page Objects (POMs)
+
+POMs live under `e2e/pom/`. The composed root is `Popup` (`e2e/pom/Popup.ts`); page-area POMs hang off it (`popup.mount`, `popup.search`, `popup.seasonDetails`, `popup.toast`, `popup.dialog`). `IntegrationPage` is standalone — it doesn't open via `chrome-extension://`.
+
+Add methods to a POM rather than reaching into selectors from a spec. If a spec needs a one-off selector that isn't worth a POM method, add a one-line comment explaining why a method wasn't added.

--- a/packages/danmaku-anywhere/e2e/AGENTS.md
+++ b/packages/danmaku-anywhere/e2e/AGENTS.md
@@ -63,7 +63,7 @@ Well-named identifiers are the WHAT. Comment only the WHY, and only when WHY is 
 
 These are enforced by `e2e/setup/fixtures.ts` and apply to every spec by default.
 
-### Network strict-mode (DA-503)
+### Network strict-mode
 Any HTTP request that isn't mocked by a per-spec route or covered by the project allow-list **fails the test**. Project allow-list covers `chrome-extension:`, `data:`, `blob:`, `about:`, and `*.invalid` hostnames.
 
 To opt extra origins in:
@@ -74,7 +74,7 @@ test.use({ allowedNetworkOrigins: ['accounts.google.com'] }) // OAuth redirect â
 
 One-line justification per entry. Prefer a per-spec mock over widening the allow-list.
 
-### Console-error default-fail (DA-502)
+### Console-error default-fail
 Any `console.error` during the test body fails it. Patterns match by `includes` (string) or `.test` (RegExp) against the formatted line â€” the entry includes a `[sw]` / `[page <url>]` prefix and a trailing `(<url>:<line>:<col>)`, so patterns can target any of those parts.
 
 To opt out:

--- a/packages/danmaku-anywhere/e2e/AGENTS.md
+++ b/packages/danmaku-anywhere/e2e/AGENTS.md
@@ -90,3 +90,6 @@ One-line justification per entry. Treat opt-outs as tech debt — leaving them u
 POMs live under `e2e/pom/`. The composed root is `Popup` (`e2e/pom/Popup.ts`); page-area POMs hang off it (`popup.mount`, `popup.search`, `popup.seasonDetails`, `popup.toast`, `popup.dialog`). `IntegrationPage` is standalone — it doesn't open via `chrome-extension://`.
 
 Add methods to a POM rather than reaching into selectors from a spec. If a spec needs a one-off selector that isn't worth a POM method, add a one-line comment explaining why a method wasn't added.
+
+### Locale-stable matchers
+Toast text and dialog title/body are i18n-translated. Prefer `popup.toast.expectSuccess` / `expectError` (which scope by `data-severity`) over raw text matching. When asserting message text, use a regex that matches both locales — see `SeasonDetailsPage.expectCommentCount` (matches `条弹幕` and `comments`).

--- a/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
@@ -61,12 +61,12 @@ export class ConfirmDialog {
 
   async confirm(options: ExpectOptions = {}): Promise<void> {
     await this.expectVisible(options)
-    await this.confirmButton.click()
+    await this.confirmButton.click({ timeout: options.timeout })
   }
 
   async cancel(options: ExpectOptions = {}): Promise<void> {
     const { timeout = 5_000 } = options
     await expect(this.cancelButton).toBeVisible({ timeout })
-    await this.cancelButton.click()
+    await this.cancelButton.click({ timeout })
   }
 }

--- a/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
@@ -60,8 +60,9 @@ export class ConfirmDialog {
   }
 
   async confirm(options: ExpectOptions = {}): Promise<void> {
-    await this.expectVisible(options)
-    await this.confirmButton.click({ timeout: options.timeout })
+    const { timeout = 5_000 } = options
+    await this.expectVisible({ timeout })
+    await this.confirmButton.click({ timeout })
   }
 
   async cancel(options: ExpectOptions = {}): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
@@ -1,0 +1,72 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+const SELECTORS = {
+  confirm: '[data-testid="dialog-confirm"]',
+  cancel: '[data-testid="dialog-cancel"]',
+  title: '[data-testid="dialog-title"]',
+  content: '[data-testid="dialog-content"]',
+}
+
+interface ExpectOptions {
+  timeout?: number
+}
+
+// POM for the global confirm Dialog (dialogStore-driven). Anchors on the
+// confirm button — present whenever the dialog has a confirm action,
+// which covers every spec call site.
+export class ConfirmDialog {
+  constructor(private readonly page: Page) {}
+
+  get confirmButton(): Locator {
+    return this.page.locator(SELECTORS.confirm)
+  }
+
+  get cancelButton(): Locator {
+    return this.page.locator(SELECTORS.cancel)
+  }
+
+  get title(): Locator {
+    return this.page.locator(SELECTORS.title)
+  }
+
+  get body(): Locator {
+    return this.page.locator(SELECTORS.content)
+  }
+
+  async expectVisible(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.confirmButton).toBeVisible({ timeout })
+  }
+
+  async expectHidden(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.confirmButton).toBeHidden({ timeout })
+  }
+
+  async expectTitle(
+    matcher: string | RegExp,
+    options: ExpectOptions = {}
+  ): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.title).toContainText(matcher, { timeout })
+  }
+
+  async expectBody(
+    matcher: string | RegExp,
+    options: ExpectOptions = {}
+  ): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.body).toContainText(matcher, { timeout })
+  }
+
+  async confirm(options: ExpectOptions = {}): Promise<void> {
+    await this.expectVisible(options)
+    await this.confirmButton.click()
+  }
+
+  async cancel(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.cancelButton).toBeVisible({ timeout })
+    await this.cancelButton.click()
+  }
+}

--- a/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ConfirmDialog.ts
@@ -11,9 +11,9 @@ interface ExpectOptions {
   timeout?: number
 }
 
-// POM for the global confirm Dialog (dialogStore-driven). Anchors on the
-// confirm button — present whenever the dialog has a confirm action,
-// which covers every spec call site.
+// POM for the global confirm Dialog (dialogStore-driven). expectVisible
+// anchors on the confirm button — true for confirm-style dialogs only.
+// Info dialogs without a confirm action need their own POM.
 export class ConfirmDialog {
   constructor(private readonly page: Page) {}
 

--- a/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/IntegrationPage.ts
@@ -7,24 +7,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const SITES_ROOT = path.join(__dirname, '..', 'fixtures', 'sites')
 
 export interface OpenOptions {
-  // Additional fixture files to serve at same-origin paths (e.g. for
-  // iframe-inner.html when the host page references it via /iframe-inner.html).
-  // Keys are URL path segments under the host URL's origin, values are
-  // fixture file names under e2e/fixtures/sites/.
+  // Same-origin sub-resources to serve, keyed by path under the host URL's
+  // origin (e.g. 'iframe-inner.html'), valued by fixture filename.
   extraFixtures?: Record<string, string>
 }
 
-// Page object for synthetic pages used to exercise the integration pipeline
-// (URL match → policy → media-info → auto-mount → render). Generic — works
-// for any fixture under e2e/fixtures/sites/, including top-frame video and
-// iframe-hosted video setups.
 export class IntegrationPage {
-  // Frame containing the <video>. Defaults to the top frame; overridden by
-  // useIframeVideo() for iframe scenarios.
   private videoFrame: Frame | null = null
-  // Selector passed to useIframeVideo, kept so commentElements() can build a
-  // frameLocator off the same selector instead of re-deriving one from the
-  // frame URL (which is fragile under query-string / hash changes).
   private iframeSelector: string | null = null
 
   constructor(private readonly page: Page) {}
@@ -45,10 +34,6 @@ export class IntegrationPage {
         body: html,
       })
     })
-    // Same-origin sub-resources (e.g. iframe-inner.html). Each entry routes
-    // a same-origin path to a static fixture file. Anchor against the origin
-    // (not `url`) so a bare 'iframe-inner.html' key resolves at root, matching
-    // the host HTML's `<iframe src="/iframe-inner.html">`.
     const origin = new URL(url).origin
     for (const [pathSuffix, fixture] of Object.entries(
       options.extraFixtures ?? {}
@@ -66,9 +51,7 @@ export class IntegrationPage {
     await this.page.goto(url)
   }
 
-  // Switch the video-control methods to operate on the <video> inside the
-  // named iframe (located by selector on the host page). Subsequent
-  // setVideoTime / playVideo calls dispatch into that iframe's document.
+  // After this, video methods target the <video> inside the named iframe.
   async useIframeVideo(iframeSelector: string): Promise<void> {
     const handle = await this.page.waitForSelector(iframeSelector)
     const frame = await handle.contentFrame()
@@ -85,10 +68,7 @@ export class IntegrationPage {
     return this.videoFrame ?? this.page
   }
 
-  // Programmatically set currentTime. An empty <video> won't fire seeking /
-  // timeupdate events on its own with no media to seek through, so we
-  // synthesize them — the renderer's bindVideo plugin listens for exactly
-  // these events to advance the danmaku cursor.
+  // Synthesize seek events — an empty <video> won't fire them on its own.
   async setVideoTime(seconds: number): Promise<void> {
     await this.target.evaluate((t) => {
       const v = document.querySelector(
@@ -103,9 +83,7 @@ export class IntegrationPage {
     }, seconds)
   }
 
-  // Force the renderer into the "playing" branch. The bare <video> has no
-  // src so .play() can't drive playback; we dispatch the events the engine
-  // listens for. Idempotent.
+  // Synthesize play events — the bare <video> has no src so .play() is a no-op.
   async playVideo(): Promise<void> {
     await this.target.evaluate(() => {
       const v = document.querySelector(
@@ -131,11 +109,8 @@ export class IntegrationPage {
     })
   }
 
-  // Danmaku comment DOM nodes rendered by the engine. Scoped to the player
-  // popover root so we don't accidentally match anything from the host page.
-  // In dev builds the shadow root is open, so Playwright's CSS selectors
-  // pierce through automatically. For iframe scenarios the renderer mounts
-  // inside the iframe's document — use page.frameLocator there.
+  // Rendered danmaku nodes inside the player's (open) shadow root. For
+  // iframe scenarios the renderer mounts in the iframe's document.
   commentElements(): Locator {
     if (this.iframeSelector) {
       return this.page

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -6,14 +6,11 @@ const SELECTORS = {
   treeItemExpand: (id: string) => `[data-testid="tree-item-expand-${id}"]`,
   drilldownButton: '[data-testid="drilldown-menu-button"]',
   menuItem: (id: string) => `[data-testid="drilldown-menu-item-${id}"]`,
-  dialogConfirm: '[data-testid="dialog-confirm"]',
   multiselectToggle: '[data-testid="multiselect-toggle"]',
   multiselectSelectAll: '[data-testid="multiselect-select-all"]',
   bulkDelete: '[data-testid="mount-bulk-delete"]',
 }
 
-// Page object for the popup's default /mount route — the DanmakuTree
-// (season/episode hierarchy with per-item context menus).
 export class MountPage {
   constructor(private readonly page: Page) {}
 
@@ -45,27 +42,17 @@ export class MountPage {
     return item
   }
 
-  // Open the per-item action menu by right-click. The tree item renders
-  // two menu variants:
-  //   - DrilldownMenu (anchored to a 3-dot IconButton, MUI Modal/Backdrop)
-  //   - DrilldownContextMenu (Popper, no Modal/Backdrop) on right-click
-  // Both render the same DAMenuItem entries with the same testids. The
-  // Modal path is brittle: the IconButton is conditionally mounted on a
-  // `hovering` React state that races with Playwright's hover() under
-  // xvfb, and the Modal's Backdrop intercepts pointer events during its
-  // close transition. The Popper path has neither footgun.
+  // Right-click opens the DrilldownContextMenu (Popper, no Modal/Backdrop).
+  // The IconButton path uses a Modal whose Backdrop intercepts pointer
+  // events during its close transition — flaky under xvfb. Same DAMenuItem
+  // entries either way, so right-click is the stable path.
   async openItemMenu(item: Locator, actionId: string): Promise<void> {
     await item.click({ button: 'right' })
     const menuItem = this.page.locator(SELECTORS.menuItem(actionId))
     await menuItem.click()
-    // Ensure the menu has fully closed before returning so a follow-up
-    // openItemMenu call doesn't race the close.
     await expect(menuItem).toBeHidden({ timeout: 5_000 })
   }
 
-  // Click the tree item's expand chevron to reveal children. RichTreeView
-  // exposes an icon container that toggles expansion; clicking the content
-  // area doesn't expand. No-op if already expanded.
   async expandSeason(seasonId: number): Promise<void> {
     const item = this.seasonItem(seasonId)
     if ((await item.getAttribute('aria-expanded')) === 'true') {
@@ -77,8 +64,6 @@ export class MountPage {
     })
   }
 
-  // Expand any tree item by its full itemId (e.g. 'season-custom',
-  // 'folder-MyFolder'). No-op if already expanded.
   async expandItem(itemId: string): Promise<void> {
     const item = this.page.locator(SELECTORS.treeItem(itemId))
     if ((await item.getAttribute('aria-expanded')) === 'true') {
@@ -96,17 +81,6 @@ export class MountPage {
 
   customEpisodeItem(episodeId: number): Locator {
     return this.page.locator(SELECTORS.treeItem(`custom-episode-${episodeId}`))
-  }
-
-  // Confirm the active MUI delete/confirm dialog. The Dialog renders in a
-  // portal, so the testid is looked up at the page level (not scoped to a
-  // tree item). Waits for the button to be visible first — without the
-  // explicit wait, a regression that no longer opens a dialog hangs on
-  // Playwright's default 30s auto-wait instead of failing fast.
-  async confirmDialog(timeout = 5_000): Promise<void> {
-    const confirm = this.page.locator(SELECTORS.dialogConfirm)
-    await expect(confirm).toBeVisible({ timeout })
-    await confirm.click()
   }
 
   async enterMultiSelect(): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -1,17 +1,23 @@
 import type { Page } from '@playwright/test'
+import { ConfirmDialog } from './ConfirmDialog'
 import { MountPage } from './MountPage'
 import { SearchPage } from './SearchPage'
 import { SeasonDetailsPage } from './SeasonDetailsPage'
+import { Toast } from './Toast'
 
 export class Popup {
   readonly mount: MountPage
   readonly search: SearchPage
   readonly seasonDetails: SeasonDetailsPage
+  readonly toast: Toast
+  readonly dialog: ConfirmDialog
 
   private constructor(page: Page) {
     this.mount = new MountPage(page)
     this.search = new SearchPage(page)
     this.seasonDetails = new SeasonDetailsPage(page)
+    this.toast = new Toast(page)
+    this.dialog = new ConfirmDialog(page)
   }
 
   static async open(

--- a/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
@@ -19,8 +19,8 @@ export class SearchPage {
     return this.page.locator(SELECTORS.searchSubmit)
   }
 
-  // Press Enter to submit; the autocomplete dropdown intercepts pointer
-  // events on the submit button when it's open.
+  // Enter, not click — the autocomplete dropdown intercepts the submit
+  // button when open.
   async submit(term: string): Promise<void> {
     await this.input.fill(term)
     await this.input.press('Enter')

--- a/packages/danmaku-anywhere/e2e/pom/Toast.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Toast.ts
@@ -29,7 +29,7 @@ export class Toast {
     options: ExpectOptions = {}
   ): Promise<void> {
     const { timeout = 5_000 } = options
-    await expect(this.all().filter({ hasText: matcher }).first()).toBeVisible({
+    await expect(this.all().filter({ hasText: matcher })).toBeVisible({
       timeout,
     })
   }
@@ -40,7 +40,7 @@ export class Toast {
   ): Promise<void> {
     const { timeout = 5_000 } = options
     await expect(
-      this.bySeverity('success').filter({ hasText: matcher }).first()
+      this.bySeverity('success').filter({ hasText: matcher })
     ).toBeVisible({ timeout })
   }
 
@@ -50,7 +50,7 @@ export class Toast {
   ): Promise<void> {
     const { timeout = 5_000 } = options
     await expect(
-      this.bySeverity('error').filter({ hasText: matcher }).first()
+      this.bySeverity('error').filter({ hasText: matcher })
     ).toBeVisible({ timeout })
   }
 }

--- a/packages/danmaku-anywhere/e2e/pom/Toast.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Toast.ts
@@ -1,0 +1,56 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+const SELECTORS = {
+  snackbar: '[data-testid="snackbar"]',
+  bySeverity: (s: string) => `[data-testid="snackbar"][data-severity="${s}"]`,
+}
+
+type Severity = 'success' | 'error' | 'warning' | 'info'
+
+interface ExpectOptions {
+  timeout?: number
+}
+
+// POM for the global Snackbar (toastStore-driven). Snackbars stack and
+// render in a portal, so all locators are page-scoped.
+export class Toast {
+  constructor(private readonly page: Page) {}
+
+  all(): Locator {
+    return this.page.locator(SELECTORS.snackbar)
+  }
+
+  bySeverity(severity: Severity): Locator {
+    return this.page.locator(SELECTORS.bySeverity(severity))
+  }
+
+  async expectVisible(
+    matcher: string | RegExp,
+    options: ExpectOptions = {}
+  ): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.all().filter({ hasText: matcher }).first()).toBeVisible({
+      timeout,
+    })
+  }
+
+  async expectSuccess(
+    matcher: string | RegExp,
+    options: ExpectOptions = {}
+  ): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(
+      this.bySeverity('success').filter({ hasText: matcher }).first()
+    ).toBeVisible({ timeout })
+  }
+
+  async expectError(
+    matcher: string | RegExp,
+    options: ExpectOptions = {}
+  ): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(
+      this.bySeverity('error').filter({ hasText: matcher }).first()
+    ).toBeVisible({ timeout })
+  }
+}

--- a/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/console-watcher.ts
@@ -11,8 +11,7 @@ export interface ConsoleWatcher {
 
 export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
   const errors: string[] = []
-  // Dedupe so a worker/page that races between context.on(...) firing and
-  // the initial enumeration below isn't double-watched.
+  // Dedupe — the context.on listener and the initial enumeration can race.
   const watched = new WeakSet<Page | Worker>()
 
   function formatLocation(msg: ConsoleMessage): string {
@@ -50,8 +49,7 @@ export function attachConsoleWatcher(context: BrowserContext): ConsoleWatcher {
     })
   }
 
-  // Attach context-level listeners FIRST so any worker/page that registers
-  // mid-enumeration is still captured, then walk the current lists.
+  // Context listeners FIRST so a mid-enumeration register is still captured.
   context.on('serviceworker', watchWorker)
   context.on('page', watchPage)
 

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -17,11 +17,9 @@ interface ContextWatchers {
   network: NetworkWatcher
 }
 
-// Watchers are attached eagerly inside the context fixture (before the SW
-// has a chance to boot) and looked up later by per-test fixtures.
-// Playwright resolves fixtures in dependency order, so a fixture that
-// depends only on `context` runs after the SW may have already emitted —
-// Playwright doesn't buffer console events for existing workers.
+// Watchers attach inside the context fixture before the SW boots; per-test
+// fixtures look them up. Attaching from a later fixture loses console events
+// from already-running workers (Playwright doesn't buffer).
 const watchersByContext = new WeakMap<BrowserContext, ContextWatchers>()
 
 export type ExpectedConsoleErrorPattern = string | RegExp
@@ -36,18 +34,8 @@ export const test = base.extend<{
   _assertNoUnexpectedConsoleErrors: void
   _assertNoUnmockedNetwork: void
 }>({
-  // Per-test opt-out: override with `test.use({ expectedConsoleErrors: [...] })`
-  // (or pass an array via `test('name', { expectedConsoleErrors: [...] })`)
-  // to allow specific errors. Entries match by `includes` (string) or `.test`
-  // (RegExp) against the formatted watcher entry — the line includes a
-  // `[sw]`/`[page <url>]` prefix and a trailing `(<url>:<line>:<col>)`
-  // location, not just the raw console message text. Patterns can target
-  // any of those parts.
+  // See e2e/AGENTS.md → Baselines for the opt-out / opt-in contract.
   expectedConsoleErrors: [[], { option: true }],
-
-  // Per-test opt-in for extra origins; matched by `includes` (string) or
-  // `.test` (RegExp). Project defaults (extension://, data:, blob:, about:,
-  // *.invalid) are always allowed. Prefer a per-spec mock over widening this.
   allowedNetworkOrigins: [[], { option: true }],
 
   context: async ({ allowedNetworkOrigins }, use) => {
@@ -88,11 +76,7 @@ export const test = base.extend<{
     await use(watchers.console.getErrors)
   },
 
-  // Auto fixture: after every test, fail if any console errors slipped
-  // through that weren't allow-listed via `expectedConsoleErrors`. Depends
-  // on `context` so teardown runs before the context closes — keeping the
-  // watcher reachable. Skipped when the test already failed so the real
-  // failure isn't drowned out.
+  // Skipped when the test already failed so a real failure isn't drowned out.
   _assertNoUnexpectedConsoleErrors: [
     async ({ context, expectedConsoleErrors }, use, testInfo) => {
       await use()

--- a/packages/danmaku-anywhere/e2e/setup/integration.ts
+++ b/packages/danmaku-anywhere/e2e/setup/integration.ts
@@ -6,12 +6,9 @@ import { LATEST_MOUNT_CONFIG_VERSION } from '../../src/common/options/mountConfi
 import type { DaClient } from './da-client'
 
 export interface IntegrationSeedInput {
-  // Match patterns the controller content script will be registered for.
-  // Use Chrome match-pattern syntax (e.g. https://www.example.com/play/*).
+  // Chrome match-pattern syntax (e.g. https://www.example.com/play/*).
   patterns: string[]
-  // CSS selector for the <video> element on the integration target page.
   mediaQuery?: string
-  // Human-readable name shown in the popup; doesn't affect runtime behavior.
   name?: string
   policy: Integration['policy']
 }
@@ -21,10 +18,8 @@ export interface IntegrationSeedResult {
   integrationId: string
 }
 
-// Seed a single MountConfig + matching IntegrationPolicy via raw storage
-// writes. Writes are immediate but content-script (re)registration happens
-// asynchronously when MountConfigService picks up the chrome.storage change —
-// the caller must wait via da.mount.waitForRegistration before navigating.
+// Storage writes are immediate; content-script registration is async, so
+// callers must `da.mount.waitForRegistration` before navigating.
 export async function seedXPathIntegration(
   da: DaClient,
   input: IntegrationSeedInput
@@ -63,9 +58,7 @@ export async function seedXPathIntegration(
   return { mountConfigId, integrationId }
 }
 
-// Generic integration policy keyed to data-testid hooks on the fixture
-// pages (native-video.html, iframe-host.html). Lets multiple specs reuse the
-// same selectors without restating XPath strings.
+// Generic policy keyed to data-testid hooks on the fixture pages.
 export function buildFixtureIntegrationPolicy(): Integration['policy'] {
   return {
     version: 3,

--- a/packages/danmaku-anywhere/e2e/setup/network-watcher.ts
+++ b/packages/danmaku-anywhere/e2e/setup/network-watcher.ts
@@ -23,8 +23,7 @@ function isProjectAllowed(url: string): boolean {
     ) {
       return true
     }
-    // `.invalid` is a project-wide fixture convention (image URLs, the
-    // da-test.invalid integration origin); RFC 6761 reserves it.
+    // `.invalid` (RFC 6761) — project-wide fixture convention.
     const host = parsed.hostname
     return host === 'invalid' || host.endsWith('.invalid')
   } catch {
@@ -43,9 +42,8 @@ function matchesAllowed(
   })
 }
 
-// Registered before per-spec routes so it lands older in Playwright's
-// handler chain (newest fires first) — only fires when nothing specific
-// matched.
+// Register before per-spec routes — Playwright fires newest handler first,
+// so this catch-all only runs when nothing specific matched.
 export async function attachNetworkWatcher(
   context: BrowserContext,
   getAllowed: () => readonly AllowedNetworkPattern[]

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -9,14 +9,10 @@ import {
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Generic happy-path proof for the integration auto-mount pipeline. Covers
- * the full chain — URL match → XPath policy → media-info extraction →
- * auto-mount → render at correct timestamp — with no site-specific
- * dependencies. Two scenarios: a native top-frame video, and a video hosted
- * inside a same-origin iframe (the player content script runs in every
- * frame, the controller only in the top frame). Both resolve through the
- * LocalMatchingStrategy against a seeded custom episode, so no provider
- * network calls are exercised here — that's covered by sources/*.spec.ts.
+ * Auto-mount happy path: URL match → XPath policy → media-info → mount →
+ * render at the right timestamp. Two video setups: top-frame and
+ * same-origin iframe. Both resolve via LocalMatchingStrategy against a
+ * seeded custom episode — no provider network is exercised here.
  */
 
 const ORIGIN = 'https://da-test.invalid'
@@ -25,8 +21,7 @@ const IFRAME_URL = `${ORIGIN}/iframe/`
 const MOUNT_PATTERN = `${ORIGIN}/*`
 
 const EPISODE_TITLE = 'DA Integration Test'
-// 3 comments at known timestamps so a seek past `SEEK_TIME_S` lands the
-// renderer's cursor on at least the first one and emits a DOM node.
+// Seeking past SEEK_TIME_S lands the cursor on at least one comment.
 const COMMENTS = [
   { p: '12,1,16777215,e2e-1', m: 'first' },
   { p: '24,1,16777215,e2e-2', m: 'second' },
@@ -42,9 +37,8 @@ async function seedFixtureProfile(
     extensionOptions: { matchLocalDanmaku: true },
   })
 
-  // Custom (MacCMS) episode keyed to the title the integration extracts from
-  // the fixture page. LocalMatchingStrategy's fuzzy fallback matches by
-  // title path-last-segment, so this resolves without naming rules.
+  // Title matches what the policy extracts from the fixture; LocalMatching
+  // resolves it via fuzzy title fallback (no naming rules needed).
   const customEpisode = await da.episode.addCustom({
     provider: DanmakuSourceType.MacCMS,
     title: EPISODE_TITLE,
@@ -59,8 +53,7 @@ async function seedFixtureProfile(
     policy: buildFixtureIntegrationPolicy(),
   })
 
-  // MountConfig write triggers async content-script registration — wait for
-  // it before navigating or the controller never loads on the page.
+  // Content-script registration is async; wait or the controller never loads.
   await da.mount.waitForRegistration(MOUNT_PATTERN, 5_000)
 
   return { episodeId: customEpisode.id }
@@ -77,16 +70,11 @@ test('integration auto-mount: native <video> happy path', async ({
   await page.bringToFront()
   await integrationPage.open(NATIVE_URL, 'native-video.html')
 
-  // Auto-mount has to thread URL match → policy extraction → local match →
-  // mount. No provider network round-trips on this path; the 15s budget is
-  // a safety margin for the observer's 1s discovery interval and React
-  // mount latency.
+  // 15s = video-discovery observer interval (1s) + React mount + slack.
   const mirror = await da.mount.waitForMount(undefined, 15_000)
   expect(mirror.isMounted).toBe(true)
   expect(mirror.episodeIds).toEqual([episodeId])
 
-  // Cross the first comment's timestamp. handleSeek + handleTimeupdate in
-  // the renderer's bindVideo plugin should emit at least one DOM node.
   await integrationPage.playVideo()
   await integrationPage.setVideoTime(SEEK_TIME_S)
 
@@ -108,10 +96,8 @@ test('integration auto-mount: same-origin iframe <video> happy path', async ({
     extraFixtures: { 'iframe-inner.html': 'iframe-inner.html' },
   })
 
-  // Same mount pipeline, but the <video> lives in a child frame. The
-  // controller (top frame only) extracts media info; the player content
-  // script (allFrames: true) running inside the iframe is what actually
-  // mounts the renderer onto the video.
+  // <video> in a child frame — controller (top) extracts media info,
+  // player content script (allFrames) inside the iframe mounts the renderer.
   await integrationPage.useIframeVideo('iframe[data-testid="da-iframe"]')
 
   const mirror = await da.mount.waitForMount(undefined, 15_000)

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -6,13 +6,11 @@ import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
 /**
- * Fresh-install smoke for the extension. Asserts the SW registers, the
- * onInstalled upgrade path seeds default extensionOptions plus the three
- * built-in provider configs, and no console errors fire during boot.
+ * Fresh-install smoke. Asserts the SW registers, onInstalled seeds default
+ * extensionOptions + the three built-in provider configs, no console errors.
  *
- * A chrome.runtime.reload() variant was intentionally dropped: under
- * Playwright's --load-extension launch, the extension does not respawn
- * after runtime.reload(), so the case isn't exercisable here.
+ * A runtime.reload() variant was dropped — under --load-extension, the
+ * extension does not respawn after reload, so the case isn't exercisable.
  */
 
 const BUILTIN_PROVIDER_IDS = [

--- a/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
@@ -11,19 +11,12 @@ import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Bookmark add/remove on the DanmakuTree (/mount). Seeds a Bilibili season
- * + one persisted episode, bookmarks via the season's context menu, and
- * asserts that:
- *   - bookmark.bySeason returns a Bookmark whose .episodes carries the
- *     upstream-fetched stubs (the "additional undownloaded episodes"
- *     surfaced to the user)
- *   - the season tree item shows the +N stub indicator
- * Then removes the bookmark and asserts both signals revert.
+ * Bookmark add/remove on the DanmakuTree (/mount) via the season context
+ * menu. Asserts the Bookmark record carries upstream stubs and the season
+ * row shows the +N stub indicator; remove reverts both.
  *
- * BookmarkService.add triggers an upstream episode fetch
- * (ProviderService.fetchEpisodesBySeason), so the Bilibili season fixture
- * (2 episodes) is mocked — yielding 1 stub after deduping the persisted
- * episode by indexedId.
+ * Bilibili season fixture has 2 episodes → 1 stub after deduping the seeded
+ * persisted episode by indexedId.
  */
 
 const SEASON: SeasonInsert = {
@@ -40,8 +33,7 @@ const SEASON: SeasonInsert = {
 }
 
 function makeEpisode(seasonId: number): EpisodeInsert {
-  // Matches the fixture's first episode by indexedId (= cid) so that the
-  // bookmark stubs dedupe it down to one undownloaded episode.
+  // indexedId matches the fixture's first episode so stub dedup leaves 1.
   return {
     provider: DanmakuSourceType.Bilibili,
     providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
@@ -80,27 +72,18 @@ test('mount tree: bookmark adds stubs, remove clears them', async ({
 
   await popup.mount.openItemMenu(seasonItem, 'bookmarkAdd')
 
-  // Ground truth: bookmark exists in DB.
+  await expect(seasonItem).toContainText(/\+1/, { timeout: 10_000 })
+
   await expect
     .poll(() => da.bookmark.bySeason(season.id), { timeout: 10_000 })
     .toBeTruthy()
-
-  // Bookmark stores all upstream episodes (2 from the season fixture).
   const bookmark = await da.bookmark.bySeason(season.id)
   expect(bookmark?.episodes.length).toBe(2)
 
-  // UI surface: the season tree item now shows a `+N` indicator for
-  // undownloaded stubs (2 from upstream - 1 already persisted = 1 stub).
-  await expect(seasonItem).toContainText(/\+1/, { timeout: 10_000 })
-
-  // Remove the bookmark via the same menu (id changes to bookmarkRemove
-  // once bookmarked).
   await popup.mount.openItemMenu(seasonItem, 'bookmarkRemove')
 
+  await expect(seasonItem).not.toContainText(/\+\d+/)
   await expect
     .poll(() => da.bookmark.bySeason(season.id), { timeout: 10_000 })
     .toBeUndefined()
-
-  // +N indicator gone.
-  await expect(seasonItem).not.toContainText(/\+\d+/)
 })

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -9,15 +9,11 @@ import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Per-item delete on the DanmakuTree (/mount). Two paths:
- *   - Season delete via the season's context menu — cascades to its
- *     episodes; the season row disappears and `da.season.get` returns
- *     undefined.
- *   - Episode delete via the episode's context menu — removes a single
- *     row, leaving the parent season intact (still has another episode).
+ * Per-item delete on the DanmakuTree (/mount) via the context menu:
+ *   - Season delete cascades to its episodes — row vanishes, DB cleared.
+ *   - Episode delete removes one row — parent + sibling stay intact.
  *
- * Both delete actions open a shared confirmation Dialog rendered in a
- * portal; the spec clicks `[data-testid="dialog-confirm"]` to commit.
+ * Both paths route through the shared confirm Dialog (`popup.dialog`).
  */
 
 const SEASON: SeasonInsert = {
@@ -69,7 +65,7 @@ test('mount tree: delete season removes it + cascades episodes', async ({
   const seasonItem = await popup.mount.waitForSeason(season.id)
 
   await popup.mount.openItemMenu(seasonItem, 'delete')
-  await popup.mount.confirmDialog()
+  await popup.dialog.confirm()
 
   await expect(seasonItem).toBeHidden({ timeout: 10_000 })
 
@@ -103,7 +99,7 @@ test('mount tree: delete single episode keeps season + siblings', async ({
   await expect(ep1Item).toBeVisible({ timeout: 10_000 })
 
   await popup.mount.openItemMenu(ep1Item, 'delete')
-  await popup.mount.confirmDialog()
+  await popup.dialog.confirm()
 
   await expect(ep1Item).toBeHidden({ timeout: 10_000 })
 
@@ -111,8 +107,8 @@ test('mount tree: delete single episode keeps season + siblings', async ({
     .poll(() => da.episode.get(ep1.id), { timeout: 10_000 })
     .toBeUndefined()
 
-  // Sibling + parent intact — checked in both UI and DB so a regression
-  // that wipes more than intended (or only updates one layer) is caught.
+  // Sibling + parent intact — checked in both UI and DB so a wider-than-
+  // intended delete (or one that updates only one layer) is caught.
   await expect(popup.mount.episodeItem(ep2.id)).toBeVisible()
   await expect(popup.mount.seasonItem(season.id)).toBeVisible()
   const survivor = await da.episode.get(ep2.id)

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -10,19 +10,11 @@ import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Export actions on the DanmakuTree (/mount). Two paths exercised
- * through the season context menu:
- *   - `export` (XML) — downloads a `.xml` payload starting with the
- *     `<i>` root element produced by `commentsToXml`.
- *   - `exportBackup` (JSON) — downloads a `.json` payload that round-
- *     trips through JSON.parse and carries the seeded episode's title
- *     + commentCount.
+ * Export actions on the DanmakuTree (/mount), via the season context menu:
+ *   - `export` — downloads a `.xml` payload with the `<i>` root + comments.
+ *   - `exportBackup` — downloads a `.json` payload with title + commentCount.
  *
- * Each test seeds a season + exactly one episode so the export emits a
- * single-file download (multi-episode exports zip; out of scope here).
- * Downloads are captured via Playwright's `page.waitForEvent('download')`
- * and read from `download.path()` — Playwright auto-manages the temp file
- * and cleans it up when the browser context closes.
+ * Single-episode seasons only; multi-episode exports zip (out of scope).
  */
 
 const SEASON: SeasonInsert = {
@@ -72,10 +64,8 @@ test('mount tree: season export downloads an XML payload', async ({
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)
 
-  // waitForEvent must be armed before the click that triggers it. 20s
-  // (vs the usual 10) gives slack for slow CI runners: the export
-  // mutation fetches via RPC, serializes, then triggers a programmatic
-  // <a download> click.
+  // Arm before the click. Wider timeout — RPC + serialize + programmatic
+  // <a download> click is slow on CI.
   const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'export')
   const download = await downloadPromise

--- a/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
@@ -5,15 +5,10 @@ import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Folder rendering in the DanmakuTree (/mount). Folders are derived from
- * custom episode titles split on '/': a title like
- * `MyFolder/ep1.xml` produces a `folder-MyFolder` node grouping the
- * matching `custom-episode-{id}` rows under the "Local Danmaku" root.
- *
- * The spec seeds two custom episodes sharing a folder prefix via the
- * dev API (no drag/drop, since folders are emergent from titles —
- * there is no separate "create folder" call), then walks the tree:
- * Local Danmaku → folder → child episodes.
+ * Folder rendering on the DanmakuTree (/mount). Folders are emergent from
+ * custom-episode titles split on '/': two episodes titled `MyFolder/epN.xml`
+ * group under a `folder-MyFolder` node. Walks Local Danmaku → folder →
+ * children to assert each level renders.
  */
 
 const FOLDER = 'MyFolder'
@@ -43,8 +38,7 @@ test('mount tree: custom episodes with shared path render under a folder node', 
 
   const popup = await Popup.open(page, extensionId, '/mount')
 
-  // The custom-episode root uses a synthetic `season-custom` id rather
-  // than a DB season id.
+  // `season-custom` is a synthetic id — there's no DB season for customs.
   await popup.mount.expandItem('season-custom')
 
   const folder = popup.mount.folderItem(FOLDER)

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -9,13 +9,10 @@ import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Multi-select bulk delete from the DanmakuTree (/mount). Seeds a season
- * with three episodes, toggles multi-select via the toolbar chip, uses
- * the toolbar's "select all" checkbox to mark every visible episode,
- * then clicks the bottom-bar Delete and confirms the dialog. Asserts
- * all three episode rows are gone from the DB. The parent season has
- * no remaining episodes, so the parent tree row disappears too — this
- * doubles as coverage that bulk delete fires once for the whole batch.
+ * Multi-select bulk delete on the DanmakuTree (/mount). Toggles multi-select,
+ * selects all visible episodes, deletes via the bulk-delete action, confirms
+ * the dialog. Asserts every row + DB record is gone. With no surviving
+ * episodes the parent season row also disappears.
  */
 
 const SEASON: SeasonInsert = {
@@ -71,8 +68,7 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   await popup.mount.waitForSeason(season.id)
   await popup.mount.expandSeason(season.id)
 
-  // Episodes must be in the DOM before "select all" — selectAll() walks
-  // the rendered tree and picks every `kind === 'episode'` node.
+  // Episodes must be rendered before selectAll — it walks the visible tree.
   for (const ep of seeded) {
     await expect(popup.mount.episodeItem(ep.id)).toBeVisible({
       timeout: 10_000,
@@ -82,7 +78,7 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   await popup.mount.enterMultiSelect()
   await popup.mount.selectAll()
   await popup.mount.bulkDelete()
-  await popup.mount.confirmDialog()
+  await popup.dialog.confirm()
 
   for (const ep of seeded) {
     await expect(popup.mount.episodeItem(ep.id)).toBeHidden({

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
@@ -74,8 +74,6 @@ test('mount tree: refresh danmaku fetches new comments for an episode', async ({
 
   await popup.mount.openItemMenu(episodeItem, 'refresh')
 
-  // Refresh writes new comments to db.episode. The seeded episode had 0;
-  // the XML fixture has > 0.
   await expect
     .poll(async () => (await da.episode.get(episode.id))?.commentCount, {
       timeout: 10_000,

--- a/packages/danmaku-anywhere/e2e/specs/sources/bilibili.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/bilibili.spec.ts
@@ -12,11 +12,9 @@ import { applyProfile } from '../../setup/profile'
 
 /**
  * Bilibili happy path in two danmakuTypePreference modes:
- *  - xml:   /x/v1/dm/list.so → text fixture parsed by danmaku-converter
- *  - proto: /x/v2/dm/web/seg.so → real protobuf segment dump exercising
- *           the bundled protobufjs decoder
- * Both share the same search (media_bangumi + media_ft) and season fetch
- * paths via runHappyPath().
+ *  - xml:   /x/v1/dm/list.so → text fixture
+ *  - proto: /x/v2/dm/web/seg.so → protobuf segment (exercises the decoder)
+ * Both share the search + season fetch paths via runHappyPath().
  */
 
 const COMMON = {

--- a/packages/danmaku-anywhere/src/common/components/Dialog/DialogRender.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Dialog/DialogRender.tsx
@@ -91,7 +91,7 @@ export const DialogRender = ({
     }
     if (typeof title === 'string') {
       return (
-        <DialogTitle>
+        <DialogTitle data-testid="dialog-title">
           {title}
           {showCloseButton && (
             <IconButton
@@ -119,13 +119,16 @@ export const DialogRender = ({
     }
     if (typeof content === 'string') {
       return (
-        <DialogContent>
+        <DialogContent data-testid="dialog-content">
           <DialogContentText>{content}</DialogContentText>
         </DialogContent>
       )
     }
     return (
-      <DialogContent sx={(theme) => getScrollBarProps(theme, 0.4)}>
+      <DialogContent
+        data-testid="dialog-content"
+        sx={(theme) => getScrollBarProps(theme, 0.4)}
+      >
         {content}
       </DialogContent>
     )

--- a/packages/danmaku-anywhere/src/common/components/Toast/Toast.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Toast/Toast.tsx
@@ -104,6 +104,8 @@ export const Toast = (props: ToastProps) => {
             },
           }}
           disableWindowBlurListener
+          data-testid="snackbar"
+          data-severity={severity}
           {...props.snackbarProps}
         >
           <AlertWithIndicator

--- a/packages/danmaku-anywhere/src/common/components/Toast/Toast.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Toast/Toast.tsx
@@ -104,8 +104,6 @@ export const Toast = (props: ToastProps) => {
             },
           }}
           disableWindowBlurListener
-          data-testid="snackbar"
-          data-severity={severity}
           {...props.snackbarProps}
         >
           <AlertWithIndicator
@@ -115,6 +113,8 @@ export const Toast = (props: ToastProps) => {
             onMouseLeave={() => unpause(key)}
             pause={paused}
             severity={severity}
+            data-testid="snackbar"
+            data-severity={severity}
             sx={{ width: '100%' }}
             action={
               actionFn ? (


### PR DESCRIPTION
## Summary
- New `packages/danmaku-anywhere/e2e/AGENTS.md` — baseline doctrine for e2e: test taxonomy, the "every spec asserts a user-visible signal" rule, comment rules, hacks-to-avoid, baseline opt-out contracts. Future e2e PRs are reviewed against this.
- New `Toast` POM (`popup.toast`) with `expectVisible` / `expectSuccess` / `expectError`; source change: `data-testid="snackbar"` + `data-severity` on the Toast Alert (Alert unmounts cleanly with the transition, unlike Snackbar root).
- New `ConfirmDialog` POM (`popup.dialog`) with visibility, title/body, confirm/cancel; source change: `data-testid` on Dialog title + content. Migrates `mount/delete.spec.ts` and `mount/multi-select.spec.ts` from `popup.mount.confirmDialog()`; removes the helper from `MountPage`.
- Mechanical comment cleanup across `e2e/`: trimmed spec header JSDocs to ≤6 lines, stripped narration that restates the next line of code, kept load-bearing comments (xvfb hover race, content-script registration async, `waitForEvent` arming, fixtures eager-attach).

New POMs are not retrofitted into existing specs in this PR — that's the next ticket.

## Test plan
- [x] `pnpm type-check` — green
- [x] `pnpm lint` — green (20 pre-existing warnings, no new)
- [x] `pnpm test:e2e` — 20/20 passing locally
- [x] Diff sanity-checked: source changes confined to `data-testid` additions on Snackbar Alert + Dialog title/body