### PR TITLE
(extension) import danmaku from a network URL [DA-509]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/ImportResultDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ImportResultDialog.ts
@@ -1,0 +1,28 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+const SELECTORS = {
+  confirm: '[data-testid="import-result-confirm"]',
+}
+
+interface ExpectOptions {
+  timeout?: number
+}
+
+export class ImportResultDialog {
+  constructor(private readonly page: Page) {}
+
+  get confirmButton(): Locator {
+    return this.page.locator(SELECTORS.confirm)
+  }
+
+  async expectVisible(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.confirmButton).toBeVisible({ timeout })
+  }
+
+  async confirm(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await this.expectVisible({ timeout })
+    await this.confirmButton.click({ timeout })
+  }
+}

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -53,6 +53,13 @@ export class MountPage {
     await expect(menuItem).toBeHidden({ timeout: 5_000 })
   }
 
+  async openToolbarMenu(actionId: string): Promise<void> {
+    await this.page.locator(SELECTORS.drilldownButton).click()
+    const menuItem = this.page.locator(SELECTORS.menuItem(actionId))
+    await menuItem.click()
+    await expect(menuItem).toBeHidden({ timeout: 5_000 })
+  }
+
   async expandSeason(seasonId: number): Promise<void> {
     const item = this.seasonItem(seasonId)
     if ((await item.getAttribute('aria-expanded')) === 'true') {

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { ConfirmDialog } from './ConfirmDialog'
+import { ImportResultDialog } from './ImportResultDialog'
 import { MountPage } from './MountPage'
 import { SearchPage } from './SearchPage'
 import { SeasonDetailsPage } from './SeasonDetailsPage'
@@ -13,6 +14,7 @@ export class Popup {
   readonly toast: Toast
   readonly dialog: ConfirmDialog
   readonly urlImport: UrlImportDialog
+  readonly importResult: ImportResultDialog
 
   private constructor(page: Page) {
     this.mount = new MountPage(page)
@@ -21,6 +23,7 @@ export class Popup {
     this.toast = new Toast(page)
     this.dialog = new ConfirmDialog(page)
     this.urlImport = new UrlImportDialog(page)
+    this.importResult = new ImportResultDialog(page)
   }
 
   static async open(

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -4,6 +4,7 @@ import { MountPage } from './MountPage'
 import { SearchPage } from './SearchPage'
 import { SeasonDetailsPage } from './SeasonDetailsPage'
 import { Toast } from './Toast'
+import { UrlImportDialog } from './UrlImportDialog'
 
 export class Popup {
   readonly mount: MountPage
@@ -11,6 +12,7 @@ export class Popup {
   readonly seasonDetails: SeasonDetailsPage
   readonly toast: Toast
   readonly dialog: ConfirmDialog
+  readonly urlImport: UrlImportDialog
 
   private constructor(page: Page) {
     this.mount = new MountPage(page)
@@ -18,6 +20,7 @@ export class Popup {
     this.seasonDetails = new SeasonDetailsPage(page)
     this.toast = new Toast(page)
     this.dialog = new ConfirmDialog(page)
+    this.urlImport = new UrlImportDialog(page)
   }
 
   static async open(

--- a/packages/danmaku-anywhere/e2e/pom/UrlImportDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/UrlImportDialog.ts
@@ -4,6 +4,7 @@ const SELECTORS = {
   dialog: '[data-testid="url-import-dialog"]',
   input: '[data-testid="url-import-input"]',
   submit: '[data-testid="url-import-submit"]',
+  helper: '[data-testid="url-import-helper"]',
 }
 
 interface ExpectOptions {
@@ -23,6 +24,18 @@ export class UrlImportDialog {
 
   get submitButton(): Locator {
     return this.page.locator(SELECTORS.submit)
+  }
+
+  get helper(): Locator {
+    return this.page.locator(SELECTORS.helper)
+  }
+
+  async expectHelperText(
+    matcher: string | RegExp,
+    options: ExpectOptions = {}
+  ): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.helper).toContainText(matcher, { timeout })
   }
 
   async expectVisible(options: ExpectOptions = {}): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/UrlImportDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/UrlImportDialog.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 
 const SELECTORS = {
-  dialog: '[data-testid="url-import-dialog"]',
+  title: '[data-testid="url-import-title"]',
   input: '[data-testid="url-import-input"]',
   submit: '[data-testid="url-import-submit"]',
   helper: '[data-testid="url-import-helper"]',
@@ -14,8 +14,8 @@ interface ExpectOptions {
 export class UrlImportDialog {
   constructor(private readonly page: Page) {}
 
-  get root(): Locator {
-    return this.page.locator(SELECTORS.dialog)
+  get title(): Locator {
+    return this.page.locator(SELECTORS.title)
   }
 
   get input(): Locator {
@@ -40,12 +40,12 @@ export class UrlImportDialog {
 
   async expectVisible(options: ExpectOptions = {}): Promise<void> {
     const { timeout = 5_000 } = options
-    await expect(this.root).toBeVisible({ timeout })
+    await expect(this.title).toBeVisible({ timeout })
   }
 
   async expectHidden(options: ExpectOptions = {}): Promise<void> {
     const { timeout = 5_000 } = options
-    await expect(this.root).toBeHidden({ timeout })
+    await expect(this.title).toBeHidden({ timeout })
   }
 
   async fillUrl(url: string): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/UrlImportDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/UrlImportDialog.ts
@@ -1,0 +1,45 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+const SELECTORS = {
+  dialog: '[data-testid="url-import-dialog"]',
+  input: '[data-testid="url-import-input"]',
+  submit: '[data-testid="url-import-submit"]',
+}
+
+interface ExpectOptions {
+  timeout?: number
+}
+
+export class UrlImportDialog {
+  constructor(private readonly page: Page) {}
+
+  get root(): Locator {
+    return this.page.locator(SELECTORS.dialog)
+  }
+
+  get input(): Locator {
+    return this.page.locator(SELECTORS.input)
+  }
+
+  get submitButton(): Locator {
+    return this.page.locator(SELECTORS.submit)
+  }
+
+  async expectVisible(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.root).toBeVisible({ timeout })
+  }
+
+  async expectHidden(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 5_000 } = options
+    await expect(this.root).toBeHidden({ timeout })
+  }
+
+  async fillUrl(url: string): Promise<void> {
+    await this.input.fill(url)
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click()
+  }
+}

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
@@ -7,8 +7,10 @@ import { applyProfile } from '../../setup/profile'
 /**
  * Import from URL: drives the toolbar 3-dot menu → URL dialog → fetch a
  * mocked .xml URL → ImportResultDialog → Confirm Import. Asserts the URL
- * dialog closes after submit, the success toast renders the file count,
- * and the custom episode lands in the DB with the URL's basename as title.
+ * dialog closes after submit, the success Alert renders inside the result
+ * dialog, and the custom episode lands in the DB with the URL's basename
+ * as title. Second test covers the 404 path: URL dialog stays open with
+ * the status surfaced in the helperText.
  */
 
 const FETCH_URL = 'https://danmaku.invalid/episode.xml'
@@ -46,9 +48,13 @@ test('mount toolbar: import from URL fetches a mocked xml and stages a custom ep
   await expect(confirm).toBeVisible({ timeout: 5_000 })
   await confirm.click()
 
-  await popup.toast.expectSuccess(/Successfully imported|成功导入/, {
-    timeout: 10_000,
-  })
+  // ImportResultContent renders an inline MUI Alert (role="alert") on
+  // success, not a snackbar toast.
+  await expect(
+    page.locator('[role="alert"]').filter({
+      hasText: /Successfully imported|成功导入/,
+    })
+  ).toBeVisible({ timeout: 10_000 })
 
   const customs = await da.episode.listCustom()
   expect(customs).toHaveLength(1)
@@ -56,31 +62,40 @@ test('mount toolbar: import from URL fetches a mocked xml and stages a custom ep
   expect(customs[0].commentCount).toBeGreaterThan(0)
 })
 
-test('mount toolbar: import from URL renders an error when the URL 404s', async ({
-  context,
-  page,
-  extensionId,
-}) => {
-  const da = await getDaClient(context)
-  await applyProfile(context, da, {
-    network: [
-      {
-        pattern: FETCH_URL,
-        respond: (route) =>
-          route.fulfill({ status: 404, contentType: 'text/plain', body: '' }),
-      },
-    ],
+// Chrome logs a "Failed to load resource" console error for any non-2xx
+// fetch — that's the production browser doing its job. The test asserts on
+// the dialog state, not the absence of the log line.
+test.describe(() => {
+  test.use({
+    expectedConsoleErrors: [/Failed to load resource.*404.*danmaku\.invalid/],
   })
 
-  const popup = await Popup.open(page, extensionId, '/mount')
-  await popup.mount.openToolbarMenu('importUrl')
+  test('mount toolbar: import from URL renders an error when the URL 404s', async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    const da = await getDaClient(context)
+    await applyProfile(context, da, {
+      network: [
+        {
+          pattern: FETCH_URL,
+          respond: (route) =>
+            route.fulfill({ status: 404, contentType: 'text/plain', body: '' }),
+        },
+      ],
+    })
 
-  await popup.urlImport.expectVisible()
-  await popup.urlImport.fillUrl(FETCH_URL)
-  await popup.urlImport.submit()
+    const popup = await Popup.open(page, extensionId, '/mount')
+    await popup.mount.openToolbarMenu('importUrl')
 
-  await expect(popup.urlImport.root).toBeVisible()
-  await expect(popup.urlImport.root).toContainText(/404/, { timeout: 5_000 })
+    await popup.urlImport.expectVisible()
+    await popup.urlImport.fillUrl(FETCH_URL)
+    await popup.urlImport.submit()
 
-  expect(await da.episode.listCustom()).toHaveLength(0)
+    await expect(popup.urlImport.root).toBeVisible()
+    await popup.urlImport.expectHelperText(/404/)
+
+    expect(await da.episode.listCustom()).toHaveLength(0)
+  })
 })

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
@@ -1,0 +1,86 @@
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { loadTextFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Import from URL: drives the toolbar 3-dot menu → URL dialog → fetch a
+ * mocked .xml URL → ImportResultDialog → Confirm Import. Asserts the URL
+ * dialog closes after submit, the success toast renders the file count,
+ * and the custom episode lands in the DB with the URL's basename as title.
+ */
+
+const FETCH_URL = 'https://danmaku.invalid/episode.xml'
+
+test('mount toolbar: import from URL fetches a mocked xml and stages a custom episode', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    network: [
+      {
+        pattern: FETCH_URL,
+        respond: (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'application/xml',
+            body: loadTextFixture('bilibili-xml.xml'),
+          }),
+      },
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  await popup.mount.openToolbarMenu('importUrl')
+
+  await popup.urlImport.expectVisible()
+  await popup.urlImport.fillUrl(FETCH_URL)
+  await popup.urlImport.submit()
+
+  await popup.urlImport.expectHidden()
+
+  const confirm = page.locator('[data-testid="import-result-confirm"]')
+  await expect(confirm).toBeVisible({ timeout: 5_000 })
+  await confirm.click()
+
+  await popup.toast.expectSuccess(/Successfully imported|成功导入/, {
+    timeout: 10_000,
+  })
+
+  const customs = await da.episode.listCustom()
+  expect(customs).toHaveLength(1)
+  expect(customs[0].title).toBe('episode.xml')
+  expect(customs[0].commentCount).toBeGreaterThan(0)
+})
+
+test('mount toolbar: import from URL renders an error when the URL 404s', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    network: [
+      {
+        pattern: FETCH_URL,
+        respond: (route) =>
+          route.fulfill({ status: 404, contentType: 'text/plain', body: '' }),
+      },
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  await popup.mount.openToolbarMenu('importUrl')
+
+  await popup.urlImport.expectVisible()
+  await popup.urlImport.fillUrl(FETCH_URL)
+  await popup.urlImport.submit()
+
+  await expect(popup.urlImport.root).toBeVisible()
+  await expect(popup.urlImport.root).toContainText(/404/, { timeout: 5_000 })
+
+  expect(await da.episode.listCustom()).toHaveLength(0)
+})

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
@@ -9,8 +9,8 @@ import { applyProfile } from '../../setup/profile'
  * mocked .xml URL → ImportResultDialog → Confirm Import. Asserts the URL
  * dialog closes after submit, the success Alert renders inside the result
  * dialog, and the custom episode lands in the DB with the URL's basename
- * as title. Second test covers the 404 path: URL dialog stays open with
- * the status surfaced in the helperText.
+ * as title. Second test covers the validation path: a bad-scheme URL
+ * disables submit and surfaces the reason in the helperText (no network).
  */
 
 const FETCH_URL = 'https://danmaku.invalid/episode.xml'
@@ -43,13 +43,8 @@ test('mount toolbar: import from URL fetches a mocked xml and stages a custom ep
   await popup.urlImport.submit()
 
   await popup.urlImport.expectHidden()
+  await popup.importResult.confirm()
 
-  const confirm = page.locator('[data-testid="import-result-confirm"]')
-  await expect(confirm).toBeVisible({ timeout: 5_000 })
-  await confirm.click()
-
-  // ImportResultContent renders an inline MUI Alert (role="alert") on
-  // success, not a snackbar toast.
   await expect(
     page.locator('[role="alert"]').filter({
       hasText: /Successfully imported|成功导入/,
@@ -62,40 +57,22 @@ test('mount toolbar: import from URL fetches a mocked xml and stages a custom ep
   expect(customs[0].commentCount).toBeGreaterThan(0)
 })
 
-// Chrome logs a "Failed to load resource" console error for any non-2xx
-// fetch — that's the production browser doing its job. The test asserts on
-// the dialog state, not the absence of the log line.
-test.describe(() => {
-  test.use({
-    expectedConsoleErrors: [/Failed to load resource.*404.*danmaku\.invalid/],
-  })
+test('mount toolbar: URL dialog surfaces a validation error in the helperText', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {})
 
-  test('mount toolbar: import from URL renders an error when the URL 404s', async ({
-    context,
-    page,
-    extensionId,
-  }) => {
-    const da = await getDaClient(context)
-    await applyProfile(context, da, {
-      network: [
-        {
-          pattern: FETCH_URL,
-          respond: (route) =>
-            route.fulfill({ status: 404, contentType: 'text/plain', body: '' }),
-        },
-      ],
-    })
+  const popup = await Popup.open(page, extensionId, '/mount')
+  await popup.mount.openToolbarMenu('importUrl')
 
-    const popup = await Popup.open(page, extensionId, '/mount')
-    await popup.mount.openToolbarMenu('importUrl')
+  await popup.urlImport.expectVisible()
+  await popup.urlImport.fillUrl('ftp://example.com/file.xml')
 
-    await popup.urlImport.expectVisible()
-    await popup.urlImport.fillUrl(FETCH_URL)
-    await popup.urlImport.submit()
+  await popup.urlImport.expectHelperText(/http and https|http 和 https/)
+  await expect(popup.urlImport.submitButton).toBeDisabled()
 
-    await expect(popup.urlImport.root).toBeVisible()
-    await popup.urlImport.expectHelperText(/404/)
-
-    expect(await da.episode.listCustom()).toHaveLength(0)
-  })
+  expect(await da.episode.listCustom()).toHaveLength(0)
 })

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/MountPageContent.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/MountPageContent.tsx
@@ -2,7 +2,7 @@ import type {
   DanmakuSourceType,
   GenericEpisodeLite,
 } from '@danmaku-anywhere/danmaku-converter'
-import { UploadFile } from '@mui/icons-material'
+import { CloudDownload, UploadFile } from '@mui/icons-material'
 import type { ReactElement } from 'react'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,6 +15,7 @@ import {
   DanmakuTree,
   type DanmakuTreeApi,
 } from '@/common/components/DanmakuSelector/tree/DanmakuTree'
+import { UrlImportDialog } from '@/common/components/DanmakuSelector/UrlImportDialog'
 import { useDanmakuTreeActions } from '@/common/components/DanmakuSelector/useDanmakuTreeActions'
 import { useImportFlow } from '@/common/components/DanmakuSelector/useImportFlow'
 import { ImportResultDialog } from '@/common/components/ImportPageCore/ImportResultDialog'
@@ -93,6 +94,13 @@ export const MountPageContent = ({
         label: t('importPage.importFolder', 'Import Danmaku Folder'),
         icon: <UploadFile />,
         onClick: importFlow.openFolderInput,
+      },
+      {
+        kind: 'item',
+        id: 'importUrl',
+        label: t('importPage.importFromUrl', 'Import from URL'),
+        icon: <CloudDownload />,
+        onClick: importFlow.openUrlInput,
       },
     ],
     [importFlow, t]
@@ -191,6 +199,12 @@ export const MountPageContent = ({
           onDelete={treeActions.handleDelete}
         />
       </CaptureKeypress>
+
+      <UrlImportDialog
+        open={importFlow.urlDialogOpen}
+        onClose={importFlow.closeUrlInput}
+        onSubmit={importFlow.importFromUrl}
+      />
 
       <ImportResultDialog
         open={importFlow.showResultDialog}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
@@ -106,8 +106,6 @@ export function UrlImportDialog({
   const validation = validateImportUrl(url)
   const canSubmit = url.length > 0 && validation.ok && !mutation.isPending
 
-  // Surface validation errors inline once the user has typed something
-  // invalid. The submit button is also disabled — this just tells them why.
   const validationError: DisplayedError | null =
     url.length > 0 && !validation.ok
       ? { code: validation.reason, params: {} }
@@ -137,7 +135,7 @@ export function UrlImportDialog({
       onClose={handleClose}
       container={dialogContainer}
     >
-      <DialogTitle data-testid="url-import-dialog">
+      <DialogTitle data-testid="url-import-title">
         {t('importPage.urlDialog.title', 'Import from URL')}
       </DialogTitle>
       <DialogContent>

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
@@ -10,6 +10,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDialogStore } from '@/common/components/Dialog/dialogStore'
+import { i18n } from '@/common/localization/i18n'
 import {
   ImportFromUrlError,
   type ImportFromUrlErrorCode,
@@ -29,20 +30,39 @@ type DisplayedError = {
   params: Record<string, string | number>
 }
 
-// Static key declarations for i18next-cli (it doesn't trace t(map[var])):
-// t('importPage.urlDialog.errors.invalid_url', 'Not a valid URL.')
-// t('importPage.urlDialog.errors.invalid_scheme', 'Only http and https URLs are supported.')
-// t('importPage.urlDialog.errors.unsupported_extension', 'URL must point to a .json, .xml, .bin, or .zip file.')
-// t('importPage.urlDialog.errors.fetch_failed', 'Failed to fetch the URL.')
-// t('importPage.urlDialog.errors.http_error', 'Server returned {{status}}.')
-// t('importPage.urlDialog.errors.size_limit_exceeded', 'File is larger than the {{limit}} limit.')
-const ERROR_MESSAGE_KEY: Record<DisplayedErrorCode, string> = {
-  invalid_url: 'importPage.urlDialog.errors.invalid_url',
-  invalid_scheme: 'importPage.urlDialog.errors.invalid_scheme',
-  unsupported_extension: 'importPage.urlDialog.errors.unsupported_extension',
-  fetch_failed: 'importPage.urlDialog.errors.fetch_failed',
-  http_error: 'importPage.urlDialog.errors.http_error',
-  size_limit_exceeded: 'importPage.urlDialog.errors.size_limit_exceeded',
+const ERROR_MESSAGE: Record<
+  DisplayedErrorCode,
+  (params: Record<string, string | number>) => string
+> = {
+  invalidUrl: () =>
+    i18n.t('importPage.urlDialog.errors.invalidUrl', 'Not a valid URL.'),
+  invalidScheme: () =>
+    i18n.t(
+      'importPage.urlDialog.errors.invalidScheme',
+      'Only http and https URLs are supported.'
+    ),
+  unsupportedExtension: () =>
+    i18n.t(
+      'importPage.urlDialog.errors.unsupportedExtension',
+      'URL must point to a .json, .xml, .bin, or .zip file.'
+    ),
+  fetchFailed: () =>
+    i18n.t(
+      'importPage.urlDialog.errors.fetchFailed',
+      'Failed to fetch the URL.'
+    ),
+  httpError: (params) =>
+    i18n.t(
+      'importPage.urlDialog.errors.httpError',
+      'Server returned {{status}}.',
+      params
+    ),
+  sizeLimitExceeded: (params) =>
+    i18n.t(
+      'importPage.urlDialog.errors.sizeLimitExceeded',
+      'File is larger than the {{limit}} limit.',
+      params
+    ),
 }
 
 export function UrlImportDialog({
@@ -70,7 +90,7 @@ export function UrlImportDialog({
         }
         return
       }
-      setError({ code: 'fetch_failed', params: {} })
+      setError({ code: 'fetchFailed', params: {} })
     },
   })
 
@@ -109,7 +129,7 @@ export function UrlImportDialog({
       onClose={handleClose}
       container={dialogContainer}
     >
-      <DialogTitle>
+      <DialogTitle data-testid="url-import-dialog">
         {t('importPage.urlDialog.title', 'Import from URL')}
       </DialogTitle>
       <DialogContent>
@@ -135,13 +155,14 @@ export function UrlImportDialog({
           error={error !== null}
           helperText={
             error
-              ? t(ERROR_MESSAGE_KEY[error.code], error.params)
+              ? ERROR_MESSAGE[error.code](error.params)
               : t(
                   'importPage.urlDialog.urlHelper',
                   'Direct link to a .json, .xml, .bin, or .zip file'
                 )
           }
           disabled={mutation.isPending}
+          slotProps={{ htmlInput: { 'data-testid': 'url-import-input' } }}
         />
       </DialogContent>
       <DialogActions>
@@ -154,6 +175,7 @@ export function UrlImportDialog({
           color="primary"
           disabled={!canSubmit}
           loading={mutation.isPending}
+          data-testid="url-import-submit"
         >
           {t('importPage.urlDialog.submit', 'Fetch & Import')}
         </Button>

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
@@ -1,0 +1,163 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@mui/material'
+import { useMutation } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDialogStore } from '@/common/components/Dialog/dialogStore'
+import {
+  ImportFromUrlError,
+  type ImportFromUrlErrorCode,
+  validateImportUrl,
+} from './fetchUrlAsFile'
+
+type UrlImportDialogProps = {
+  open: boolean
+  onClose: () => void
+  onSubmit: (url: string, signal: AbortSignal) => Promise<void>
+}
+
+type DisplayedErrorCode = Exclude<ImportFromUrlErrorCode, 'aborted'>
+
+type DisplayedError = {
+  code: DisplayedErrorCode
+  params: Record<string, string | number>
+}
+
+// Static key declarations for i18next-cli (it doesn't trace t(map[var])):
+// t('importPage.urlDialog.errors.invalid_url', 'Not a valid URL.')
+// t('importPage.urlDialog.errors.invalid_scheme', 'Only http and https URLs are supported.')
+// t('importPage.urlDialog.errors.unsupported_extension', 'URL must point to a .json, .xml, .bin, or .zip file.')
+// t('importPage.urlDialog.errors.fetch_failed', 'Failed to fetch the URL.')
+// t('importPage.urlDialog.errors.http_error', 'Server returned {{status}}.')
+// t('importPage.urlDialog.errors.size_limit_exceeded', 'File is larger than the {{limit}} limit.')
+const ERROR_MESSAGE_KEY: Record<DisplayedErrorCode, string> = {
+  invalid_url: 'importPage.urlDialog.errors.invalid_url',
+  invalid_scheme: 'importPage.urlDialog.errors.invalid_scheme',
+  unsupported_extension: 'importPage.urlDialog.errors.unsupported_extension',
+  fetch_failed: 'importPage.urlDialog.errors.fetch_failed',
+  http_error: 'importPage.urlDialog.errors.http_error',
+  size_limit_exceeded: 'importPage.urlDialog.errors.size_limit_exceeded',
+}
+
+export function UrlImportDialog({
+  open,
+  onClose,
+  onSubmit,
+}: UrlImportDialogProps) {
+  const { t } = useTranslation()
+  const dialogContainer = useDialogStore.use.container()
+
+  const [url, setUrl] = useState('')
+  const [error, setError] = useState<DisplayedError | null>(null)
+  const controllerRef = useRef<AbortController | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: async (value: string) => {
+      const controller = new AbortController()
+      controllerRef.current = controller
+      await onSubmit(value, controller.signal)
+    },
+    onError: (err) => {
+      if (err instanceof ImportFromUrlError) {
+        if (err.code !== 'aborted') {
+          setError({ code: err.code, params: err.params })
+        }
+        return
+      }
+      setError({ code: 'fetch_failed', params: {} })
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      setUrl('')
+      setError(null)
+      controllerRef.current = null
+      mutation.reset()
+    }
+  }, [open])
+
+  const validation = validateImportUrl(url)
+  const canSubmit = url.length > 0 && validation.ok && !mutation.isPending
+
+  const handleSubmit = () => {
+    if (!canSubmit) {
+      return
+    }
+    setError(null)
+    mutation.mutate(url)
+  }
+
+  const handleClose = () => {
+    if (mutation.isPending) {
+      controllerRef.current?.abort()
+    }
+    onClose()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      maxWidth="sm"
+      fullWidth
+      onClose={handleClose}
+      container={dialogContainer}
+    >
+      <DialogTitle>
+        {t('importPage.urlDialog.title', 'Import from URL')}
+      </DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          fullWidth
+          margin="dense"
+          label={t('importPage.urlDialog.urlLabel', 'URL')}
+          placeholder="https://"
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value)
+            if (error) {
+              setError(null)
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && canSubmit) {
+              e.preventDefault()
+              handleSubmit()
+            }
+          }}
+          error={error !== null}
+          helperText={
+            error
+              ? t(ERROR_MESSAGE_KEY[error.code], error.params)
+              : t(
+                  'importPage.urlDialog.urlHelper',
+                  'Direct link to a .json, .xml, .bin, or .zip file'
+                )
+          }
+          disabled={mutation.isPending}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="primary">
+          {t('common.cancel', 'Cancel')}
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          color="primary"
+          disabled={!canSubmit}
+          loading={mutation.isPending}
+        >
+          {t('importPage.urlDialog.submit', 'Fetch & Import')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
@@ -162,12 +162,14 @@ export function UrlImportDialog({
           }}
           error={displayedError !== null}
           helperText={
-            displayedError
-              ? ERROR_MESSAGE[displayedError.code](displayedError.params)
-              : t(
-                  'importPage.urlDialog.urlHelper',
-                  'Direct link to a .json, .xml, .bin, or .zip file'
-                )
+            <span data-testid="url-import-helper">
+              {displayedError
+                ? ERROR_MESSAGE[displayedError.code](displayedError.params)
+                : t(
+                    'importPage.urlDialog.urlHelper',
+                    'Direct link to a .json, .xml, .bin, or .zip file'
+                  )}
+            </span>
           }
           disabled={mutation.isPending}
           slotProps={{ htmlInput: { 'data-testid': 'url-import-input' } }}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/UrlImportDialog.tsx
@@ -106,6 +106,14 @@ export function UrlImportDialog({
   const validation = validateImportUrl(url)
   const canSubmit = url.length > 0 && validation.ok && !mutation.isPending
 
+  // Surface validation errors inline once the user has typed something
+  // invalid. The submit button is also disabled — this just tells them why.
+  const validationError: DisplayedError | null =
+    url.length > 0 && !validation.ok
+      ? { code: validation.reason, params: {} }
+      : null
+  const displayedError = error ?? validationError
+
   const handleSubmit = () => {
     if (!canSubmit) {
       return
@@ -152,10 +160,10 @@ export function UrlImportDialog({
               handleSubmit()
             }
           }}
-          error={error !== null}
+          error={displayedError !== null}
           helperText={
-            error
-              ? ERROR_MESSAGE[error.code](error.params)
+            displayedError
+              ? ERROR_MESSAGE[displayedError.code](displayedError.params)
               : t(
                   'importPage.urlDialog.urlHelper',
                   'Direct link to a .json, .xml, .bin, or .zip file'

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.test.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.test.ts
@@ -19,56 +19,56 @@ afterEach(() => {
 })
 
 describe('validateImportUrl', () => {
-  it('rejects an empty string as invalid_url', () => {
-    expect(validateImportUrl('')).toEqual({ ok: false, reason: 'invalid_url' })
+  it('rejects an empty string as invalidUrl', () => {
+    expect(validateImportUrl('')).toEqual({ ok: false, reason: 'invalidUrl' })
   })
 
-  it('rejects a malformed URL as invalid_url', () => {
+  it('rejects a malformed URL as invalidUrl', () => {
     expect(validateImportUrl('not a url')).toEqual({
       ok: false,
-      reason: 'invalid_url',
+      reason: 'invalidUrl',
     })
   })
 
-  it('rejects file:// URLs as invalid_scheme', () => {
+  it('rejects file:// URLs as invalidScheme', () => {
     expect(validateImportUrl('file:///tmp/danmaku.xml')).toEqual({
       ok: false,
-      reason: 'invalid_scheme',
+      reason: 'invalidScheme',
     })
   })
 
-  it('rejects data: URLs as invalid_scheme', () => {
+  it('rejects data: URLs as invalidScheme', () => {
     expect(validateImportUrl('data:application/json,{}')).toEqual({
       ok: false,
-      reason: 'invalid_scheme',
+      reason: 'invalidScheme',
     })
   })
 
-  it('rejects chrome-extension:// URLs as invalid_scheme', () => {
+  it('rejects chrome-extension:// URLs as invalidScheme', () => {
     expect(validateImportUrl('chrome-extension://abc/file.xml')).toEqual({
       ok: false,
-      reason: 'invalid_scheme',
+      reason: 'invalidScheme',
     })
   })
 
   it('rejects URLs without a recognized extension', () => {
     expect(validateImportUrl('https://example.com/file.txt')).toEqual({
       ok: false,
-      reason: 'unsupported_extension',
+      reason: 'unsupportedExtension',
     })
   })
 
   it('rejects URLs whose basename is "."', () => {
     expect(validateImportUrl('https://example.com/some/path/.')).toEqual({
       ok: false,
-      reason: 'unsupported_extension',
+      reason: 'unsupportedExtension',
     })
   })
 
   it('rejects URLs whose basename is empty', () => {
     expect(validateImportUrl('https://example.com/')).toEqual({
       ok: false,
-      reason: 'unsupported_extension',
+      reason: 'unsupportedExtension',
     })
   })
 
@@ -146,18 +146,18 @@ describe('fetchUrlAsFile', () => {
     expect(bin.type).toBe('application/octet-stream')
   })
 
-  it('rejects http_error with status for a non-2xx response', async () => {
+  it('rejects httpError with status for a non-2xx response', async () => {
     mockFetchOnce(new Response('nope', { status: 404 }))
 
     const err = await fetchUrlAsFile('https://example.com/a.json').catch(
       (e) => e
     )
     expect(err).toBeInstanceOf(ImportFromUrlError)
-    expect((err as ImportFromUrlError).code).toBe('http_error')
+    expect((err as ImportFromUrlError).code).toBe('httpError')
     expect((err as ImportFromUrlError).params).toEqual({ status: 404 })
   })
 
-  it('rejects fetch_failed when fetch itself throws', async () => {
+  it('rejects fetchFailed when fetch itself throws', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockRejectedValueOnce(new TypeError('network down'))
@@ -167,7 +167,7 @@ describe('fetchUrlAsFile', () => {
       (e) => e
     )
     expect(err).toBeInstanceOf(ImportFromUrlError)
-    expect((err as ImportFromUrlError).code).toBe('fetch_failed')
+    expect((err as ImportFromUrlError).code).toBe('fetchFailed')
   })
 
   it('rejects aborted when the signal is aborted mid-fetch', async () => {
@@ -188,7 +188,7 @@ describe('fetchUrlAsFile', () => {
     expect((err as ImportFromUrlError).code).toBe('aborted')
   })
 
-  it('rejects size_limit_exceeded and cancels the reader when body is too large', async () => {
+  it('rejects sizeLimitExceeded and cancels the reader when body is too large', async () => {
     const cancel = vi.fn().mockResolvedValue(undefined)
     const chunks = [new Uint8Array(8), new Uint8Array(8), new Uint8Array(8)]
     let i = 0
@@ -214,27 +214,27 @@ describe('fetchUrlAsFile', () => {
     }).catch((e) => e)
 
     expect(err).toBeInstanceOf(ImportFromUrlError)
-    expect((err as ImportFromUrlError).code).toBe('size_limit_exceeded')
+    expect((err as ImportFromUrlError).code).toBe('sizeLimitExceeded')
     expect(cancel).toHaveBeenCalledTimes(1)
   })
 
-  it('rejects invalid_url before calling fetch', async () => {
+  it('rejects invalidUrl before calling fetch', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
     const err = await fetchUrlAsFile('not a url').catch((e) => e)
     expect(err).toBeInstanceOf(ImportFromUrlError)
-    expect((err as ImportFromUrlError).code).toBe('invalid_url')
+    expect((err as ImportFromUrlError).code).toBe('invalidUrl')
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('rejects invalid_scheme before calling fetch', async () => {
+  it('rejects invalidScheme before calling fetch', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
     const err = await fetchUrlAsFile('file:///etc/passwd.json').catch((e) => e)
     expect(err).toBeInstanceOf(ImportFromUrlError)
-    expect((err as ImportFromUrlError).code).toBe('invalid_scheme')
+    expect((err as ImportFromUrlError).code).toBe('invalidScheme')
     expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.test.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchUrlAsFile,
+  ImportFromUrlError,
+  validateImportUrl,
+} from './fetchUrlAsFile'
+
+/**
+ * Verifies the URL-to-File helper that powers "Import from URL".
+ *
+ * Covers `validateImportUrl` (scheme/extension/basename rules, percent-decoding,
+ * query/hash stripping) and `fetchUrlAsFile` (happy path, HTTP and network
+ * failures, abort, size-cap enforcement with `reader.cancel()`).
+ */
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('validateImportUrl', () => {
+  it('rejects an empty string as invalid_url', () => {
+    expect(validateImportUrl('')).toEqual({ ok: false, reason: 'invalid_url' })
+  })
+
+  it('rejects a malformed URL as invalid_url', () => {
+    expect(validateImportUrl('not a url')).toEqual({
+      ok: false,
+      reason: 'invalid_url',
+    })
+  })
+
+  it('rejects file:// URLs as invalid_scheme', () => {
+    expect(validateImportUrl('file:///tmp/danmaku.xml')).toEqual({
+      ok: false,
+      reason: 'invalid_scheme',
+    })
+  })
+
+  it('rejects data: URLs as invalid_scheme', () => {
+    expect(validateImportUrl('data:application/json,{}')).toEqual({
+      ok: false,
+      reason: 'invalid_scheme',
+    })
+  })
+
+  it('rejects chrome-extension:// URLs as invalid_scheme', () => {
+    expect(validateImportUrl('chrome-extension://abc/file.xml')).toEqual({
+      ok: false,
+      reason: 'invalid_scheme',
+    })
+  })
+
+  it('rejects URLs without a recognized extension', () => {
+    expect(validateImportUrl('https://example.com/file.txt')).toEqual({
+      ok: false,
+      reason: 'unsupported_extension',
+    })
+  })
+
+  it('rejects URLs whose basename is "."', () => {
+    expect(validateImportUrl('https://example.com/some/path/.')).toEqual({
+      ok: false,
+      reason: 'unsupported_extension',
+    })
+  })
+
+  it('rejects URLs whose basename is empty', () => {
+    expect(validateImportUrl('https://example.com/')).toEqual({
+      ok: false,
+      reason: 'unsupported_extension',
+    })
+  })
+
+  it('accepts .json / .xml / .bin / .zip with mixed case', () => {
+    expect(validateImportUrl('https://example.com/a.JSON')).toMatchObject({
+      ok: true,
+      filename: 'a.JSON',
+      extension: '.json',
+    })
+    expect(validateImportUrl('http://example.com/a.Xml')).toMatchObject({
+      ok: true,
+      filename: 'a.Xml',
+      extension: '.xml',
+    })
+    expect(validateImportUrl('https://example.com/a.BIN')).toMatchObject({
+      ok: true,
+      filename: 'a.BIN',
+      extension: '.bin',
+    })
+    expect(validateImportUrl('https://example.com/a.Zip')).toMatchObject({
+      ok: true,
+      filename: 'a.Zip',
+      extension: '.zip',
+    })
+  })
+
+  it('strips query/hash before checking extension', () => {
+    expect(
+      validateImportUrl('https://example.com/file.json?token=abc#frag')
+    ).toMatchObject({ ok: true, filename: 'file.json', extension: '.json' })
+  })
+
+  it('decodes percent-escapes in the basename', () => {
+    expect(
+      validateImportUrl('https://example.com/folder/%E5%BC%B9%E5%B9%95.xml')
+    ).toMatchObject({ ok: true, filename: '弹幕.xml', extension: '.xml' })
+  })
+
+  it('uses only the basename, never the multi-segment path', () => {
+    const result = validateImportUrl('https://example.com/path/to/episode.json')
+    expect(result).toMatchObject({ ok: true, filename: 'episode.json' })
+    if (result.ok) {
+      expect(result.filename).not.toContain('/')
+    }
+  })
+})
+
+function mockFetchOnce(response: Response) {
+  const fetchMock = vi.fn().mockResolvedValueOnce(response)
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('fetchUrlAsFile', () => {
+  it('returns a File with correct name, type, and bytes for a 200 response', async () => {
+    const payload = new TextEncoder().encode('{"hello":"world"}')
+    mockFetchOnce(new Response(payload, { status: 200 }))
+
+    const file = await fetchUrlAsFile('https://example.com/data.json')
+
+    expect(file).toBeInstanceOf(File)
+    expect(file.name).toBe('data.json')
+    expect(file.type).toBe('application/json')
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    expect(Array.from(bytes)).toEqual(Array.from(payload))
+  })
+
+  it('tags .xml with text/xml and .bin with application/octet-stream', async () => {
+    mockFetchOnce(new Response('<i></i>', { status: 200 }))
+    const xml = await fetchUrlAsFile('https://example.com/a.xml')
+    expect(xml.type).toBe('text/xml')
+
+    mockFetchOnce(new Response(new Uint8Array([1, 2, 3]), { status: 200 }))
+    const bin = await fetchUrlAsFile('https://example.com/a.bin')
+    expect(bin.type).toBe('application/octet-stream')
+  })
+
+  it('rejects http_error with status for a non-2xx response', async () => {
+    mockFetchOnce(new Response('nope', { status: 404 }))
+
+    const err = await fetchUrlAsFile('https://example.com/a.json').catch(
+      (e) => e
+    )
+    expect(err).toBeInstanceOf(ImportFromUrlError)
+    expect((err as ImportFromUrlError).code).toBe('http_error')
+    expect((err as ImportFromUrlError).params).toEqual({ status: 404 })
+  })
+
+  it('rejects fetch_failed when fetch itself throws', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValueOnce(new TypeError('network down'))
+    )
+
+    const err = await fetchUrlAsFile('https://example.com/a.json').catch(
+      (e) => e
+    )
+    expect(err).toBeInstanceOf(ImportFromUrlError)
+    expect((err as ImportFromUrlError).code).toBe('fetch_failed')
+  })
+
+  it('rejects aborted when the signal is aborted mid-fetch', async () => {
+    const controller = new AbortController()
+    const abortErr = new DOMException('Aborted', 'AbortError')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() => {
+        controller.abort()
+        return Promise.reject(abortErr)
+      })
+    )
+
+    const err = await fetchUrlAsFile('https://example.com/a.json', {
+      signal: controller.signal,
+    }).catch((e) => e)
+    expect(err).toBeInstanceOf(ImportFromUrlError)
+    expect((err as ImportFromUrlError).code).toBe('aborted')
+  })
+
+  it('rejects size_limit_exceeded and cancels the reader when body is too large', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    const chunks = [new Uint8Array(8), new Uint8Array(8), new Uint8Array(8)]
+    let i = 0
+    const reader = {
+      read: vi.fn().mockImplementation(async () => {
+        if (i >= chunks.length) {
+          return { done: true, value: undefined }
+        }
+        return { done: false, value: chunks[i++] }
+      }),
+      cancel,
+    }
+    const body = { getReader: () => reader }
+    const response = {
+      ok: true,
+      status: 200,
+      body,
+    } as unknown as Response
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response))
+
+    const err = await fetchUrlAsFile('https://example.com/a.bin', {
+      maxBytes: 16,
+    }).catch((e) => e)
+
+    expect(err).toBeInstanceOf(ImportFromUrlError)
+    expect((err as ImportFromUrlError).code).toBe('size_limit_exceeded')
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects invalid_url before calling fetch', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const err = await fetchUrlAsFile('not a url').catch((e) => e)
+    expect(err).toBeInstanceOf(ImportFromUrlError)
+    expect((err as ImportFromUrlError).code).toBe('invalid_url')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid_scheme before calling fetch', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const err = await fetchUrlAsFile('file:///etc/passwd.json').catch((e) => e)
+    expect(err).toBeInstanceOf(ImportFromUrlError)
+    expect((err as ImportFromUrlError).code).toBe('invalid_scheme')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.ts
@@ -127,9 +127,11 @@ export async function fetchUrlAsFile(
     throw new ImportFromUrlError('httpError', { status: response.status })
   }
 
-  const buffer = await readBodyWithCap(response, maxBytes, signal)
+  const chunks = await readBodyWithCap(response, maxBytes, signal)
 
-  return new File([buffer], validation.filename, {
+  // Hand chunks straight to File — pre-merging into one ArrayBuffer here
+  // would double peak memory near maxBytes.
+  return new File(chunks as BlobPart[], validation.filename, {
     type: contentTypeFor(validation.extension),
   })
 }
@@ -138,7 +140,7 @@ async function readBodyWithCap(
   response: Response,
   maxBytes: number,
   signal: AbortSignal | undefined
-): Promise<ArrayBuffer> {
+): Promise<Uint8Array[]> {
   if (!response.body) {
     const buffer = await response.arrayBuffer()
     if (buffer.byteLength > maxBytes) {
@@ -146,7 +148,7 @@ async function readBodyWithCap(
         limit: formatBytes(maxBytes),
       })
     }
-    return buffer
+    return [new Uint8Array(buffer)]
   }
 
   const reader = response.body.getReader()
@@ -183,14 +185,7 @@ async function readBodyWithCap(
     throw new ImportFromUrlError('fetchFailed')
   }
 
-  const merged = new ArrayBuffer(total)
-  const view = new Uint8Array(merged)
-  let offset = 0
-  for (const chunk of chunks) {
-    view.set(chunk, offset)
-    offset += chunk.byteLength
-  }
-  return merged
+  return chunks
 }
 
 function formatBytes(bytes: number): string {

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.ts
@@ -1,10 +1,10 @@
 export type ImportFromUrlErrorCode =
-  | 'invalid_url'
-  | 'invalid_scheme'
-  | 'unsupported_extension'
-  | 'fetch_failed'
-  | 'http_error'
-  | 'size_limit_exceeded'
+  | 'invalidUrl'
+  | 'invalidScheme'
+  | 'unsupportedExtension'
+  | 'fetchFailed'
+  | 'httpError'
+  | 'sizeLimitExceeded'
   | 'aborted'
 
 export class ImportFromUrlError extends Error {
@@ -33,7 +33,7 @@ export type ValidateImportUrlResult =
       ok: false
       reason: Extract<
         ImportFromUrlErrorCode,
-        'invalid_url' | 'invalid_scheme' | 'unsupported_extension'
+        'invalidUrl' | 'invalidScheme' | 'unsupportedExtension'
       >
     }
 
@@ -42,18 +42,18 @@ export function validateImportUrl(rawUrl: string): ValidateImportUrlResult {
   try {
     parsed = new URL(rawUrl)
   } catch {
-    return { ok: false, reason: 'invalid_url' }
+    return { ok: false, reason: 'invalidUrl' }
   }
 
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return { ok: false, reason: 'invalid_scheme' }
+    return { ok: false, reason: 'invalidScheme' }
   }
 
   let decodedPath: string
   try {
     decodedPath = decodeURIComponent(parsed.pathname)
   } catch {
-    return { ok: false, reason: 'invalid_url' }
+    return { ok: false, reason: 'invalidUrl' }
   }
 
   const lastSlash = decodedPath.lastIndexOf('/')
@@ -61,7 +61,7 @@ export function validateImportUrl(rawUrl: string): ValidateImportUrlResult {
     lastSlash === -1 ? decodedPath : decodedPath.slice(lastSlash + 1)
 
   if (basename === '' || basename === '.') {
-    return { ok: false, reason: 'unsupported_extension' }
+    return { ok: false, reason: 'unsupportedExtension' }
   }
 
   const lowerBasename = basename.toLowerCase()
@@ -69,7 +69,7 @@ export function validateImportUrl(rawUrl: string): ValidateImportUrlResult {
     lowerBasename.endsWith(ext)
   )
   if (!extension) {
-    return { ok: false, reason: 'unsupported_extension' }
+    return { ok: false, reason: 'unsupportedExtension' }
   }
 
   return { ok: true, filename: basename, extension }
@@ -120,11 +120,11 @@ export async function fetchUrlAsFile(
     ) {
       throw new ImportFromUrlError('aborted')
     }
-    throw new ImportFromUrlError('fetch_failed')
+    throw new ImportFromUrlError('fetchFailed')
   }
 
   if (!response.ok) {
-    throw new ImportFromUrlError('http_error', { status: response.status })
+    throw new ImportFromUrlError('httpError', { status: response.status })
   }
 
   const buffer = await readBodyWithCap(response, maxBytes, signal)
@@ -142,7 +142,7 @@ async function readBodyWithCap(
   if (!response.body) {
     const buffer = await response.arrayBuffer()
     if (buffer.byteLength > maxBytes) {
-      throw new ImportFromUrlError('size_limit_exceeded', {
+      throw new ImportFromUrlError('sizeLimitExceeded', {
         limit: formatBytes(maxBytes),
       })
     }
@@ -163,7 +163,7 @@ async function readBodyWithCap(
         total += value.byteLength
         if (total > maxBytes) {
           await reader.cancel()
-          throw new ImportFromUrlError('size_limit_exceeded', {
+          throw new ImportFromUrlError('sizeLimitExceeded', {
             limit: formatBytes(maxBytes),
           })
         }
@@ -180,7 +180,7 @@ async function readBodyWithCap(
     ) {
       throw new ImportFromUrlError('aborted')
     }
-    throw new ImportFromUrlError('fetch_failed')
+    throw new ImportFromUrlError('fetchFailed')
   }
 
   const merged = new ArrayBuffer(total)

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/fetchUrlAsFile.ts
@@ -1,0 +1,202 @@
+export type ImportFromUrlErrorCode =
+  | 'invalid_url'
+  | 'invalid_scheme'
+  | 'unsupported_extension'
+  | 'fetch_failed'
+  | 'http_error'
+  | 'size_limit_exceeded'
+  | 'aborted'
+
+export class ImportFromUrlError extends Error {
+  readonly code: ImportFromUrlErrorCode
+  readonly params: Record<string, string | number>
+
+  constructor(
+    code: ImportFromUrlErrorCode,
+    params: Record<string, string | number> = {}
+  ) {
+    super(code)
+    this.name = 'ImportFromUrlError'
+    this.code = code
+    this.params = params
+  }
+}
+
+const SUPPORTED_EXTENSIONS = ['.json', '.xml', '.bin', '.zip'] as const
+type SupportedExtension = (typeof SUPPORTED_EXTENSIONS)[number]
+
+const DEFAULT_MAX_BYTES = 500 * 1024 * 1024
+
+export type ValidateImportUrlResult =
+  | { ok: true; filename: string; extension: SupportedExtension }
+  | {
+      ok: false
+      reason: Extract<
+        ImportFromUrlErrorCode,
+        'invalid_url' | 'invalid_scheme' | 'unsupported_extension'
+      >
+    }
+
+export function validateImportUrl(rawUrl: string): ValidateImportUrlResult {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return { ok: false, reason: 'invalid_url' }
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'invalid_scheme' }
+  }
+
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(parsed.pathname)
+  } catch {
+    return { ok: false, reason: 'invalid_url' }
+  }
+
+  const lastSlash = decodedPath.lastIndexOf('/')
+  const basename =
+    lastSlash === -1 ? decodedPath : decodedPath.slice(lastSlash + 1)
+
+  if (basename === '' || basename === '.') {
+    return { ok: false, reason: 'unsupported_extension' }
+  }
+
+  const lowerBasename = basename.toLowerCase()
+  const extension = SUPPORTED_EXTENSIONS.find((ext) =>
+    lowerBasename.endsWith(ext)
+  )
+  if (!extension) {
+    return { ok: false, reason: 'unsupported_extension' }
+  }
+
+  return { ok: true, filename: basename, extension }
+}
+
+function contentTypeFor(extension: SupportedExtension): string {
+  switch (extension) {
+    case '.xml':
+      return 'text/xml'
+    case '.bin':
+      return 'application/octet-stream'
+    case '.zip':
+      return 'application/zip'
+    default:
+      return 'application/json'
+  }
+}
+
+export type FetchUrlAsFileOptions = {
+  maxBytes?: number
+  signal?: AbortSignal
+}
+
+export async function fetchUrlAsFile(
+  rawUrl: string,
+  options: FetchUrlAsFileOptions = {}
+): Promise<File> {
+  const validation = validateImportUrl(rawUrl)
+  if (!validation.ok) {
+    throw new ImportFromUrlError(validation.reason)
+  }
+
+  const { signal } = options
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
+
+  let response: Response
+  try {
+    response = await fetch(rawUrl, {
+      credentials: 'omit',
+      redirect: 'follow',
+      cache: 'no-store',
+      signal,
+    })
+  } catch (err) {
+    if (
+      signal?.aborted ||
+      (err instanceof Error && err.name === 'AbortError')
+    ) {
+      throw new ImportFromUrlError('aborted')
+    }
+    throw new ImportFromUrlError('fetch_failed')
+  }
+
+  if (!response.ok) {
+    throw new ImportFromUrlError('http_error', { status: response.status })
+  }
+
+  const buffer = await readBodyWithCap(response, maxBytes, signal)
+
+  return new File([buffer], validation.filename, {
+    type: contentTypeFor(validation.extension),
+  })
+}
+
+async function readBodyWithCap(
+  response: Response,
+  maxBytes: number,
+  signal: AbortSignal | undefined
+): Promise<ArrayBuffer> {
+  if (!response.body) {
+    const buffer = await response.arrayBuffer()
+    if (buffer.byteLength > maxBytes) {
+      throw new ImportFromUrlError('size_limit_exceeded', {
+        limit: formatBytes(maxBytes),
+      })
+    }
+    return buffer
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      if (value) {
+        total += value.byteLength
+        if (total > maxBytes) {
+          await reader.cancel()
+          throw new ImportFromUrlError('size_limit_exceeded', {
+            limit: formatBytes(maxBytes),
+          })
+        }
+        chunks.push(value)
+      }
+    }
+  } catch (err) {
+    if (err instanceof ImportFromUrlError) {
+      throw err
+    }
+    if (
+      signal?.aborted ||
+      (err instanceof Error && err.name === 'AbortError')
+    ) {
+      throw new ImportFromUrlError('aborted')
+    }
+    throw new ImportFromUrlError('fetch_failed')
+  }
+
+  const merged = new ArrayBuffer(total)
+  const view = new Uint8Array(merged)
+  let offset = 0
+  for (const chunk of chunks) {
+    view.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return merged
+}
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  if (Number.isInteger(mb)) {
+    return `${mb} MB`
+  }
+  return `${mb.toFixed(1)} MB`
+}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/useImportFlow.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/useImportFlow.ts
@@ -93,8 +93,10 @@ export const useImportFlow = () => {
 
   const importFromUrl = async (url: string, signal: AbortSignal) => {
     const file = await fetchUrlAsFile(url, { signal })
-    setUrlDialogOpen(false)
+    // Await handleFiles before closing so a corrupt-zip extraction throw
+    // surfaces in the URL dialog instead of closing it silently.
     await handleFiles([file])
+    setUrlDialogOpen(false)
   }
 
   const closeDialog = () => {

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/useImportFlow.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/useImportFlow.ts
@@ -57,7 +57,7 @@ export const useImportFlow = () => {
     const processedFiles: File[] = []
 
     for (const file of files) {
-      if (file.name.endsWith('.zip')) {
+      if (file.name.toLowerCase().endsWith('.zip')) {
         processedFiles.push(...(await extractZipFile(file)))
       } else if (file.webkitRelativePath !== '') {
         // convert the relative path to the file's name

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/useImportFlow.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/useImportFlow.ts
@@ -1,5 +1,6 @@
 import JSZip from 'jszip'
 import { useRef, useState } from 'react'
+import { fetchUrlAsFile } from '@/common/components/DanmakuSelector/fetchUrlAsFile'
 import { useFileDragDrop } from '@/common/components/DanmakuSelector/useFileDragDrop'
 import {
   useDanmakuImport,
@@ -47,6 +48,7 @@ export const useImportFlow = () => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)
   const [showResultDialog, setShowResultDialog] = useState(false)
+  const [urlDialogOpen, setUrlDialogOpen] = useState(false)
 
   const { handleImportClick, mutate, data, isPending, isError, error, reset } =
     useDanmakuImport()
@@ -81,6 +83,20 @@ export const useImportFlow = () => {
     folderInputRef.current?.click()
   }
 
+  const openUrlInput = () => {
+    setUrlDialogOpen(true)
+  }
+
+  const closeUrlInput = () => {
+    setUrlDialogOpen(false)
+  }
+
+  const importFromUrl = async (url: string, signal: AbortSignal) => {
+    const file = await fetchUrlAsFile(url, { signal })
+    setUrlDialogOpen(false)
+    await handleFiles([file])
+  }
+
   const closeDialog = () => {
     setShowResultDialog(false)
     reset()
@@ -91,6 +107,7 @@ export const useImportFlow = () => {
   return {
     // State
     showResultDialog,
+    urlDialogOpen,
     isDragging,
     dragProps,
     fileInputRef,
@@ -100,6 +117,9 @@ export const useImportFlow = () => {
     // Actions
     openFileInput,
     openFolderInput,
+    openUrlInput,
+    closeUrlInput,
+    importFromUrl,
     handleFiles,
     closeDialog,
     confirmImport: handleImportClick,

--- a/packages/danmaku-anywhere/src/common/components/ImportPageCore/ImportResultDialog.tsx
+++ b/packages/danmaku-anywhere/src/common/components/ImportPageCore/ImportResultDialog.tsx
@@ -126,6 +126,7 @@ export const ImportResultDialog = <T,>({
               color="primary"
               disabled={disableImport || status === 'uploading'}
               loading={status === 'uploading'}
+              data-testid="import-result-confirm"
             >
               {t('importPage.confirm', 'Confirm Import')}
             </Button>

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -267,11 +267,26 @@
     "importError_one": "Failed to import {{count}} file",
     "importError_other": "Failed to import {{count}} files",
     "importFolder": "Import Danmaku Folder",
+    "importFromUrl": "Import from URL",
     "importSuccess_one": "Successfully imported {{count}} file",
     "importSuccess_other": "Successfully imported {{count}} files",
     "parseError": "Failed to parse file",
     "skipped_one": "Skpped {{count}} file",
     "skipped_other": "Skpped {{count}} files",
+    "urlDialog": {
+      "errors": {
+        "fetch_failed": "Failed to fetch the URL.",
+        "http_error": "Server returned {{status}}.",
+        "invalid_scheme": "Only http and https URLs are supported.",
+        "invalid_url": "Not a valid URL.",
+        "size_limit_exceeded": "File is larger than the {{limit}} limit.",
+        "unsupported_extension": "URL must point to a .json, .xml, .bin, or .zip file."
+      },
+      "submit": "Fetch & Import",
+      "title": "Import from URL",
+      "urlHelper": "Direct link to a .json, .xml, .bin, or .zip file",
+      "urlLabel": "URL"
+    },
     "willImport_one": "Will import {{count}} file",
     "willImport_other": "Will import {{count}} files"
   },

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -275,12 +275,12 @@
     "skipped_other": "Skpped {{count}} files",
     "urlDialog": {
       "errors": {
-        "fetch_failed": "Failed to fetch the URL.",
-        "http_error": "Server returned {{status}}.",
-        "invalid_scheme": "Only http and https URLs are supported.",
-        "invalid_url": "Not a valid URL.",
-        "size_limit_exceeded": "File is larger than the {{limit}} limit.",
-        "unsupported_extension": "URL must point to a .json, .xml, .bin, or .zip file."
+        "fetchFailed": "Failed to fetch the URL.",
+        "httpError": "Server returned {{status}}.",
+        "invalidScheme": "Only http and https URLs are supported.",
+        "invalidUrl": "Not a valid URL.",
+        "sizeLimitExceeded": "File is larger than the {{limit}} limit.",
+        "unsupportedExtension": "URL must point to a .json, .xml, .bin, or .zip file."
       },
       "submit": "Fetch & Import",
       "title": "Import from URL",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -267,12 +267,12 @@
     "skipped_other": "跳过{{count}}个文件",
     "urlDialog": {
       "errors": {
-        "fetch_failed": "请求 URL 失败",
-        "http_error": "服务器返回 {{status}}",
-        "invalid_scheme": "仅支持 http 和 https URL",
-        "invalid_url": "URL 格式不正确",
-        "size_limit_exceeded": "文件大小超过 {{limit}} 限制",
-        "unsupported_extension": "URL 必须指向 .json、.xml、.bin 或 .zip 文件"
+        "fetchFailed": "请求 URL 失败",
+        "httpError": "服务器返回 {{status}}",
+        "invalidScheme": "仅支持 http 和 https URL",
+        "invalidUrl": "URL 格式不正确",
+        "sizeLimitExceeded": "文件大小超过 {{limit}} 限制",
+        "unsupportedExtension": "URL 必须指向 .json、.xml、.bin 或 .zip 文件"
       },
       "submit": "下载并导入",
       "title": "从 URL 导入",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -261,9 +261,24 @@
     "importDesc": "导入本地弹幕时文件名将用为弹幕名称。支持 .json、.xml 和 .bin（B站 protobuf）文件",
     "importError_other": "{{count}}个文件导入失败",
     "importFolder": "导入文件夹",
+    "importFromUrl": "从 URL 导入",
     "importSuccess_other": "成功导入{{count}}个文件",
     "parseError": "文件解析失败",
     "skipped_other": "跳过{{count}}个文件",
+    "urlDialog": {
+      "errors": {
+        "fetch_failed": "请求 URL 失败",
+        "http_error": "服务器返回 {{status}}",
+        "invalid_scheme": "仅支持 http 和 https URL",
+        "invalid_url": "URL 格式不正确",
+        "size_limit_exceeded": "文件大小超过 {{limit}} 限制",
+        "unsupported_extension": "URL 必须指向 .json、.xml、.bin 或 .zip 文件"
+      },
+      "submit": "下载并导入",
+      "title": "从 URL 导入",
+      "urlHelper": "指向 .json、.xml、.bin 或 .zip 文件的直链",
+      "urlLabel": "URL"
+    },
     "willImport_other": "将导入{{count}}个文件"
   },
   "integration": {


### PR DESCRIPTION
## Summary

Adds a third "Import from URL" item to the danmaku library's 3-dot menu. Clicking it opens a small Dialog that takes a `http(s)` URL pointing to a `.json` / `.xml` / `.bin` / `.zip` danmaku file. The popup fetches the bytes, wraps them as a `File`, and feeds the result into the existing `handleFiles` import pipeline — zip extraction, parsing, the result dialog, and episode invalidation are reused unchanged.

## How it works

- The popup already inherits `host_permissions: <all_urls>` from the manifest, so `fetch()` bypasses CORS for any http(s) URL — no background round-trip and no new permission ask. The bytes never cross a `sendMessage` boundary.
- New helper `fetchUrlAsFile.ts` validates URL/scheme/extension, streams the body with a **500 MB cap** (mid-stream `reader.cancel()` so the popup doesn't OOM on huge files), and derives the filename from the URL's basename only (never the multi-segment path).
- New `UrlImportDialog.tsx` owns the input UI and an `AbortController` so clicking Cancel during an in-flight fetch actually aborts.
- The URL dialog closes **before** `handleFiles` runs (which synchronously opens the result dialog), so the two dialogs never overlap.
- Validation errors get static i18n keys via a `Record<ErrorCode, string>` map with comment-based extraction markers so `i18next-cli` picks them up (dynamic `` t(`...${code}`) `` would silently break `i18n:check`).

## Files

- **Added**: `fetchUrlAsFile.ts` + `fetchUrlAsFile.test.ts` (19 cases: validation, happy path, HTTP errors, network failures, abort, size-cap with `reader.cancel()` spy), `UrlImportDialog.tsx`.
- **Modified**: `useImportFlow.ts` (new `urlDialogOpen` state + `openUrlInput` / `closeUrlInput` / `importFromUrl` actions), `MountPageContent.tsx` (3rd menu item + mounted dialog), `locales/{en,zh}/translation.json` (regenerated via `pnpm i18n extract`, zh hand-translated).

No new permissions, no manifest changes, no public-API delta. The downstream `episodeImport` RPC and `parseFile` are untouched.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm lint:ci` (no new warnings)
- [x] `pnpm --filter @mr-quin/danmaku-anywhere test` — 293/293 pass
- [x] `pnpm i18n:check` — idempotent
- [x] Manual: paste a local `.xml` URL → result dialog → confirm → episode in library
- [x] Manual: paste a 76 MB `.zip` → streams, extracts, all episodes imported
- [ ] Manual: 404 URL → "Server returned 404."
- [ ] Manual: `ftp://...` → submit disabled, "Only http and https URLs are supported."
- [ ] Manual: URL without recognized extension → submit disabled
- [ ] Manual: Cancel mid-fetch on a large download → request aborts (DevTools Network)

No new e2e — the mount-page import e2e doesn't cover file-import-via-menu either, and adding network-mocked URL import is materially more work for a single-screen feature with strong unit coverage.