### PR TITLE
(extension) e2e toast retrofit for mount specs [DA-507]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/Toast.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Toast.ts
@@ -35,22 +35,39 @@ export class Toast {
   }
 
   async expectSuccess(
-    matcher: string | RegExp,
+    matcher?: string | RegExp,
     options: ExpectOptions = {}
   ): Promise<void> {
     const { timeout = 5_000 } = options
-    await expect(
-      this.bySeverity('success').filter({ hasText: matcher })
-    ).toBeVisible({ timeout })
+    const locator =
+      matcher === undefined
+        ? this.bySeverity('success')
+        : this.bySeverity('success').filter({ hasText: matcher })
+    await expect(locator.first()).toBeVisible({ timeout })
   }
 
   async expectError(
-    matcher: string | RegExp,
+    matcher?: string | RegExp,
     options: ExpectOptions = {}
   ): Promise<void> {
     const { timeout = 5_000 } = options
-    await expect(
-      this.bySeverity('error').filter({ hasText: matcher })
-    ).toBeVisible({ timeout })
+    const locator =
+      matcher === undefined
+        ? this.bySeverity('error')
+        : this.bySeverity('error').filter({ hasText: matcher })
+    await expect(locator.first()).toBeVisible({ timeout })
+  }
+
+  // Click each visible toast's close button and wait for them to leave the
+  // DOM. Use between back-to-back identical-text mutations so the second
+  // expectSuccess() can't pass on the first toast lingering through its
+  // autoHideDuration (default 3500ms, see toastStore.notify).
+  async dismissAll(timeout = 5_000): Promise<void> {
+    const closeButtons = this.all().getByRole('button', { name: 'Close' })
+    const count = await closeButtons.count()
+    for (let i = 0; i < count; i++) {
+      await closeButtons.first().click()
+    }
+    await expect(this.all()).toHaveCount(0, { timeout })
   }
 }

--- a/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
@@ -72,6 +72,8 @@ test('mount tree: bookmark adds stubs, remove clears them', async ({
 
   await popup.mount.openItemMenu(seasonItem, 'bookmarkAdd')
 
+  await popup.toast.expectSuccess()
+
   await expect(seasonItem).toContainText(/\+1/, { timeout: 10_000 })
 
   await expect
@@ -80,7 +82,11 @@ test('mount tree: bookmark adds stubs, remove clears them', async ({
   const bookmark = await da.bookmark.bySeason(season.id)
   expect(bookmark?.episodes.length).toBe(2)
 
+  await popup.toast.dismissAll()
+
   await popup.mount.openItemMenu(seasonItem, 'bookmarkRemove')
+
+  await popup.toast.expectSuccess()
 
   await expect(seasonItem).not.toContainText(/\+\d+/)
   await expect

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -67,6 +67,8 @@ test('mount tree: delete season removes it + cascades episodes', async ({
   await popup.mount.openItemMenu(seasonItem, 'delete')
   await popup.dialog.confirm()
 
+  await popup.toast.expectSuccess()
+
   await expect(seasonItem).toBeHidden({ timeout: 10_000 })
 
   await expect
@@ -100,6 +102,8 @@ test('mount tree: delete single episode keeps season + siblings', async ({
 
   await popup.mount.openItemMenu(ep1Item, 'delete')
   await popup.dialog.confirm()
+
+  await popup.toast.expectSuccess(/Danmaku Deleted|弹幕已删除/i)
 
   await expect(ep1Item).toBeHidden({ timeout: 10_000 })
 

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -65,12 +65,15 @@ test('mount tree: season export downloads an XML payload', async ({
   const seasonItem = await popup.mount.waitForSeason(season.id)
 
   // Arm before the click. Wider timeout — RPC + serialize + programmatic
-  // <a download> click is slow on CI.
+  // <a download> click is slow on CI. Assert the toast before awaiting
+  // the download so a slow download event can't outrun the toast's
+  // autoHideDuration (~3500ms) and produce a false-negative flake.
   const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'export')
-  const download = await downloadPromise
 
   await popup.toast.expectSuccess(/Export XML successful|导出XML成功/i)
+
+  const download = await downloadPromise
 
   expect(download.suggestedFilename()).toMatch(/\.xml$/i)
 
@@ -101,9 +104,10 @@ test('mount tree: season exportBackup downloads a JSON payload', async ({
 
   const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'exportBackup')
-  const download = await downloadPromise
 
   await popup.toast.expectSuccess(/Export successful|导出成功/i)
+
+  const download = await downloadPromise
 
   expect(download.suggestedFilename()).toMatch(/\.json$/i)
 

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -70,6 +70,8 @@ test('mount tree: season export downloads an XML payload', async ({
   await popup.mount.openItemMenu(seasonItem, 'export')
   const download = await downloadPromise
 
+  await popup.toast.expectSuccess(/Export XML successful|导出XML成功/i)
+
   expect(download.suggestedFilename()).toMatch(/\.xml$/i)
 
   const path = await download.path()
@@ -100,6 +102,8 @@ test('mount tree: season exportBackup downloads a JSON payload', async ({
   const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'exportBackup')
   const download = await downloadPromise
+
+  await popup.toast.expectSuccess(/Export successful|导出成功/i)
 
   expect(download.suggestedFilename()).toMatch(/\.json$/i)
 

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -80,6 +80,8 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   await popup.mount.bulkDelete()
   await popup.dialog.confirm()
 
+  await popup.toast.expectSuccess(/Danmaku Deleted|弹幕已删除/i)
+
   for (const ep of seeded) {
     await expect(popup.mount.episodeItem(ep.id)).toBeHidden({
       timeout: 10_000,

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-metadata.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-metadata.spec.ts
@@ -74,6 +74,8 @@ test('mount tree: refresh metadata replaces stale season info', async ({
 
   await popup.mount.openItemMenu(seasonItem, 'refresh')
 
+  await popup.toast.expectSuccess()
+
   await expect
     .poll(async () => (await da.season.get(seeded.id))?.version, {
       timeout: 10_000,


### PR DESCRIPTION
## Summary

- Retrofit toast assertions into mount-area mutation specs so a regression that silently breaks the user-visible success toast (mutation hook loses `onSuccess`, `useToast` refactor regresses, i18n key gets removed) actually fails the test rather than shipping green. The existing tree-item visibility + DB-state assertions catch data bugs but mask the UI signal the e2e doctrine (`packages/danmaku-anywhere/e2e/AGENTS.md`) explicitly requires.
- Toast assertions placed **between** the user action and the tree/DB assertions, so a toast regression fails fast instead of being masked by correct downstream state.

## Specs retrofitted

| Spec | Toast asserted |
|---|---|
| `delete.spec.ts` — season delete | bare `expectSuccess()` (`common.success` — generic, severity is the signal) |
| `delete.spec.ts` — episode delete | `/Danmaku Deleted\|弹幕已删除/i` (distinctive `danmaku.alert.deleted`) |
| `bookmark.spec.ts` — add + remove | bare `expectSuccess()` after each, with `dismissAll()` between |
| `refresh-metadata.spec.ts` | bare `expectSuccess()` (`common.success`) |
| `multi-select.spec.ts` | `/Danmaku Deleted\|弹幕已删除/i` (one toast — `selectAll` picks only episode ids → one `useDeleteEpisode.mutateAsync` call) |
| `export.spec.ts` — XML | `/Export XML successful\|导出XML成功/i` |
| `export.spec.ts` — backup | `/Export successful\|导出成功/i` (verified not to cross-match the XML message) |

## Not modified (intentional)

- **`refresh-danmaku.spec.ts`** — `useFetchDanmaku` emits an error toast only; no success-path toast to assert. Adding one would require a source change (out of scope per task).
- **`folder.spec.ts`** — read-only, no mutation.

## Toast POM changes (`e2e/pom/Toast.ts`)

- `expectSuccess` / `expectError` matchers are now optional. Use the bare form when text adds no signal beyond severity (per doctrine: `popup.toast.expectSuccess(matcher?)`).
- Locator uses `.first()` for existential semantics — "at least one matching success toast is visible" — so a stacked carryover toast from an earlier step doesn't trigger a Playwright strict-mode violation.
- New `dismissAll()` for back-to-back identical-text mutations (bookmark add → remove both fire `common.success`). Without it, the second `expectSuccess()` could pass on the first toast still visible during its autoHideDuration (~3500ms in `toastStore.notify`).

## Verify

- `pnpm type-check` ✓
- `pnpm lint` ✓ (no new warnings)
- `pnpm test:e2e` ✓ — all 20 e2e specs pass (mount: 9/9)
- `pnpm test` ✓ — all 273 unit tests pass