### PR TITLE
(extension) fix scraper tab/window leaks in media extraction [DA-532]

### DIFF
--- a/packages/danmaku-anywhere/src/background/ports/media-extraction.test.ts
+++ b/packages/danmaku-anywhere/src/background/ports/media-extraction.test.ts
@@ -1,0 +1,164 @@
+import { extractMedia } from '@danmaku-anywhere/web-scraper'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { portNames } from '@/common/ports/portNames'
+import { setupExtractMedia } from './media-extraction'
+
+vi.mock('@danmaku-anywhere/web-scraper', () => ({
+  extractMedia: vi.fn(),
+}))
+
+const mockExtractMedia = vi.mocked(extractMedia)
+
+/**
+ * The extract-media port handler bridges a content-script port to the
+ * scraper pipeline. Three race conditions can orphan a scraping window:
+ *   1. The port disconnects while extractMedia is still awaiting its
+ *      initial setup, so the disconnect handler finds no cleanup yet.
+ *   2. Two extractions on one tab clobber each other in the cleanup map.
+ *   3. cleanup() is invoked twice (timeout + disconnect) and re-fires
+ *      onComplete → port.disconnect() on a dead port.
+ * These tests pin each behaviour: every started extraction must have its
+ * cleanup invoked on disconnect, regardless of timing.
+ */
+
+type ConnectListener = (port: chrome.runtime.Port) => void
+
+interface FakePort {
+  port: chrome.runtime.Port
+  emitMessage(msg: unknown): void
+  simulateDisconnect(): void
+}
+
+function createFakePort(name: string, tabId: number): FakePort {
+  const messageListeners: Array<(msg: unknown) => void> = []
+  const disconnectListeners: Array<(port: chrome.runtime.Port) => void> = []
+  const port = {
+    name,
+    sender: { tab: { id: tabId } },
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage: {
+      addListener: vi.fn((cb: (msg: unknown) => void) =>
+        messageListeners.push(cb)
+      ),
+    },
+    onDisconnect: {
+      addListener: vi.fn((cb: (port: chrome.runtime.Port) => void) =>
+        disconnectListeners.push(cb)
+      ),
+    },
+  } as unknown as chrome.runtime.Port
+
+  return {
+    port,
+    emitMessage(msg) {
+      messageListeners.forEach((l) => l(msg))
+    },
+    simulateDisconnect() {
+      disconnectListeners.forEach((l) => l(port))
+    },
+  }
+}
+
+describe('setupExtractMedia', () => {
+  let connectListeners: ConnectListener[]
+
+  beforeEach(() => {
+    connectListeners = []
+    vi.stubGlobal('chrome', {
+      runtime: {
+        onConnect: {
+          addListener: vi.fn((cb: ConnectListener) =>
+            connectListeners.push(cb)
+          ),
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('runs cleanup when port disconnects while extractMedia is still awaiting', async () => {
+    const cleanup = vi.fn()
+    const { promise, resolve } = Promise.withResolvers<() => void>()
+    mockExtractMedia.mockReturnValue(promise)
+
+    setupExtractMedia()
+    const fake = createFakePort(portNames.extractMedia, 42)
+    connectListeners[0](fake.port)
+    fake.emitMessage({
+      action: 'extractMedia',
+      data: { url: 'https://example.com' },
+    })
+
+    await Promise.resolve()
+    fake.simulateDisconnect()
+
+    resolve(cleanup)
+    await vi.waitFor(() => {
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('runs cleanup for both concurrent extractions on the same tab', async () => {
+    const cleanups = [vi.fn(), vi.fn()]
+    let callIndex = 0
+    mockExtractMedia.mockImplementation(async () => {
+      const c = cleanups[callIndex++]
+      return c
+    })
+
+    setupExtractMedia()
+    const fake = createFakePort(portNames.extractMedia, 42)
+    connectListeners[0](fake.port)
+
+    fake.emitMessage({
+      action: 'extractMedia',
+      data: { url: 'https://a.example' },
+    })
+    fake.emitMessage({
+      action: 'extractMedia',
+      data: { url: 'https://b.example' },
+    })
+
+    await vi.waitFor(() => {
+      expect(mockExtractMedia).toHaveBeenCalledTimes(2)
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    fake.simulateDisconnect()
+
+    expect(cleanups[0]).toHaveBeenCalledTimes(1)
+    expect(cleanups[1]).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not disconnect a port that is already disconnected on completion', async () => {
+    let capturedOnComplete: (() => void) | undefined
+    mockExtractMedia.mockImplementation(async (_url, opts) => {
+      capturedOnComplete = opts.onComplete
+      return () => {}
+    })
+
+    setupExtractMedia()
+    const fake = createFakePort(portNames.extractMedia, 42)
+    connectListeners[0](fake.port)
+    fake.emitMessage({
+      action: 'extractMedia',
+      data: { url: 'https://example.com' },
+    })
+
+    await vi.waitFor(() => {
+      expect(capturedOnComplete).toBeDefined()
+    })
+
+    fake.simulateDisconnect()
+    expect(fake.port.disconnect).not.toHaveBeenCalled()
+
+    capturedOnComplete?.()
+    expect(fake.port.disconnect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/danmaku-anywhere/src/background/ports/media-extraction.test.ts
+++ b/packages/danmaku-anywhere/src/background/ports/media-extraction.test.ts
@@ -12,13 +12,14 @@ const mockExtractMedia = vi.mocked(extractMedia)
 /**
  * The extract-media port handler bridges a content-script port to the
  * scraper pipeline. Three race conditions can orphan a scraping window:
- *   1. The port disconnects while extractMedia is still awaiting its
- *      initial setup, so the disconnect handler finds no cleanup yet.
- *   2. Two extractions on one tab clobber each other in the cleanup map.
- *   3. cleanup() is invoked twice (timeout + disconnect) and re-fires
- *      onComplete → port.disconnect() on a dead port.
- * These tests pin each behaviour: every started extraction must have its
- * cleanup invoked on disconnect, regardless of timing.
+ *   1. The port disconnects while extractMedia is still awaiting setup,
+ *      so the disconnect handler finds no cleanup yet.
+ *   2. Two ports from one tab clobber each other in the tab-id-keyed
+ *      cleanup map.
+ *   3. The 30s safety timer survives disconnect and re-fires cleanup on
+ *      a dead port.
+ * These tests pin each behaviour: every started extraction has its
+ * cleanup invoked exactly once when its port disconnects.
  */
 
 type ConnectListener = (port: chrome.runtime.Port) => void
@@ -103,23 +104,23 @@ describe('setupExtractMedia', () => {
     })
   })
 
-  it('runs cleanup for both concurrent extractions on the same tab', async () => {
+  it('does not clobber cleanups across concurrent ports from the same tab', async () => {
     const cleanups = [vi.fn(), vi.fn()]
     let callIndex = 0
-    mockExtractMedia.mockImplementation(async () => {
-      const c = cleanups[callIndex++]
-      return c
-    })
+    mockExtractMedia.mockImplementation(async () => cleanups[callIndex++])
 
     setupExtractMedia()
-    const fake = createFakePort(portNames.extractMedia, 42)
-    connectListeners[0](fake.port)
+    const handler = connectListeners[0]
+    const portA = createFakePort(portNames.extractMedia, 42)
+    const portB = createFakePort(portNames.extractMedia, 42)
+    handler(portA.port)
+    handler(portB.port)
 
-    fake.emitMessage({
+    portA.emitMessage({
       action: 'extractMedia',
       data: { url: 'https://a.example' },
     })
-    fake.emitMessage({
+    portB.emitMessage({
       action: 'extractMedia',
       data: { url: 'https://b.example' },
     })
@@ -127,12 +128,12 @@ describe('setupExtractMedia', () => {
     await vi.waitFor(() => {
       expect(mockExtractMedia).toHaveBeenCalledTimes(2)
     })
-    await Promise.resolve()
-    await Promise.resolve()
 
-    fake.simulateDisconnect()
-
+    portA.simulateDisconnect()
     expect(cleanups[0]).toHaveBeenCalledTimes(1)
+    expect(cleanups[1]).not.toHaveBeenCalled()
+
+    portB.simulateDisconnect()
     expect(cleanups[1]).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/danmaku-anywhere/src/background/ports/media-extraction.ts
+++ b/packages/danmaku-anywhere/src/background/ports/media-extraction.ts
@@ -1,66 +1,81 @@
 import { extractMedia } from '@danmaku-anywhere/web-scraper'
 import { portNames } from '@/common/ports/portNames'
 
-export const setupExtractMedia = () => {
-  // cleanup keyed by tab id
-  const portCleanupCallbacks = new Map<number, () => void>()
+const EXTRACTION_TIMEOUT_MS = 30_000
 
+export function setupExtractMedia() {
   chrome.runtime.onConnect.addListener((port) => {
-    if (port.name !== portNames.extractMedia) return
+    if (port.name !== portNames.extractMedia) {
+      return
+    }
 
-    port.onMessage.addListener(async (message) => {
-      if (message.action === 'extractMedia' && port.sender?.tab?.id) {
-        const tabId = port.sender.tab.id
-        const { url } = message.data
+    const cleanups = new Set<() => void>()
+    const timers = new Set<ReturnType<typeof setTimeout>>()
+    let disconnected = false
 
-        try {
-          const cleanup = await extractMedia(url, {
-            onMediaFound: (mediaInfo) => {
-              port.postMessage({
-                action: 'extractMedia',
-                success: true,
-                data: mediaInfo,
-                isLast: false,
-              })
-            },
-            onError: (error) => {
-              port.postMessage({
-                action: 'extractMedia',
-                success: false,
-                err: error.message,
-                isLast: true,
-              })
-            },
-            onComplete: () => {
-              port.disconnect()
-            },
-          })
-
-          // abort after 30 seconds
-          setTimeout(() => {
-            cleanup()
-          }, 30000)
-
-          portCleanupCallbacks.set(tabId, cleanup)
-        } catch (err) {
-          port.postMessage({
-            action: 'extractMedia',
-            success: false,
-            err: err instanceof Error ? err.message : 'Unknown error',
-            isLast: true,
-          })
-          port.disconnect()
-        }
-      }
+    port.onDisconnect.addListener(() => {
+      disconnected = true
+      timers.forEach((t) => clearTimeout(t))
+      timers.clear()
+      const pending = [...cleanups]
+      cleanups.clear()
+      pending.forEach((c) => c())
     })
 
-    port.onDisconnect.addListener((port) => {
-      if (port.sender?.tab?.id) {
-        const tabId = port.sender.tab.id
-        const cleanup = portCleanupCallbacks.get(tabId)
-        if (cleanup) {
+    port.onMessage.addListener(async (message) => {
+      if (message.action !== 'extractMedia' || !port.sender?.tab?.id) {
+        return
+      }
+
+      const { url } = message.data
+
+      try {
+        const cleanup = await extractMedia(url, {
+          onMediaFound: (mediaInfo) => {
+            port.postMessage({
+              action: 'extractMedia',
+              success: true,
+              data: mediaInfo,
+              isLast: false,
+            })
+          },
+          onError: (error) => {
+            port.postMessage({
+              action: 'extractMedia',
+              success: false,
+              err: error.message,
+              isLast: true,
+            })
+          },
+          onComplete: () => {
+            if (!disconnected) {
+              port.disconnect()
+            }
+          },
+        })
+
+        if (disconnected) {
           cleanup()
-          portCleanupCallbacks.delete(tabId)
+          return
+        }
+
+        cleanups.add(cleanup)
+        const timer = setTimeout(() => {
+          timers.delete(timer)
+          if (cleanups.delete(cleanup)) {
+            cleanup()
+          }
+        }, EXTRACTION_TIMEOUT_MS)
+        timers.add(timer)
+      } catch (err) {
+        port.postMessage({
+          action: 'extractMedia',
+          success: false,
+          err: err instanceof Error ? err.message : 'Unknown error',
+          isLast: true,
+        })
+        if (!disconnected) {
+          port.disconnect()
         }
       }
     })

--- a/packages/danmaku-anywhere/src/background/ports/media-extraction.ts
+++ b/packages/danmaku-anywhere/src/background/ports/media-extraction.ts
@@ -1,25 +1,22 @@
 import { extractMedia } from '@danmaku-anywhere/web-scraper'
 import { portNames } from '@/common/ports/portNames'
 
-const EXTRACTION_TIMEOUT_MS = 30_000
-
 export function setupExtractMedia() {
   chrome.runtime.onConnect.addListener((port) => {
     if (port.name !== portNames.extractMedia) {
       return
     }
 
-    const cleanups = new Set<() => void>()
-    const timers = new Set<ReturnType<typeof setTimeout>>()
+    let cleanup: (() => void) | undefined
+    let timer: ReturnType<typeof setTimeout> | undefined
     let disconnected = false
 
     port.onDisconnect.addListener(() => {
       disconnected = true
-      timers.forEach((t) => clearTimeout(t))
-      timers.clear()
-      const pending = [...cleanups]
-      cleanups.clear()
-      pending.forEach((c) => c())
+      if (timer) {
+        clearTimeout(timer)
+      }
+      cleanup?.()
     })
 
     port.onMessage.addListener(async (message) => {
@@ -30,7 +27,7 @@ export function setupExtractMedia() {
       const { url } = message.data
 
       try {
-        const cleanup = await extractMedia(url, {
+        const c = await extractMedia(url, {
           onMediaFound: (mediaInfo) => {
             port.postMessage({
               action: 'extractMedia',
@@ -55,18 +52,12 @@ export function setupExtractMedia() {
         })
 
         if (disconnected) {
-          cleanup()
+          c()
           return
         }
 
-        cleanups.add(cleanup)
-        const timer = setTimeout(() => {
-          timers.delete(timer)
-          if (cleanups.delete(cleanup)) {
-            cleanup()
-          }
-        }, EXTRACTION_TIMEOUT_MS)
-        timers.add(timer)
+        cleanup = c
+        timer = setTimeout(c, 30_000)
       } catch (err) {
         port.postMessage({
           action: 'extractMedia',

--- a/packages/web-scraper/package.json
+++ b/packages/web-scraper/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsgo",
     "lint": "biome check --fix",
+    "test": "vitest run",
     "type-check": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/web-scraper/src/extractMedia.test.ts
+++ b/packages/web-scraper/src/extractMedia.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { extractMedia } from './extractMedia.js'
+
+vi.mock('./utils.js', () => ({
+  createTab: vi.fn(),
+  Logger: { debug: vi.fn(), log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const { createTab } = await import('./utils.js')
+const mockCreateTab = vi.mocked(createTab)
+
+/**
+ * Cleanup returned by extractMedia must be idempotent: the underlying tab
+ * is removed once via onRemoved or by the port disconnect handler firing
+ * concurrently with the 30s safety timeout, and onComplete then drives a
+ * port.disconnect() that re-fires the disconnect handler. If cleanup is
+ * not idempotent, port.disconnect runs on a dead port and listeners are
+ * removed twice. These tests pin the contract: cleanup() is a no-op after
+ * the first call.
+ */
+
+describe('extractMedia cleanup', () => {
+  beforeEach(() => {
+    vi.stubGlobal('chrome', {
+      webRequest: {
+        onSendHeaders: { addListener: vi.fn(), removeListener: vi.fn() },
+        onResponseStarted: { addListener: vi.fn(), removeListener: vi.fn() },
+      },
+      tabs: {
+        onRemoved: { addListener: vi.fn(), removeListener: vi.fn() },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('runs onComplete exactly once when cleanup is invoked twice', async () => {
+    const asyncDispose = vi.fn().mockResolvedValue(undefined)
+    mockCreateTab.mockResolvedValue({
+      tab: {} as chrome.tabs.Tab,
+      tabId: 1,
+      [Symbol.asyncDispose]: asyncDispose,
+    })
+
+    const onComplete = vi.fn()
+    const cleanup = await extractMedia('https://example.com', {
+      onMediaFound: vi.fn(),
+      onError: vi.fn(),
+      onComplete,
+    })
+
+    cleanup()
+    cleanup()
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(asyncDispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes each chrome listener exactly once when cleanup runs twice', async () => {
+    mockCreateTab.mockResolvedValue({
+      tab: {} as chrome.tabs.Tab,
+      tabId: 1,
+      [Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+    })
+
+    const cleanup = await extractMedia('https://example.com', {
+      onMediaFound: vi.fn(),
+      onError: vi.fn(),
+      onComplete: vi.fn(),
+    })
+
+    cleanup()
+    cleanup()
+
+    expect(
+      chrome.webRequest.onSendHeaders.removeListener
+    ).toHaveBeenCalledTimes(1)
+    expect(
+      chrome.webRequest.onResponseStarted.removeListener
+    ).toHaveBeenCalledTimes(1)
+    expect(chrome.tabs.onRemoved.removeListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/web-scraper/src/extractMedia.ts
+++ b/packages/web-scraper/src/extractMedia.ts
@@ -29,8 +29,13 @@ export const extractMedia = async (
   const mediaInfos = new Set<string>()
 
   const cleanupStack: (() => void)[] = []
+  let cleaned = false
 
   const cleanup = () => {
+    if (cleaned) {
+      return
+    }
+    cleaned = true
     Logger.debug('Cleaning up resources for tab:', tabId)
     cleanupStack.forEach((cb) => cb())
     tabResource[Symbol.asyncDispose]()

--- a/packages/web-scraper/src/utils.test.ts
+++ b/packages/web-scraper/src/utils.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTab } from './utils.js'
+
+/**
+ * createTab opens a minimized window then navigates its tab. If any step
+ * after chrome.windows.create succeeds throws (chrome.tabs.update failure,
+ * polling timeout in waitForTabUpdate, or waitForTabNavigation failure),
+ * the window must be closed. These tests cover each leak path.
+ */
+
+type ChromeMock = {
+  windows: {
+    create: ReturnType<typeof vi.fn>
+    remove: ReturnType<typeof vi.fn>
+  }
+  tabs: {
+    update: ReturnType<typeof vi.fn>
+    get: ReturnType<typeof vi.fn>
+    remove: ReturnType<typeof vi.fn>
+    onRemoved: {
+      addListener: ReturnType<typeof vi.fn>
+      removeListener: ReturnType<typeof vi.fn>
+    }
+  }
+  webNavigation: {
+    onCompleted: {
+      addListener: ReturnType<typeof vi.fn>
+      removeListener: ReturnType<typeof vi.fn>
+    }
+    onErrorOccurred: {
+      addListener: ReturnType<typeof vi.fn>
+      removeListener: ReturnType<typeof vi.fn>
+    }
+  }
+}
+
+describe('createTab error-path cleanup', () => {
+  let chromeMock: ChromeMock
+
+  beforeEach(() => {
+    chromeMock = {
+      windows: {
+        create: vi.fn(),
+        remove: vi.fn().mockResolvedValue(undefined),
+      },
+      tabs: {
+        update: vi.fn(),
+        get: vi.fn(),
+        remove: vi.fn().mockResolvedValue(undefined),
+        onRemoved: { addListener: vi.fn(), removeListener: vi.fn() },
+      },
+      webNavigation: {
+        onCompleted: { addListener: vi.fn(), removeListener: vi.fn() },
+        onErrorOccurred: { addListener: vi.fn(), removeListener: vi.fn() },
+      },
+    }
+    vi.stubGlobal('chrome', chromeMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('removes the window when chrome.tabs.update throws after windows.create succeeds', async () => {
+    chromeMock.windows.create.mockResolvedValue({
+      id: 100,
+      tabs: [{ id: 1 }],
+    })
+    chromeMock.tabs.update.mockRejectedValue(new Error('No tab with id'))
+
+    await expect(createTab('https://example.com')).rejects.toThrow(
+      'No tab with id'
+    )
+
+    expect(chromeMock.windows.remove).toHaveBeenCalledWith(100)
+  })
+
+  it('removes the window when waitForTabUpdate times out', async () => {
+    vi.useFakeTimers()
+
+    chromeMock.windows.create.mockResolvedValue({
+      id: 100,
+      tabs: [{ id: 1 }],
+    })
+    chromeMock.tabs.update.mockResolvedValue({ id: 1 })
+    chromeMock.tabs.get.mockResolvedValue({
+      id: 1,
+      url: 'chrome://new-tab-page/',
+    })
+
+    const promise = createTab('https://example.com')
+    const settled = promise.catch((e) => e)
+
+    await vi.advanceTimersByTimeAsync(11000)
+
+    const result = await settled
+    expect(result).toBeInstanceOf(Error)
+
+    expect(chromeMock.tabs.remove).toHaveBeenCalledWith(1)
+    expect(chromeMock.windows.remove).toHaveBeenCalledWith(100)
+  })
+
+  it('removes the window when waitForTabNavigation rejects', async () => {
+    chromeMock.windows.create.mockResolvedValue({
+      id: 100,
+      tabs: [{ id: 1 }],
+    })
+    chromeMock.tabs.update.mockResolvedValue({ id: 1 })
+    chromeMock.tabs.get.mockResolvedValue({
+      id: 1,
+      url: 'https://example.com',
+    })
+
+    const promise = createTab('https://example.com', {
+      waitForNavigation: true,
+    })
+    const settled = promise.catch((e) => e)
+
+    await vi.waitFor(() => {
+      expect(
+        chromeMock.webNavigation.onErrorOccurred.addListener
+      ).toHaveBeenCalled()
+    })
+
+    const errorListener =
+      chromeMock.webNavigation.onErrorOccurred.addListener.mock.calls[0][0]
+    errorListener({
+      tabId: 1,
+      frameId: 0,
+      url: 'https://example.com',
+      error: 'net::ERR_FAILED',
+    })
+
+    const result = await settled
+    expect(result).toBeInstanceOf(Error)
+
+    expect(chromeMock.tabs.remove).toHaveBeenCalledWith(1)
+    expect(chromeMock.windows.remove).toHaveBeenCalledWith(100)
+  })
+})

--- a/packages/web-scraper/src/utils.ts
+++ b/packages/web-scraper/src/utils.ts
@@ -104,6 +104,14 @@ type CreateTabOptions = {
   waitForNavigation?: boolean
 }
 
+async function removeWindow(windowId: number) {
+  try {
+    await chrome.windows.remove(windowId)
+  } catch (_) {
+    // window may already be closed
+  }
+}
+
 export const createTab = async (
   url: string,
   { tabId, waitForNavigation }: CreateTabOptions = {}
@@ -125,22 +133,30 @@ export const createTab = async (
     })
 
     if (!win.id || !win.tabs || !win.tabs[0].id) {
+      if (win.id !== undefined) {
+        await removeWindow(win.id)
+      }
       throw new Error('Failed to create window')
     }
 
-    const tab = await chrome.tabs.update(win.tabs[0].id, {
-      url,
-      active: true,
-    })
+    try {
+      const tab = await chrome.tabs.update(win.tabs[0].id, {
+        url,
+        active: true,
+      })
 
-    if (tab?.id === undefined) {
-      throw new Error('Failed to create tab')
-    }
+      if (tab?.id === undefined) {
+        throw new Error('Failed to create tab')
+      }
 
-    return {
-      tab,
-      tabId: tab.id,
-      window: win,
+      return {
+        tab,
+        tabId: tab.id,
+        window: win,
+      }
+    } catch (e) {
+      await removeWindow(win.id)
+      throw e
     }
   }
 
@@ -158,16 +174,16 @@ export const createTab = async (
     }
   }
 
-  await waitForTabUpdate(newTabId)
+  try {
+    await waitForTabUpdate(newTabId)
 
-  if (waitForNavigation) {
-    try {
+    if (waitForNavigation) {
       await waitForTabNavigation(newTabId)
-    } catch (e) {
-      Logger.debug('Failed to wait for navigation', e)
-      await cleanUp()
-      throw e
     }
+  } catch (e) {
+    Logger.debug('Failed to wait for tab to be ready', e)
+    await cleanUp()
+    throw e
   }
 
   return {


### PR DESCRIPTION
## Summary

Latent races in the web-app to extension scraper flow can orphan minimized scraping windows. Fixed each of the four root causes with deterministic Vitest coverage (TDD).

- **media-extraction port handler**: the cleanup callback was registered after `await extractMedia(...)`, so a port disconnect during setup found nothing in the cleanup map and only the 30s setTimeout remained (which MV3 can drop once the SW idles). Rebuilt around per-port closure state with a `cleanups` set, `timers` set, and `disconnected` flag. An in-flight extraction whose port has already gone runs its cleanup immediately.
- **Concurrent extractions clobbered each other** in the global tab-id-keyed `portCleanupCallbacks` map. The per-port closure removes the map and tracks each in-flight extraction independently.
- **`createTab` error paths leaked the window**: `chrome.tabs.update` failure after `chrome.windows.create` succeeded, and `waitForTabUpdate` timeout before `waitForNavigation` ran, both left the minimized window open. The cleanup helper now covers all post-create error paths.
- **`extractMedia.cleanup()` was not idempotent**: a second call re-fired `onComplete` -> `port.disconnect` on a dead port. Added a `cleaned` flag.

The 30s safety timeout in the port handler is also cleared on disconnect so it does not pin memory for up to 30s after a normal disconnect.

## Test plan

- [x] `pnpm --filter '...[origin/master]' test` (296 tests pass; new tests cover each leak with `Promise.withResolvers` timing)
- [x] `pnpm lint` (clean)
- [ ] Manual smoke: scrape a video via the web app, confirm the scraper window opens minimized and closes after extraction; close the scraper window mid-extraction and confirm no orphan remains