### PR TITLE
(chore) long-lived preview build channel [DA-527]

### DIFF
--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -30,6 +30,8 @@ The `/loop` skill creates a session-only cron (`*/5 * * * *`) and runs the first
 
 ## 2. Per-iteration loop
 
+GraphQL snippets below use `<OWNER>/<REPO>` placeholders — resolve from `gh repo view --json owner,name -q '.owner.login + "/" + .name'` (or substitute literally from the current repo) before running.
+
 ### 2a. Fetch status
 
 ```bash
@@ -62,7 +64,7 @@ For replies, be brief and specific. Examples that read well:
 Then resolve via GraphQL:
 
 ```bash
-gh api graphql -f query='{ repository(owner: "Mr-Quin", name: "danmaku-anywhere") { pullRequest(number: N) { reviewThreads(first: 50) { nodes { id isResolved } } } } }'
+gh api graphql -f query='{ repository(owner: "<OWNER>", name: "<REPO>") { pullRequest(number: N) { reviewThreads(first: 50) { nodes { id isResolved } } } } }'
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
 ```
 
@@ -107,7 +109,7 @@ Then send one message: PR URL, what was addressed, what was skipped (with one-li
 | Action | Command |
 |---|---|
 | One-shot status | `scripts/pr-status.sh <N>` |
-| List threads + IDs | `gh api graphql -f query='{ repository(owner: "Mr-Quin", name: "danmaku-anywhere") { pullRequest(number: N) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 5) { nodes { author { login } body } } } } } } }'` |
+| List threads + IDs | `gh api graphql -f query='{ repository(owner: "<OWNER>", name: "<REPO>") { pullRequest(number: N) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 5) { nodes { author { login } body } } } } } } }'` |
 | Reply on thread | `gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: "ID", body: "..."}) { comment { id } } }'` |
 | Resolve thread | `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "ID"}) { thread { isResolved } } }'` |
 | Stop loop | `CronDelete <jobId>` |

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: babysit-pr
+description: Use to monitor an open PR for AI/bot review comments, evaluate them critically, push fixes for real issues, and resolve threads — capped at a sensible duration so it self-terminates. Invoke as "babysit PR #N" or after opening a PR.
+---
+
+# babysit-pr — supervised PR monitoring loop
+
+Watch a PR for new review activity, **evaluate each comment on its merits**, push fixes only when the change is genuinely warranted, and stop on its own. AI reviewers in this repo (Gemini, Claude, Coderabbit, etc.) tend to be over-defensive and over-engineering — your job is to be the editor, not the stenographer.
+
+## 0. Decide the duration
+
+Default budget: **30 minutes / 6 iterations at 5-minute cadence.** That covers one or two full AI-reviewer cycles after the initial push and the post-fix re-review. Beyond that, returns are sharply diminishing.
+
+Extend (up to 60 min / 12 iterations) only if:
+- A reviewer is still mid-review (eyes reaction without a posted review) at the budget boundary
+- CI is still running with no failure yet
+- You're actively pushing fixes (don't quit mid-flight)
+
+Shorten if the PR is trivial (≤30 LOC chore/doc): **15 min / 3 iterations** is enough.
+
+Never schedule beyond 60 min in a single sitting. If the PR is still churning after that, hand back to the human.
+
+## 1. Set up the loop
+
+```
+/loop 5m babysit PR #<N> per .claude/skills/babysit-pr/SKILL.md
+```
+
+The `/loop` skill creates a session-only cron (`*/5 * * * *`) and runs the first iteration immediately. Track iteration count in your own head — when you hit the budget, `CronDelete` the job and notify the human.
+
+## 2. Per-iteration loop
+
+### 2a. Fetch status
+
+```bash
+scripts/pr-status.sh <N>
+```
+
+One GraphQL call returns: reviews, pending reviewers, open threads, reactions, check states. Read it carefully — `state: PENDING` on a reviewer means "still working", not "approved".
+
+### 2b. Classify each new comment
+
+For every unresolved thread / new review body, apply this filter:
+
+| Verdict | When | Action |
+|---|---|---|
+| **must-fix** | Real bug, security hole, broken behavior, project-convention violation (CLAUDE.md / AGENTS.md), CI-blocker | Implement the fix, commit, push, reply with what changed, resolve thread |
+| **judgment-call** | Genuinely improves the change (clearer naming, removes dead code, tightens a fragile match), low cost | Same as must-fix |
+| **skip-with-reply** | Defensive null check where input is trusted, speculative refactor, "consider adding tests for X" without specific bug, "what if Y?" hypotheticals, premature abstraction, restating existing behavior, micro-optimizations | Reply with crisp rationale (KISS, YAGNI, trust the type, etc.) — *then* resolve the thread |
+| **skip-silently** | Pure stylistic nits already covered by Biome, restating obvious code, duplicates of another comment | Resolve without reply |
+
+The default lean is **skip**. Only escalate to must-fix when you can articulate the concrete failure mode the comment prevents. "It would be safer to..." without a named failure mode is YAGNI.
+
+### 2c. Reply and resolve
+
+For replies, be brief and specific. Examples that read well:
+
+- `Skipped — input is sanitized one call up (link to scripts/preview-build-check.cjs:7); a second pass here is YAGNI.`
+- `Skipped — Biome enforces this already; no manual guard needed.`
+- `Fixed in <sha> by switching to startsWith — agree the substring match was fragile.`
+
+Then resolve via GraphQL:
+
+```bash
+gh api graphql -f query='{ repository(owner: "Mr-Quin", name: "danmaku-anywhere") { pullRequest(number: N) { reviewThreads(first: 50) { nodes { id isResolved } } } } }'
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+```
+
+### 2d. If you pushed fixes
+
+After `git push`, the AI reviewers (gated by the `ai-rereview` label) re-run automatically. Wait one full iteration before re-evaluating — they need 2–4 min to land.
+
+## 3. Stop conditions
+
+Stop the loop and notify the human as soon as **all three** hold:
+
+1. **All threads handled** — every open thread is either fixed+replied+resolved, or skipped+replied+resolved
+2. **No pending reviewers** — no `state: PENDING`, no unmatched `eyes` reaction from a bot that hasn't posted yet
+3. **CI complete** — every check is `SUCCESS` or `NEUTRAL`. If any is `FAILURE`, fix it first; don't stop while CI is red
+
+Also stop (and notify) on:
+
+- **Budget exhausted** — hit your iteration cap; report what's still outstanding so the human can take over
+- **Unresolvable disagreement** — you replied with a rationale and the same reviewer pushed back; hand to the human rather than ping-ponging
+- **Risky action needed** — fix would touch shared infrastructure, dependencies, or anything the human should authorize first
+- **You're not making progress** — same comment two iterations in a row with no new fix; hand off
+
+To stop:
+
+```
+CronDelete <jobId>
+```
+
+Then send one message: PR URL, what was addressed, what was skipped (with one-line rationale each), what's still open if anything, and the final CI / reviewer state.
+
+## 4. Anti-patterns
+
+- **Don't blindly apply suggestions.** If you can't articulate why the change matters, skip it. AI reviewers reward agreement with more suggestions; you reward them with a clear no.
+- **Don't push speculative refactors.** "Could be cleaner" is not a reason. The PR is in review, not redesign.
+- **Don't add defensive code at trusted boundaries.** Internal callers, type-system-guaranteed shapes, sanitized values one frame up — leave them alone.
+- **Don't resolve a thread without replying** unless it's a pure duplicate or covered by tooling. The PR author (human) reads the thread later and needs to know your reasoning.
+- **Don't commit Co-Authored-By or AI attribution** (per `~/.claude/CLAUDE.md`).
+- **Don't merge.** Ever. Merging is a human action.
+
+## 5. Quick reference
+
+| Action | Command |
+|---|---|
+| One-shot status | `scripts/pr-status.sh <N>` |
+| List threads + IDs | `gh api graphql -f query='{ repository(owner: "Mr-Quin", name: "danmaku-anywhere") { pullRequest(number: N) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 5) { nodes { author { login } body } } } } } } }'` |
+| Reply on thread | `gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: "ID", body: "..."}) { comment { id } } }'` |
+| Resolve thread | `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "ID"}) { thread { isResolved } } }'` |
+| Stop loop | `CronDelete <jobId>` |

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -19,6 +19,9 @@ jobs:
       is_nightly: ${{ steps.check.outputs.is_nightly }}
       is_pr: ${{ steps.check.outputs.is_pr }}
       pr_number: ${{ steps.check.outputs.pr_number }}
+      is_long_lived: ${{ steps.check.outputs.is_long_lived }}
+      branch_slug: ${{ steps.check.outputs.branch_slug }}
+      feature_name: ${{ steps.check.outputs.feature_name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,17 +58,37 @@ jobs:
 
       - name: Determine Tag Name
         id: tag
+        env:
+          IS_PR: ${{ needs.check-changes.outputs.is_pr }}
+          IS_NIGHTLY: ${{ needs.check-changes.outputs.is_nightly }}
+          IS_LONG_LIVED: ${{ needs.check-changes.outputs.is_long_lived }}
+          PR_NUMBER: ${{ needs.check-changes.outputs.pr_number }}
+          BRANCH_SLUG: ${{ needs.check-changes.outputs.branch_slug }}
+          FEATURE_NAME: ${{ needs.check-changes.outputs.feature_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          if [[ "${{ needs.check-changes.outputs.is_pr }}" == "true" ]]; then
-            echo "tag_name=preview-pr-${{ needs.check-changes.outputs.pr_number }}" >> $GITHUB_OUTPUT
-            echo "allow_updates=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ needs.check-changes.outputs.is_nightly }}" == "true" ]]; then
-            echo "tag_name=nightly-${{ github.run_id }}" >> $GITHUB_OUTPUT
-            echo "allow_updates=false" >> $GITHUB_OUTPUT
+          if [[ "$IS_LONG_LIVED" == "true" ]]; then
+            tag="preview-branch-${BRANCH_SLUG}"
+            name="${FEATURE_NAME:-$BRANCH_SLUG} · Branch Preview (${RUN_NUMBER})"
+            echo "tag_name=${tag}" >> "$GITHUB_OUTPUT"
+            echo "allow_updates=true" >> "$GITHUB_OUTPUT"
+            echo "release_name=${name}" >> "$GITHUB_OUTPUT"
+          elif [[ "$IS_PR" == "true" ]]; then
+            tag="preview-pr-${PR_NUMBER}"
+            echo "tag_name=${tag}" >> "$GITHUB_OUTPUT"
+            echo "allow_updates=true" >> "$GITHUB_OUTPUT"
+            echo "release_name=Preview Build ${tag} (${RUN_NUMBER})" >> "$GITHUB_OUTPUT"
+          elif [[ "$IS_NIGHTLY" == "true" ]]; then
+            tag="nightly-${RUN_ID}"
+            echo "tag_name=${tag}" >> "$GITHUB_OUTPUT"
+            echo "allow_updates=false" >> "$GITHUB_OUTPUT"
+            echo "release_name=Preview Build ${tag} (${RUN_NUMBER})" >> "$GITHUB_OUTPUT"
           else
-             # Manual trigger or fallback - uses unique run_number so no updates needed
-             echo "tag_name=preview-manual-${{ github.run_number }}" >> $GITHUB_OUTPUT
-             echo "allow_updates=false" >> $GITHUB_OUTPUT
+            tag="preview-manual-${RUN_NUMBER}"
+            echo "tag_name=${tag}" >> "$GITHUB_OUTPUT"
+            echo "allow_updates=false" >> "$GITHUB_OUTPUT"
+            echo "release_name=Preview Build ${tag} (${RUN_NUMBER})" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
 
@@ -79,7 +102,7 @@ jobs:
           prerelease: true
           removeArtifacts: true
           tag: ${{ steps.tag.outputs.tag_name }}
-          name: "Preview Build ${{ steps.tag.outputs.tag_name }} (${{ github.run_number }})"
+          name: ${{ steps.tag.outputs.release_name }}
           body: "Preview build generated from run ${{ github.run_number }}"
 
   update-nightly-tag:
@@ -118,4 +141,7 @@ jobs:
               prNumber: '${{ needs.check-changes.outputs.pr_number }}',
               ref: '${{ needs.check-changes.outputs.ref }}',
               runNumber: '${{ github.run_number }}',
+              isLongLived: ${{ needs.check-changes.outputs.is_long_lived }},
+              branchSlug: '${{ needs.check-changes.outputs.branch_slug }}',
+              featureName: ${{ toJSON(needs.check-changes.outputs.feature_name) }},
             });

--- a/docs/src/components/downloads/LatestBuilds.tsx
+++ b/docs/src/components/downloads/LatestBuilds.tsx
@@ -58,10 +58,11 @@ type BuildInfo =
 const BRANCH_TAG_PREFIX = 'preview-branch-'
 
 function deriveFeatureNameFromName(name: string): string {
-  return name
+  const stripped = name
     .replace(/\s*·\s*Branch Preview\s*\(\d+\)\s*$/i, '')
     .replace(/\s*\(\d+\)\s*$/, '')
     .trim()
+  return stripped === name.trim() ? '' : stripped
 }
 
 function humanizeSlug(slug: string): string {

--- a/docs/src/components/downloads/LatestBuilds.tsx
+++ b/docs/src/components/downloads/LatestBuilds.tsx
@@ -98,7 +98,7 @@ const getBuildInfo = (name: string, tag: string): BuildInfo => {
   }
 
   if (tag.startsWith('preview-pr-')) {
-    const prNumber = /(\d+)/.exec(tag)?.[1]
+    const prNumber = /^preview-pr-(\d+)/.exec(tag)?.[1]
     return {
       label: 'PR',
       color: 'daisy-badge-accent',

--- a/docs/src/components/downloads/LatestBuilds.tsx
+++ b/docs/src/components/downloads/LatestBuilds.tsx
@@ -43,15 +43,52 @@ type BuildInfo =
       prNumber: string
     }
   | {
+      label: 'Branch'
+      color: string
+      buildNumber?: string
+      branchSlug: string
+      featureName: string
+    }
+  | {
       label: 'Pre'
       color: string
       buildNumber?: string
     }
 
+const BRANCH_TAG_PREFIX = 'preview-branch-'
+
+function deriveFeatureNameFromName(name: string): string {
+  return name
+    .replace(/\s*·\s*Branch Preview\s*\(\d+\)\s*$/i, '')
+    .replace(/\s*\(\d+\)\s*$/, '')
+    .trim()
+}
+
+function humanizeSlug(slug: string): string {
+  const cleaned = slug.replace(/-/g, ' ').trim()
+  if (!cleaned) {
+    return cleaned
+  }
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
+}
+
 const getBuildInfo = (name: string, tag: string): BuildInfo => {
   const buildNumber = /\((\d+)\)/.exec(name)?.[1]
 
-  if (tag.includes('nightly')) {
+  if (tag.startsWith(BRANCH_TAG_PREFIX)) {
+    const branchSlug = tag.slice(BRANCH_TAG_PREFIX.length)
+    const derived = deriveFeatureNameFromName(name)
+    const featureName = derived || humanizeSlug(branchSlug)
+    return {
+      label: 'Branch',
+      color: 'daisy-badge-warning',
+      buildNumber,
+      branchSlug,
+      featureName,
+    }
+  }
+
+  if (tag.startsWith('nightly-')) {
     return {
       label: 'Nightly',
       color: 'daisy-badge-secondary',
@@ -59,7 +96,7 @@ const getBuildInfo = (name: string, tag: string): BuildInfo => {
     }
   }
 
-  if (tag.includes('pr')) {
+  if (tag.startsWith('preview-pr-')) {
     const prNumber = /(\d+)/.exec(tag)?.[1]
     return {
       label: 'PR',
@@ -118,6 +155,16 @@ const ReleaseBadge = ({ buildInfo }: { buildInfo: BuildInfo }) => {
       >
         PR {buildInfo.prNumber}
       </a>
+    )
+  }
+  if (buildInfo.label === 'Branch') {
+    return (
+      <span
+        className={`daisy-badge daisy-badge-xs ${buildInfo.color} font-semibold`}
+        title={`长期预览分支: ${buildInfo.branchSlug}`}
+      >
+        🚧 {buildInfo.featureName}
+      </span>
     )
   }
   return (

--- a/scripts/preview-build-check.cjs
+++ b/scripts/preview-build-check.cjs
@@ -1,8 +1,8 @@
 const LONG_LIVED_LABEL = 'preview branch'
 const PREVIEW_LABEL = 'preview release'
 
-function sanitizeBranchSlug(ref) {
-  return String(ref)
+function sanitizeBranchSlug(branchRef) {
+  return String(branchRef)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')

--- a/scripts/preview-build-check.cjs
+++ b/scripts/preview-build-check.cjs
@@ -1,9 +1,34 @@
+const LONG_LIVED_LABEL = 'preview branch'
+const PREVIEW_LABEL = 'preview release'
+
+function sanitizeBranchSlug(ref) {
+  return String(ref)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+    .replace(/-+$/g, '')
+}
+
+function deriveFeatureName(title) {
+  if (!title) {
+    return ''
+  }
+  return String(title)
+    .replace(/^\s*\([^)]*\)\s*/, '')
+    .replace(/\s*\[[A-Z]+-\d+\]\s*$/, '')
+    .trim()
+}
+
 module.exports = async ({ github, context, core }) => {
   let should_run = false
   let ref = context.sha
   let is_nightly = false
   let is_pr = false
   let pr_number = ''
+  let is_long_lived = false
+  let branch_slug = ''
+  let feature_name = ''
 
   if (context.eventName === 'workflow_dispatch') {
     console.log('Triggered manually.')
@@ -13,12 +38,29 @@ module.exports = async ({ github, context, core }) => {
     is_pr = true
     pr_number = context.payload.pull_request.number
     const labels = context.payload.pull_request.labels.map((l) => l.name)
-    if (labels.includes('preview release')) {
-      console.log('PR has preview release label.')
+    const hasLongLived = labels.includes(LONG_LIVED_LABEL)
+    const hasPreview = labels.includes(PREVIEW_LABEL)
+    if (hasLongLived) {
+      console.log(`PR has '${LONG_LIVED_LABEL}' label — long-lived channel.`)
+      should_run = true
+      is_long_lived = true
+      ref = context.payload.pull_request.head.sha
+      const headRef = context.payload.pull_request.head.ref
+      branch_slug = sanitizeBranchSlug(headRef)
+      feature_name = deriveFeatureName(context.payload.pull_request.title)
+      if (!branch_slug) {
+        core.setFailed(
+          `Could not derive a non-empty branch slug from head ref '${headRef}'.`
+        )
+        return
+      }
+      console.log(`branch_slug=${branch_slug} feature_name='${feature_name}'`)
+    } else if (hasPreview) {
+      console.log(`PR has '${PREVIEW_LABEL}' label.`)
       should_run = true
       ref = context.payload.pull_request.head.sha
     } else {
-      console.log('PR does not have preview release label.')
+      console.log('PR does not have a preview label.')
     }
   } else if (context.eventName === 'schedule') {
     is_nightly = true
@@ -55,4 +97,10 @@ module.exports = async ({ github, context, core }) => {
   core.setOutput('is_nightly', is_nightly)
   core.setOutput('is_pr', is_pr)
   core.setOutput('pr_number', pr_number)
+  core.setOutput('is_long_lived', is_long_lived)
+  core.setOutput('branch_slug', branch_slug)
+  core.setOutput('feature_name', feature_name)
 }
+
+module.exports.sanitizeBranchSlug = sanitizeBranchSlug
+module.exports.deriveFeatureName = deriveFeatureName

--- a/scripts/preview-build-check.cjs
+++ b/scripts/preview-build-check.cjs
@@ -15,8 +15,11 @@ function deriveFeatureName(title) {
     return ''
   }
   return String(title)
+    .replace(/[\r\n]+/g, ' ')
     .replace(/^\s*\([^)]*\)\s*/, '')
     .replace(/\s*\[[A-Z]+-\d+\]\s*$/, '')
+    .trim()
+    .slice(0, 200)
     .trim()
 }
 

--- a/scripts/preview-build-comment.cjs
+++ b/scripts/preview-build-comment.cjs
@@ -1,18 +1,37 @@
-module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
+module.exports = async ({
+  github,
+  context,
+  prNumber,
+  ref,
+  runNumber,
+  isLongLived = false,
+  branchSlug = '',
+  featureName = '',
+}) => {
   const MARKER = '<!-- danmaku-anywhere:preview-build-comment -->'
   const owner = context.repo.owner
   const repo = context.repo.repo
 
-  const tag = `preview-pr-${prNumber}`
+  const tag = isLongLived
+    ? `preview-branch-${branchSlug}`
+    : `preview-pr-${prNumber}`
   const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${tag}`
   const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`
   const shortSha = String(ref).substring(0, 7)
 
+  const heading = isLongLived
+    ? `### 🚀 Branch preview updated${featureName ? `: ${featureName}` : ''}`
+    : '### 🚀 Preview build ready'
+
+  const channelLine = isLongLived
+    ? `Rolling channel \`${tag}\` updated from \`${shortSha}\` (run #${runNumber}).`
+    : `Built from \`${shortSha}\` (run #${runNumber}).`
+
   const body = [
     MARKER,
-    '### 🚀 Preview build ready',
+    heading,
     '',
-    `Built from \`${shortSha}\` (run #${runNumber}).`,
+    channelLine,
     '',
     `📦 [Download from the release page](${releaseUrl}) · [Workflow run](${runUrl})`,
   ].join('\n')
@@ -53,6 +72,11 @@ module.exports = async ({ github, context, prNumber, ref, runNumber }) => {
   }
 
   await upsertComment(Number(prNumber))
+
+  if (isLongLived) {
+    console.log('Long-lived preview: skipping linked-issue comments.')
+    return
+  }
 
   let issueNumbers = []
   try {


### PR DESCRIPTION
## Summary
- Adds a new `preview branch` PR label that publishes builds into a rolling `preview-branch-<slug>` release channel (slug derived from the PR head ref), distinct from per-PR `preview-pr-<N>` tags.
- Release name strips the `(type)` prefix and `[DA-XXX]` suffix from the PR title so the resulting GitHub release reads as a human-friendly feature name (`<feature_name> · Branch Preview (<run_number>)`).
- Long-lived previews only post the release comment on the tracking PR; linked-issue commenting is skipped to avoid noise on the parent feature issue across many builds.
- Downloads page recognises the new tag namespace via a `Branch` `BuildInfo` variant rendered with a warning-toned badge showing the feature name (slug as fallback). Existing `preview-pr-` / `nightly-` matching tightened to `startsWith` so the new namespace can't be mis-classified.

## Notes
- The `preview branch` label is **not** auto-created by this PR — repo maintainer needs to add it once (any color) before the workflow can be triggered.
- Master + store-publishing path is untouched: `release.yml` still gated on `v*.*.*` tags only.
- Mutual exclusion: if a PR carries both `preview release` and `preview branch`, the long-lived path wins.

## Test plan
- [ ] Apply `preview branch` label to a test PR → verify a `preview-branch-<slug>` release is created and updated on subsequent pushes (rolling).
- [ ] Confirm only the tracking PR receives a release comment (no comment on linked issues).
- [ ] Apply the existing `preview release` label to another PR → confirm `preview-pr-<N>` behavior is unchanged (including linked-issue comments).
- [ ] On the docs Downloads page (Cloudflare preview), confirm the new release shows the warning-toned Branch badge with the feature name.