### PR TITLE
(extension) batch IDB hot paths: season join + episode counts [DA-510]

### DIFF
--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -206,9 +206,8 @@ export class DanmakuService {
     return toUpdate
   }
 
-  // One bulkGet on the unique seasonIds replaces N per-episode mustGetById
-  // reads. Throws on any missing row to preserve the mustGetById semantics
-  // this used to call inside the per-episode map.
+  // Filtering by seasonId — the common path — returns N episodes that
+  // share one season, so a per-episode lookup reads the same row N times.
   private async joinSeasons<T extends EpisodeLite>(
     episodes: T[]
   ): Promise<WithSeason<T>[]> {

--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -206,6 +206,9 @@ export class DanmakuService {
     return toUpdate
   }
 
+  // One bulkGet on the unique seasonIds replaces N per-episode mustGetById
+  // reads. Throws on any missing row to preserve the mustGetById semantics
+  // this used to call inside the per-episode map.
   private async joinSeasons<T extends EpisodeLite>(
     episodes: T[]
   ): Promise<WithSeason<T>[]> {

--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -9,6 +9,7 @@ import {
   type EpisodeInsert,
   type EpisodeLite,
   parseBackupMany,
+  type Season,
   type WithSeason,
   zCombinedDanmaku,
 } from '@danmaku-anywhere/danmaku-converter'
@@ -205,18 +206,28 @@ export class DanmakuService {
     return toUpdate
   }
 
-  /**
-   * This is an arrow function so that the "this" keyword is bound to the class instance
-   */
-  private joinSeason = async <T extends EpisodeLite>(
-    episode: T
-  ): Promise<WithSeason<T>> => {
-    const season = await this.seasonService.mustGetById(episode.seasonId)
+  private async joinSeasons<T extends EpisodeLite>(
+    episodes: T[]
+  ): Promise<WithSeason<T>[]> {
+    if (episodes.length === 0) {
+      return []
+    }
 
-    return {
+    const uniqueIds = [...new Set(episodes.map((e) => e.seasonId))]
+    const seasonRows = await this.db.season.bulkGet(uniqueIds)
+    const seasonById = new Map<number, Season>()
+    for (let i = 0; i < uniqueIds.length; i++) {
+      const season = seasonRows[i]
+      if (!season) {
+        throw new Error(`No season found for id ${uniqueIds[i]}`)
+      }
+      seasonById.set(uniqueIds[i], season)
+    }
+
+    return episodes.map((episode) => ({
       ...episode,
-      season,
-    } as WithSeason<T>
+      season: seasonById.get(episode.seasonId),
+    })) as WithSeason<T>[]
   }
 
   async filterLite(
@@ -233,24 +244,18 @@ export class DanmakuService {
   async filter(filter: EpisodeQueryFilter): Promise<WithSeason<Episode>[]> {
     if (filter.all) {
       const res = await this.db.episode.toArray()
-      return Promise.all(res.map(this.joinSeason))
+      return this.joinSeasons(res)
     }
 
     if (filter.ids) {
-      const getMany = async (ids: number[]): Promise<WithSeason<Episode>[]> => {
-        const res = await this.db.episode.bulkGet(ids)
-        const filtered = res.filter((r) => r !== undefined)
-        return Promise.all(filtered.map(this.joinSeason))
-      }
-      return getMany(filter.ids)
+      const res = await this.db.episode.bulkGet(filter.ids)
+      return this.joinSeasons(res.filter((r) => r !== undefined))
     }
 
     const res = await this.db.episode.where(filter).toArray()
 
-    return Promise.all(
-      res
-        .toSorted((a, b) => a.indexedId.localeCompare(b.indexedId))
-        .map(this.joinSeason)
+    return this.joinSeasons(
+      res.toSorted((a, b) => a.indexedId.localeCompare(b.indexedId))
     )
   }
 

--- a/packages/danmaku-anywhere/src/background/services/persistence/SeasonService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/SeasonService.ts
@@ -96,10 +96,17 @@ export class SeasonService {
       async () => {
         const allSeasons = await this.db.season.toArray()
 
+        // Index-only cursor: walks the seasonId index without reading the
+        // episode rows, so the heavy comments field (can be 30k+ entries
+        // per row) is never deserialized.
+        const counts = new Map<number, number>()
+        await this.db.episode.orderBy('seasonId').eachKey((key) => {
+          const seasonId = key as number
+          counts.set(seasonId, (counts.get(seasonId) ?? 0) + 1)
+        })
+
         for (const season of allSeasons) {
-          const episodeCount = await this.db.episode
-            .where({ seasonId: season.id })
-            .count()
+          const episodeCount = counts.get(season.id) ?? 0
           if (episodeCount > 0 || options.includeEmpty) {
             seasons.push({
               ...season,


### PR DESCRIPTION
## Summary
Follow-up to #402. #402 batched the per-row episode-danmaku RPC at the React layer; this batches the two IDB hot paths reached from that single RPC.

- **`DanmakuService.filter`**: `joinSeason` was calling `seasonService.mustGetById` per episode — N reads of the same row when filtering by `seasonId`. New `joinSeasons` helper collects unique season ids, does one `bulkGet`, and attaches via a `Map`. Throws on any missing row to preserve the `mustGetById` semantics.
- **`SeasonService.getAll`**: replaced N per-season `episode.where({seasonId}).count()` calls with one `orderBy('seasonId').eachKey()` pass. `eachKey` opens an index-only cursor and never reads the episode row, so the heavy `comments` field is not deserialized. Avoids the natural-but-bad `.toArray()` rewrite.

The two other persistence batching changes flagged in DA-510 (`SeasonService.bulkUpsert` collapsing, `DanmakuService.import` rework) will land in a separate PR.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm --filter @mr-quin/danmaku-anywhere test`
- [x] `pnpm --filter @mr-quin/danmaku-anywhere build`
- [ ] Manual: open a 200+ episode season; episode list renders correctly with danmaku metadata attached
- [ ] Manual: open the Seasons page, the DanmakuSelector tree, and TitleMappingDetails — episode counts correct, empty seasons handled per `includeEmpty`
- [ ] Manual: heap-snapshot the Seasons page load on a profile that has an episode with a large `comments` array; size delta should be in KBs, not MBs (confirms `eachKey` is index-only)