### PR TITLE
(extension) move default FAB position farther from corner [DA-458]

### DIFF
--- a/packages/danmaku-anywhere/src/content/controller/ui/components/DraggableContainer.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/components/DraggableContainer.tsx
@@ -145,7 +145,6 @@ export const DraggableContainer = ({
       anchorEl={anchorEl}
       popperRef={setPopperInst}
       placement="top-start"
-      popperOptions={{ strategy: 'fixed' }}
       sx={{
         zIndex: 1402,
         userSelect: isDragging ? 'none' : 'auto',

--- a/packages/danmaku-anywhere/src/content/controller/ui/components/DraggableContainer.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/components/DraggableContainer.tsx
@@ -145,6 +145,7 @@ export const DraggableContainer = ({
       anchorEl={anchorEl}
       popperRef={setPopperInst}
       placement="top-start"
+      popperOptions={{ strategy: 'fixed' }}
       sx={{
         zIndex: 1402,
         userSelect: isDragging ? 'none' : 'auto',

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/FloatingButton.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/FloatingButton.tsx
@@ -37,9 +37,6 @@ const StyledFab = styled(Fab, {
 })
 
 const useInitialAnchor = () => {
-  // Keep some margin from the viewport edges: on sites whose body height is
-  // close to the viewport, an edge-hugging FAB can push the document past the
-  // viewport, triggering a scrollbar add/remove loop and page shake.
   const left = 32
   const bottom = window.innerHeight - 128
 

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/FloatingButton.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/FloatingButton.tsx
@@ -37,9 +37,11 @@ const StyledFab = styled(Fab, {
 })
 
 const useInitialAnchor = () => {
-  // bottom 12, left 3
-  const left = 24
-  const bottom = window.innerHeight - 96
+  // Keep some margin from the viewport edges: on sites whose body height is
+  // close to the viewport, an edge-hugging FAB can push the document past the
+  // viewport, triggering a scrollbar add/remove loop and page shake.
+  const left = 32
+  const bottom = window.innerHeight - 128
 
   return useRef(createVirtualElement(left, bottom))
 }


### PR DESCRIPTION
## Summary

- Bump the default FAB anchor from `(24, innerHeight - 96)` to `(32, innerHeight - 128)` so the floating button sits a bit farther from the bottom-left corner on first render.
- Fixes user-reported page shake on 移动云盘 (yun.139.com) where the edge-hugging default FAB caused the document to overflow by a few pixels, triggering a scrollbar appear → viewport shrink → scrollbar disappear loop.
- Replaces the stale `// bottom 12, left 3` comment with a short note explaining the WHY.

## Notes

- Users without a persisted `fabOffset` in LocalStorage get the new default.
- Users who previously dragged the FAB keep their persisted offset; since the offset is relative to the anchor, their FAB will shift by the same delta (~8px right, ~32px up). Minor visual nudge for existing users.
- Follow-up candidate: switch the FAB's MUI Popper to `strategy: 'fixed'` so the FAB no longer contributes to document layout regardless of position — eliminates the underlying scrollbar-shake class of bugs more thoroughly. Out of scope for this hotfix.

## Test plan

- [ ] Manual: open yun.139.com (Yidong cloud disk) with the extension, default FAB shown — confirm no scrollbar flicker / page shake.
- [ ] Sanity: FAB still appears in expected position on a normal video page (e.g. Plex/Jellyfin).
- [ ] Existing persisted FAB offset is respected (drag, reload, FAB returns to dragged spot).