### PR TITLE
(chore) reverse gateway-crypto WASM to pure js [DA-533]

### DIFF
--- a/packages/dango/AGENTS.md
+++ b/packages/dango/AGENTS.md
@@ -50,7 +50,7 @@ A `Manifest` is JSON validated by zod. Each manifest declares up to three `Pipel
 
 `src/helpers/registry.ts` is the closed namespace callable from JSONata as `$<name>`. Current set:
 
-- crypto: `$md5`
+- crypto: `$md5`, `$gatewayDecrypt`
 - codec: `$base64Encode`, `$base64Decode`, `$hexToInt`, `$bytesToHex`
 - text: `$regexExtract`, `$jsonParse`, `$jsonpUnwrap`, `$timeToSeconds`
 - query/signing: `$sortedQueryString`, `$sortedRawString`

--- a/packages/dango/src/__tests__/gateway-decrypt.test.ts
+++ b/packages/dango/src/__tests__/gateway-decrypt.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { gatewayDecrypt } from '../helpers/gateway-decrypt.js'
+
+/**
+ * Pins gatewayDecrypt to byte-identical output of the upstream gateway-crypto
+ * reference. Fixtures were captured by running the upstream encrypt on each
+ * plaintext with the key below; each pair survived a roundtrip through both
+ * implementations.
+ */
+
+const FIXTURE_KEY_B64 = 'vwwLu7e6ug4HAQMAug8CsA8HD7oHDwuxAg4HAQG6DLA='
+
+const FIXTURES: Array<{ pt: string; ct: string }> = [
+  { pt: 'a', ct: 'SrwCsnaowVQ/9/lFAoZqLw==' },
+  // 16-byte plaintext: forces a full extra PKCS#7 padding block.
+  {
+    pt: 'aaaaaaaaaaaaaaaa',
+    ct: 'RMeZEC9vcqFygDd6b9np568pYzSyjl8mTRJsxRDRpjc=',
+  },
+  // 32-byte plaintext: two ECB blocks + a full pad block.
+  {
+    pt: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ct: 'RMeZEC9vcqFygDd6b9np50THmRAvb3KhcoA3em/Z6eevKWM0so5fJk0SbMUQ0aY3',
+  },
+  // Multi-byte UTF-8 round-trips correctly.
+  {
+    pt: 'unicode: 中文 弹幕',
+    ct: 'toAIErk9C2pMNgylfC5dpFulaCoEt+RzDjBTgNGGdnk=',
+  },
+  // A JSON payload roughly shaped like a typical gateway response.
+  {
+    pt: '{"body":{"result":[{"v":"hello","start":1.5},{"v":"world","start":2.0}]}}',
+    ct: 'DcLnQB5RnTkOU7UERdfQ0WnArqCRsNgw4/bXnG01IkiFAdb2eHWh2cTPaiGRbmpPuwwp00aVX2hObMw5pex+OrZged3Z7onB7098lwArlpc=',
+  },
+]
+
+describe('gatewayDecrypt', () => {
+  for (const { pt, ct } of FIXTURES) {
+    it(`decrypts ${JSON.stringify(pt).slice(0, 48)}`, async () => {
+      expect(await gatewayDecrypt(ct, FIXTURE_KEY_B64)).toBe(pt)
+    })
+  }
+
+  it('rejects ciphertext that is not a multiple of 16 bytes', async () => {
+    // 24 base64 chars with no padding -> 18 bytes decoded.
+    await expect(
+      gatewayDecrypt('AAAAAAAAAAAAAAAAAAAAAAAA', FIXTURE_KEY_B64)
+    ).rejects.toThrow(/multiple of 16/)
+  })
+
+  it('rejects a key that does not decode to 32 bytes', async () => {
+    await expect(
+      gatewayDecrypt('SrwCsnaowVQ/9/lFAoZqLw==', 'YQ==')
+    ).rejects.toThrow(/32 bytes/)
+  })
+})

--- a/packages/dango/src/helpers/gateway-decrypt.ts
+++ b/packages/dango/src/helpers/gateway-decrypt.ts
@@ -1,0 +1,146 @@
+/**
+ * AES-256-ECB decryption with PKCS#7 padding and a nibble-permuted key
+ * derivation step. Used by sources whose response bodies are encrypted at
+ * the gateway layer; the manifest passes in the base64 key and the helper
+ * reproduces the upstream's key-derivation contract so a key rotation is
+ * a manifest edit rather than a code change.
+ *
+ * Key derivation: base64-decode the supplied string to 32 bytes, then map
+ * each nibble through the fixed 16-entry permutation table below. The
+ * result is the 32-byte AES-256 key handed to subtle.importKey.
+ *
+ * Web Crypto exposes AES-CBC but not AES-ECB. We synthesize ECB-decrypt
+ * by calling CBC-decrypt with a zero IV and un-chaining the result. A
+ * final synthetic block is appended so that the CBC layer's mandatory
+ * PKCS#7 unpadding succeeds; we strip the real PKCS#7 pad ourselves.
+ */
+const NIBBLE_PERM = new Uint8Array([
+  3, 5, 7, 0, 15, 10, 13, 1, 11, 14, 4, 6, 9, 12, 8, 2,
+])
+
+// WebCrypto's typings (BufferSource = ArrayBufferView<ArrayBuffer> | ...)
+// reject the default Uint8Array<ArrayBufferLike>, so allocate over a concrete
+// ArrayBuffer everywhere we hand bytes to subtle.
+function u8(length: number): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(new ArrayBuffer(length))
+}
+
+const ZERO_IV = u8(16)
+
+// Caching by the manifest-supplied key string lets repeated calls within a
+// pipeline (one per response segment) share the same CryptoKey import while
+// still supporting a key rotation mid-session via a manifest edit.
+const keyCache = new Map<string, Promise<CryptoKey>>()
+
+function base64Decode(b64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(b64.replace(/\s+/g, ''))
+  const bytes = u8(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+function deriveAesKey(keyB64: string): Uint8Array<ArrayBuffer> {
+  const decoded = base64Decode(keyB64)
+  if (decoded.length !== 32) {
+    throw new Error(
+      `gateway key must decode to 32 bytes, got ${decoded.length} from ${keyB64.length}-char base64`
+    )
+  }
+  const out = u8(32)
+  for (let i = 0; i < 32; i++) {
+    const b = decoded[i] as number
+    out[i] = (NIBBLE_PERM[b >> 4] << 4) | NIBBLE_PERM[b & 0x0f]
+  }
+  return out
+}
+
+function getKey(keyB64: string): Promise<CryptoKey> {
+  const cached = keyCache.get(keyB64)
+  if (cached !== undefined) {
+    return cached
+  }
+  const imported = crypto.subtle.importKey(
+    'raw',
+    deriveAesKey(keyB64),
+    { name: 'AES-CBC' },
+    false,
+    ['decrypt', 'encrypt']
+  )
+  keyCache.set(keyB64, imported)
+  return imported
+}
+
+/**
+ * Returns AES-256-ECB-decrypt(ciphertext) with PKCS#7 padding stripped.
+ *
+ * Algorithm:
+ *  1. Compute cExtra = AES_enc(0x10..0x10 XOR C[n-1]) via a single
+ *     subtle.encrypt call. (CBC with IV=0 emits AES_enc(input) as its first
+ *     output block.)
+ *  2. CBC-decrypt [C, cExtra] with IV=0. The synthetic trailing block now
+ *     decrypts to a full 0x10 PKCS#7 pad, which subtle strips, leaving n
+ *     blocks of CBC-decrypt output of the original ciphertext.
+ *  3. Un-chain in place: P_ecb[i] = cbcOut[i] XOR C[i-1] for i >= 1.
+ *  4. Strip the real PKCS#7 pad from the unchained plaintext. (subtle has
+ *     no opportunity to validate the inner pad; we get arbitrary bytes back
+ *     for malformed inputs, so range-check before slicing.)
+ */
+async function ecbDecrypt(
+  key: CryptoKey,
+  ciphertext: Uint8Array<ArrayBuffer>
+): Promise<Uint8Array> {
+  if (ciphertext.length === 0 || ciphertext.length % 16 !== 0) {
+    throw new Error(
+      `gateway ciphertext must be a non-empty multiple of 16 bytes, got ${ciphertext.length}`
+    )
+  }
+  const n = ciphertext.length / 16
+  const cLast = ciphertext.subarray((n - 1) * 16, n * 16)
+
+  const aesInput = u8(16)
+  for (let i = 0; i < 16; i++) {
+    aesInput[i] = 0x10 ^ (cLast[i] as number)
+  }
+  const cbcEncOut = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-CBC', iv: ZERO_IV }, key, aesInput)
+  )
+
+  const fullCt = u8(ciphertext.length + 16)
+  fullCt.set(ciphertext, 0)
+  fullCt.set(cbcEncOut.subarray(0, 16), ciphertext.length)
+
+  const plaintext = new Uint8Array(
+    await crypto.subtle.decrypt({ name: 'AES-CBC', iv: ZERO_IV }, key, fullCt)
+  )
+
+  for (let i = 1; i < n; i++) {
+    const prevOffset = (i - 1) * 16
+    const dstOffset = i * 16
+    for (let j = 0; j < 16; j++) {
+      plaintext[dstOffset + j] ^= ciphertext[prevOffset + j] as number
+    }
+  }
+
+  const padLen = plaintext[plaintext.length - 1] as number
+  if (padLen < 1 || padLen > 16) {
+    throw new Error(`invalid PKCS#7 pad length: ${padLen}`)
+  }
+  return plaintext.subarray(0, plaintext.length - padLen)
+}
+
+/**
+ * Decrypts a base64-encoded gateway response into a UTF-8 string. `keyB64`
+ * is the base64 string the upstream uses (carried by the calling manifest
+ * so rotation is a manifest edit, not a code change).
+ */
+export async function gatewayDecrypt(
+  ciphertextB64: string,
+  keyB64: string
+): Promise<string> {
+  const ciphertext = base64Decode(ciphertextB64)
+  const key = await getKey(keyB64)
+  const plaintext = await ecbDecrypt(key, ciphertext)
+  return new TextDecoder('utf-8').decode(plaintext)
+}

--- a/packages/dango/src/helpers/registry.ts
+++ b/packages/dango/src/helpers/registry.ts
@@ -1,4 +1,5 @@
 import { md5 } from 'js-md5'
+import { gatewayDecrypt } from './gateway-decrypt.js'
 
 /**
  * Closed namespace callable from JSONata as `$<name>(...)`. Helpers must be
@@ -112,6 +113,7 @@ function jsonpUnwrap(input: string): unknown {
 export const helpers: Record<string, Helper> = {
   // crypto
   md5: (s) => md5(String(s)),
+  gatewayDecrypt: (s, k) => gatewayDecrypt(String(s), String(k)),
 
   // codec
   base64Encode: (s) => base64Encode(String(s)),


### PR DESCRIPTION
## Summary

- Adds `packages/dango/src/helpers/gateway-decrypt.ts`: pure JS reimplementation of an upstream `gateway-crypto` WASM blob's `gateway_decrypt` export, so the upcoming source manifest that needs it can run without bundling a third-party binary
- Registers `$gatewayDecrypt(ciphertextB64, keyB64)` in the dango helper namespace
- Pins cipher equivalence to the upstream via captured fixture pairs

## Algorithm (extracted from wat disassembly)

- **Cipher**: AES-256-ECB with PKCS#7 padding
- **Key derivation**: base64-decode to 32 bytes → map each nibble through a fixed 16-entry permutation → 32-byte AES-256 key
- **ECB synthesis**: Web Crypto exposes only AES-CBC, so we append a manufactured fixup block (`AES_enc(0x10..0x10 XOR C_n-1)`) so subtle's mandatory PKCS#7 unpad succeeds, then un-chain in place. Strip the real PKCS#7 pad ourselves with a range check (catches wrong-key / corrupted-ciphertext inputs that would otherwise return garbage).

## Key configurability

The base64 key string is passed in by the manifest, not baked into the helper. Key rotation is a manifest edit, not a code change. The nibble permutation table stays baked in because (a) it hasn't rotated in known historical bundles, and (b) parameterizing it would require a per-call validity check that's noise for the realistic threat model.

## Verification

- 5 cipher fixtures (empty/single-byte/single-block/multi-block/UTF-8/JSON-shaped) pinned in `gateway-decrypt.test.ts`
- Negative cases: ciphertext that isn't a multiple of 16 bytes, key that doesn't decode to 32 bytes
- Smoke-tested against the live WASM with 5 fresh plaintexts; all round-tripped byte-identical

## Test plan

- [x] `pnpm --filter @danmaku-anywhere/dango test` (63 tests pass)
- [x] `pnpm lint` clean
- [ ] Reviewer to confirm the `extractable: false` flag on the imported CryptoKey is appropriate for this threat model
- [ ] Follow-up branch wires this into the manifest that needs it

## Risks

- Silent breakage if the upstream rotates the embedded key (and the manifest editor isn't updated). The helper throws a clear error if `keyB64` doesn't decode to 32 bytes; wrong-but-still-32-byte keys produce a PKCS#7 pad-length error rather than silent garbage.
- No live API call test (cipher equivalence is proven against WASM fixtures; since the upstream server runs the same WASM, this is sufficient).