### PR TITLE
(extension) restore popup history stack on route persistence [DA-534]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
@@ -47,17 +47,10 @@ test('reopened popup at a nested route rebuilds back stack to ancestors', async 
   extensionId,
 }) => {
   const da = await getDaClient(context)
-  await da.storage.setRaw(
-    'session',
-    'popup:lastRoute',
-    '/config/integration-policy/edit'
-  )
+  await da.storage.setRaw('session', 'popup:lastRoute', '/config/add')
 
   await openPopup(page, extensionId)
-  await expect(page).toHaveURL(/#\/config\/integration-policy\/edit$/)
-
-  await page.goBack()
-  await expect(page).toHaveURL(/#\/config\/integration-policy$/)
+  await expect(page).toHaveURL(/#\/config\/add$/)
 
   await page.goBack()
   await expect(page).toHaveURL(/#\/config$/)

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
@@ -6,8 +6,9 @@ import { expect, test } from '../../setup/fixtures'
  * chrome.storage.session on navigation, restored on the next popup open
  * within the same session, and cleared when the stored path no longer
  * matches a known route (popup falls back to /mount). Also asserts that
- * restoration preserves a back-navigable history entry so the in-page
- * back button returns to /mount instead of dead-ending.
+ * restoration rebuilds the URL hierarchy so the in-page back button
+ * walks through ancestor routes (e.g. /options/advanced -> /options ->
+ * /mount) instead of dead-ending at home.
  */
 
 async function openPopup(page: import('@playwright/test').Page, id: string) {
@@ -35,6 +36,31 @@ test('reopened popup lands on the last-visited route within the session', async 
 
   await openPopup(page, extensionId)
   await expect(page).toHaveURL(/#\/styles$/)
+
+  await page.goBack()
+  await expect(page).toHaveURL(/#\/mount$/)
+})
+
+test('reopened popup at a nested route rebuilds back stack to ancestors', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await da.storage.setRaw(
+    'session',
+    'popup:lastRoute',
+    '/config/integration-policy/edit'
+  )
+
+  await openPopup(page, extensionId)
+  await expect(page).toHaveURL(/#\/config\/integration-policy\/edit$/)
+
+  await page.goBack()
+  await expect(page).toHaveURL(/#\/config\/integration-policy$/)
+
+  await page.goBack()
+  await expect(page).toHaveURL(/#\/config$/)
 
   await page.goBack()
   await expect(page).toHaveURL(/#\/mount$/)

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
@@ -5,8 +5,9 @@ import { expect, test } from '../../setup/fixtures'
  * Verifies popup route persistence: the active hash is written to
  * chrome.storage.session on navigation, restored on the next popup open
  * within the same session, and cleared when the stored path no longer
- * matches a known route (popup falls back to /mount). This is the
- * focus-loss reopen fix from DA-529 (issue #416).
+ * matches a known route (popup falls back to /mount). Also asserts that
+ * restoration preserves a back-navigable history entry so the in-page
+ * back button returns to /mount instead of dead-ending.
  */
 
 async function openPopup(page: import('@playwright/test').Page, id: string) {
@@ -34,6 +35,9 @@ test('reopened popup lands on the last-visited route within the session', async 
 
   await openPopup(page, extensionId)
   await expect(page).toHaveURL(/#\/styles$/)
+
+  await page.goBack()
+  await expect(page).toHaveURL(/#\/mount$/)
 })
 
 test('invalid stored route is cleared and popup falls back to /mount', async ({

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -1,13 +1,22 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { matchRoutes } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 import { getStorageArea } from '@/common/storage/getStorageArea'
 import { POPUP_ROUTE_STORAGE_KEY, router, routes } from './router'
 
 export const RootRouter = () => {
+  // Gate the persist subscriber until the restore effect has read storage.
+  // Without this, the initial /mount redirect's settled navigation can write
+  // '/mount' to storage before storage.get resolves, clobbering the persisted
+  // route the user is supposed to be restored to.
+  const restored = useRef(false)
+
   useEffect(
     () =>
       router.subscribe((state) => {
+        if (!restored.current) {
+          return
+        }
         if (state.navigation.state !== 'idle') {
           return
         }
@@ -30,24 +39,30 @@ export const RootRouter = () => {
     let cancelled = false
     const storage = getStorageArea('session')
     void (async () => {
-      const data = await storage.get(POPUP_ROUTE_STORAGE_KEY).catch(() => null)
-      if (cancelled) {
-        return
+      try {
+        const data = await storage
+          .get(POPUP_ROUTE_STORAGE_KEY)
+          .catch(() => null)
+        if (cancelled) {
+          return
+        }
+        const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
+        if (
+          typeof persisted !== 'string' ||
+          persisted === '' ||
+          persisted === '/' ||
+          persisted === '/mount'
+        ) {
+          return
+        }
+        if (!matchRoutes(routes, persisted)) {
+          void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
+          return
+        }
+        void router.navigate(persisted)
+      } finally {
+        restored.current = true
       }
-      const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
-      if (
-        typeof persisted !== 'string' ||
-        persisted === '' ||
-        persisted === '/' ||
-        persisted === '/mount'
-      ) {
-        return
-      }
-      if (!matchRoutes(routes, persisted)) {
-        void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
-        return
-      }
-      void router.navigate(persisted)
     })()
     return () => {
       cancelled = true

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -3,7 +3,12 @@ import { matchRoutes } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 import { getStorageArea } from '@/common/storage/getStorageArea'
 import { getAncestorPaths } from './getAncestorPaths'
-import { POPUP_ROUTE_STORAGE_KEY, router, routes } from './router'
+import {
+  POPUP_DEFAULT_ROUTE,
+  POPUP_ROUTE_STORAGE_KEY,
+  router,
+  routes,
+} from './router'
 
 export const RootRouter = () => {
   // Gate the persist subscriber until the restore effect is ready. Closed
@@ -39,14 +44,15 @@ export const RootRouter = () => {
   // /options/advanced -> back -> /options -> back -> /mount). A loader
   // redirect would REPLACE history and leave back() dead-ending.
   useEffect(() => {
-    let cancelled = false
+    const ac = new AbortController()
+    const { signal } = ac
     const storage = getStorageArea('session')
     void (async () => {
       try {
         const data = await storage
           .get(POPUP_ROUTE_STORAGE_KEY)
           .catch(() => null)
-        if (cancelled) {
+        if (signal.aborted) {
           return
         }
         const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
@@ -54,7 +60,7 @@ export const RootRouter = () => {
           typeof persisted !== 'string' ||
           persisted === '' ||
           persisted === '/' ||
-          persisted === '/mount'
+          persisted === POPUP_DEFAULT_ROUTE
         ) {
           return
         }
@@ -62,13 +68,18 @@ export const RootRouter = () => {
           void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
           return
         }
-        for (const ancestor of getAncestorPaths(persisted, routes)) {
-          if (cancelled) {
+        const ancestors = getAncestorPaths(
+          persisted,
+          routes,
+          POPUP_DEFAULT_ROUTE
+        )
+        for (const ancestor of ancestors) {
+          if (signal.aborted) {
             return
           }
           await router.navigate(ancestor)
         }
-        if (cancelled) {
+        if (signal.aborted) {
           return
         }
         restored.current = true
@@ -78,7 +89,7 @@ export const RootRouter = () => {
       }
     })()
     return () => {
-      cancelled = true
+      ac.abort()
     }
   }, [])
 

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -10,6 +10,53 @@ import {
   routes,
 } from './router'
 
+// Restore the persisted popup route by walking the URL hierarchy and PUSHing
+// each ancestor on top of /mount, so the in-page back button steps back
+// through the URL tree (e.g. /options/advanced -> back -> /options -> back
+// -> /mount). A loader redirect would REPLACE history and leave back()
+// dead-ending. openGate is called immediately before the final navigate so
+// the target's settled state is persisted, and again from `finally` so the
+// gate also opens on every early-return path.
+async function restoreRoute(
+  signal: AbortSignal,
+  openGate: () => void
+): Promise<void> {
+  const storage = getStorageArea('session')
+  try {
+    const data = await storage.get(POPUP_ROUTE_STORAGE_KEY).catch(() => null)
+    if (signal.aborted) {
+      return
+    }
+    const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
+    if (
+      typeof persisted !== 'string' ||
+      persisted === '' ||
+      persisted === '/' ||
+      persisted === POPUP_DEFAULT_ROUTE
+    ) {
+      return
+    }
+    if (!matchRoutes(routes, persisted)) {
+      void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
+      return
+    }
+    const ancestors = getAncestorPaths(persisted, routes, POPUP_DEFAULT_ROUTE)
+    for (const ancestor of ancestors) {
+      if (signal.aborted) {
+        return
+      }
+      await router.navigate(ancestor)
+    }
+    if (signal.aborted) {
+      return
+    }
+    openGate()
+    await router.navigate(persisted)
+  } finally {
+    openGate()
+  }
+}
+
 export const RootRouter = () => {
   // Gate the persist subscriber until the restore effect is ready. Closed
   // through storage.get and the ancestor walk so intermediate routes never
@@ -39,55 +86,11 @@ export const RootRouter = () => {
     []
   )
 
-  // Restore by walking the URL hierarchy and PUSHing each ancestor on top of
-  // /mount, so the in-page back button steps back through the URL tree (e.g.
-  // /options/advanced -> back -> /options -> back -> /mount). A loader
-  // redirect would REPLACE history and leave back() dead-ending.
   useEffect(() => {
     const ac = new AbortController()
-    const { signal } = ac
-    const storage = getStorageArea('session')
-    void (async () => {
-      try {
-        const data = await storage
-          .get(POPUP_ROUTE_STORAGE_KEY)
-          .catch(() => null)
-        if (signal.aborted) {
-          return
-        }
-        const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
-        if (
-          typeof persisted !== 'string' ||
-          persisted === '' ||
-          persisted === '/' ||
-          persisted === POPUP_DEFAULT_ROUTE
-        ) {
-          return
-        }
-        if (!matchRoutes(routes, persisted)) {
-          void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
-          return
-        }
-        const ancestors = getAncestorPaths(
-          persisted,
-          routes,
-          POPUP_DEFAULT_ROUTE
-        )
-        for (const ancestor of ancestors) {
-          if (signal.aborted) {
-            return
-          }
-          await router.navigate(ancestor)
-        }
-        if (signal.aborted) {
-          return
-        }
-        restored.current = true
-        await router.navigate(persisted)
-      } finally {
-        restored.current = true
-      }
-    })()
+    void restoreRoute(ac.signal, () => {
+      restored.current = true
+    })
     return () => {
       ac.abort()
     }

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -6,14 +6,18 @@ import { POPUP_ROUTE_STORAGE_KEY, router, routes } from './router'
 
 // Walk the URL hierarchy of `target` and return the intermediate paths that
 // resolve to real routes, excluding /mount (the initial entry) and the target
-// itself. e.g. '/options/advanced' -> ['/options']; '/styles' -> [].
+// itself. e.g. '/options/advanced' -> ['/options']; '/styles' -> []. Search
+// and hash fragments are stripped before splitting so a '/' inside a query
+// (e.g. ?next=/foo) can't be mistaken for a path segment.
 function getAncestorPaths(target: string): string[] {
-  const segments = target.split('/').filter(Boolean)
+  const queryIdx = target.search(/[?#]/)
+  const pathname = queryIdx >= 0 ? target.slice(0, queryIdx) : target
+  const segments = pathname.split('/').filter(Boolean)
   const paths: string[] = []
   let current = ''
   for (const seg of segments) {
     current += `/${seg}`
-    if (current === target || current === '/mount') {
+    if (current === pathname || current === '/mount') {
       continue
     }
     if (matchRoutes(routes, current)) {

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react'
+import { matchRoutes } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 import { getStorageArea } from '@/common/storage/getStorageArea'
-import { POPUP_ROUTE_STORAGE_KEY, router } from './router'
+import { POPUP_ROUTE_STORAGE_KEY, router, routes } from './router'
 
 export const RootRouter = () => {
   useEffect(
@@ -21,5 +22,37 @@ export const RootRouter = () => {
       }),
     []
   )
+
+  // Restore as a PUSH on top of the initial /mount entry so the in-page
+  // back button has somewhere to return to. Using a loader redirect here
+  // would REPLACE history and leave back() dead-ending.
+  useEffect(() => {
+    let cancelled = false
+    const storage = getStorageArea('session')
+    void (async () => {
+      const data = await storage.get(POPUP_ROUTE_STORAGE_KEY).catch(() => null)
+      if (cancelled) {
+        return
+      }
+      const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
+      if (
+        typeof persisted !== 'string' ||
+        persisted === '' ||
+        persisted === '/' ||
+        persisted === '/mount'
+      ) {
+        return
+      }
+      if (!matchRoutes(routes, persisted)) {
+        void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
+        return
+      }
+      void router.navigate(persisted)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   return <RouterProvider router={router} />
 }

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -59,6 +59,7 @@ export const RootRouter = () => {
           void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
           return
         }
+        restored.current = true
         void router.navigate(persisted)
       } finally {
         restored.current = true

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -4,6 +4,25 @@ import { RouterProvider } from 'react-router/dom'
 import { getStorageArea } from '@/common/storage/getStorageArea'
 import { POPUP_ROUTE_STORAGE_KEY, router, routes } from './router'
 
+// Walk the URL hierarchy of `target` and return the intermediate paths that
+// resolve to real routes, excluding /mount (the initial entry) and the target
+// itself. e.g. '/options/advanced' -> ['/options']; '/styles' -> [].
+function getAncestorPaths(target: string): string[] {
+  const segments = target.split('/').filter(Boolean)
+  const paths: string[] = []
+  let current = ''
+  for (const seg of segments) {
+    current += `/${seg}`
+    if (current === target || current === '/mount') {
+      continue
+    }
+    if (matchRoutes(routes, current)) {
+      paths.push(current)
+    }
+  }
+  return paths
+}
+
 export const RootRouter = () => {
   // Gate the persist subscriber until the restore effect has read storage.
   // Without this, the initial /mount redirect's settled navigation can write
@@ -32,9 +51,10 @@ export const RootRouter = () => {
     []
   )
 
-  // Restore as a PUSH on top of the initial /mount entry so the in-page
-  // back button has somewhere to return to. Using a loader redirect here
-  // would REPLACE history and leave back() dead-ending.
+  // Restore by walking the URL hierarchy and PUSHing each ancestor on top of
+  // /mount, so the in-page back button steps back through the URL tree (e.g.
+  // /options/advanced -> back -> /options -> back -> /mount). A loader
+  // redirect would REPLACE history and leave back() dead-ending.
   useEffect(() => {
     let cancelled = false
     const storage = getStorageArea('session')
@@ -60,7 +80,16 @@ export const RootRouter = () => {
           return
         }
         restored.current = true
-        void router.navigate(persisted)
+        for (const ancestor of getAncestorPaths(persisted)) {
+          if (cancelled) {
+            return
+          }
+          await router.navigate(ancestor)
+        }
+        if (cancelled) {
+          return
+        }
+        await router.navigate(persisted)
       } finally {
         restored.current = true
       }

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -10,13 +10,10 @@ import {
   routes,
 } from './router'
 
-// Restore the persisted popup route by walking the URL hierarchy and PUSHing
-// each ancestor on top of /mount, so the in-page back button steps back
-// through the URL tree (e.g. /options/advanced -> back -> /options -> back
-// -> /mount). A loader redirect would REPLACE history and leave back()
-// dead-ending. openGate is called immediately before the final navigate so
-// the target's settled state is persisted, and again from `finally` so the
-// gate also opens on every early-return path.
+// PUSH each ancestor of the persisted route on top of /mount so back walks
+// through them instead of dead-ending. openGate fires before the final
+// navigate (so its settled state persists) and again in finally (so
+// early-return paths still resume persistence).
 async function restoreRoute(
   signal: AbortSignal,
   openGate: () => void
@@ -58,11 +55,8 @@ async function restoreRoute(
 }
 
 export const RootRouter = () => {
-  // Gate the persist subscriber until the restore effect is ready. Closed
-  // through storage.get and the ancestor walk so intermediate routes never
-  // overwrite the target in storage; opened just before the final navigate so
-  // the target's settled state is persisted (and so subsequent user-driven
-  // navigations resume normal persistence).
+  // Gate the persist subscriber so intermediate restore navigations don't
+  // overwrite the persisted target.
   const restored = useRef(false)
 
   useEffect(

--- a/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/RootRouter.tsx
@@ -2,36 +2,15 @@ import { useEffect, useRef } from 'react'
 import { matchRoutes } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 import { getStorageArea } from '@/common/storage/getStorageArea'
+import { getAncestorPaths } from './getAncestorPaths'
 import { POPUP_ROUTE_STORAGE_KEY, router, routes } from './router'
 
-// Walk the URL hierarchy of `target` and return the intermediate paths that
-// resolve to real routes, excluding /mount (the initial entry) and the target
-// itself. e.g. '/options/advanced' -> ['/options']; '/styles' -> []. Search
-// and hash fragments are stripped before splitting so a '/' inside a query
-// (e.g. ?next=/foo) can't be mistaken for a path segment.
-function getAncestorPaths(target: string): string[] {
-  const queryIdx = target.search(/[?#]/)
-  const pathname = queryIdx >= 0 ? target.slice(0, queryIdx) : target
-  const segments = pathname.split('/').filter(Boolean)
-  const paths: string[] = []
-  let current = ''
-  for (const seg of segments) {
-    current += `/${seg}`
-    if (current === pathname || current === '/mount') {
-      continue
-    }
-    if (matchRoutes(routes, current)) {
-      paths.push(current)
-    }
-  }
-  return paths
-}
-
 export const RootRouter = () => {
-  // Gate the persist subscriber until the restore effect has read storage.
-  // Without this, the initial /mount redirect's settled navigation can write
-  // '/mount' to storage before storage.get resolves, clobbering the persisted
-  // route the user is supposed to be restored to.
+  // Gate the persist subscriber until the restore effect is ready. Closed
+  // through storage.get and the ancestor walk so intermediate routes never
+  // overwrite the target in storage; opened just before the final navigate so
+  // the target's settled state is persisted (and so subsequent user-driven
+  // navigations resume normal persistence).
   const restored = useRef(false)
 
   useEffect(
@@ -83,8 +62,7 @@ export const RootRouter = () => {
           void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
           return
         }
-        restored.current = true
-        for (const ancestor of getAncestorPaths(persisted)) {
+        for (const ancestor of getAncestorPaths(persisted, routes)) {
           if (cancelled) {
             return
           }
@@ -93,6 +71,7 @@ export const RootRouter = () => {
         if (cancelled) {
           return
         }
+        restored.current = true
         await router.navigate(persisted)
       } finally {
         restored.current = true

--- a/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.test.ts
+++ b/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.test.ts
@@ -1,0 +1,100 @@
+import type { RouteObject } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { getAncestorPaths } from './getAncestorPaths'
+import { routes as popupRoutes } from './router'
+
+/**
+ * Verifies getAncestorPaths walks a URL hierarchy and returns intermediate
+ * paths that resolve to real routes. Covers single and multi-level depth,
+ * /mount and target exclusion, search/hash stripping, unmatched intermediate
+ * segments, and the real popup route table.
+ */
+
+const fixtureRoutes: RouteObject[] = [
+  {
+    path: '/',
+    children: [
+      { path: 'mount', Component: () => null },
+      {
+        path: 'a',
+        Component: () => null,
+        children: [
+          { path: 'b', Component: () => null },
+          {
+            path: 'nested',
+            Component: () => null,
+            children: [{ path: 'deep', Component: () => null }],
+          },
+        ],
+      },
+      { path: 'c', Component: () => null },
+    ],
+  },
+]
+
+describe('getAncestorPaths', () => {
+  it('returns [] for a top-level route (no ancestors)', () => {
+    expect(getAncestorPaths('/a', fixtureRoutes)).toEqual([])
+  })
+
+  it('returns the parent for a two-level route', () => {
+    expect(getAncestorPaths('/a/b', fixtureRoutes)).toEqual(['/a'])
+  })
+
+  it('returns the chain for a three-level route', () => {
+    expect(getAncestorPaths('/a/nested/deep', fixtureRoutes)).toEqual([
+      '/a',
+      '/a/nested',
+    ])
+  })
+
+  it('excludes /mount from the chain', () => {
+    expect(getAncestorPaths('/mount', fixtureRoutes)).toEqual([])
+  })
+
+  it('strips query string before walking segments', () => {
+    expect(getAncestorPaths('/a/b?from=settings', fixtureRoutes)).toEqual([
+      '/a',
+    ])
+  })
+
+  it('strips hash fragment before walking segments', () => {
+    expect(getAncestorPaths('/a/b#anchor', fixtureRoutes)).toEqual(['/a'])
+  })
+
+  it('strips both query and hash', () => {
+    expect(getAncestorPaths('/a/b?x=1#y', fixtureRoutes)).toEqual(['/a'])
+  })
+
+  it('does not split on / inside a query string', () => {
+    expect(getAncestorPaths('/a/b?next=/c/d', fixtureRoutes)).toEqual(['/a'])
+  })
+
+  it('skips intermediate segments that do not resolve to routes', () => {
+    expect(getAncestorPaths('/a/ghost/b', fixtureRoutes)).toEqual(['/a'])
+  })
+
+  it('returns [] for the root path', () => {
+    expect(getAncestorPaths('/', fixtureRoutes)).toEqual([])
+  })
+
+  it('handles trailing slashes via Boolean filter on segments', () => {
+    expect(getAncestorPaths('/a/b/', fixtureRoutes)).toEqual(['/a'])
+  })
+
+  it('walks /options/advanced against the real popup routes', () => {
+    expect(getAncestorPaths('/options/advanced', popupRoutes)).toEqual([
+      '/options',
+    ])
+  })
+
+  it('walks /config/integration-policy/edit against the real popup routes', () => {
+    expect(
+      getAncestorPaths('/config/integration-policy/edit', popupRoutes)
+    ).toEqual(['/config', '/config/integration-policy'])
+  })
+
+  it('returns [] for /styles against the real popup routes', () => {
+    expect(getAncestorPaths('/styles', popupRoutes)).toEqual([])
+  })
+})

--- a/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.test.ts
+++ b/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.test.ts
@@ -1,13 +1,14 @@
 import type { RouteObject } from 'react-router'
 import { describe, expect, it } from 'vitest'
 import { getAncestorPaths } from './getAncestorPaths'
-import { routes as popupRoutes } from './router'
+import { POPUP_DEFAULT_ROUTE, routes as popupRoutes } from './router'
 
 /**
  * Verifies getAncestorPaths walks a URL hierarchy and returns intermediate
  * paths that resolve to real routes. Covers single and multi-level depth,
- * /mount and target exclusion, search/hash stripping, unmatched intermediate
- * segments, and the real popup route table.
+ * the alreadyInHistory and target exclusions, search/hash stripping, query
+ * strings containing '/', unmatched intermediate segments, trailing slash
+ * normalization, and the real popup route table.
  */
 
 const fixtureRoutes: RouteObject[] = [
@@ -32,69 +33,73 @@ const fixtureRoutes: RouteObject[] = [
   },
 ]
 
+const walk = (target: string, routes = fixtureRoutes) =>
+  getAncestorPaths(target, routes, '/mount')
+
 describe('getAncestorPaths', () => {
   it('returns [] for a top-level route (no ancestors)', () => {
-    expect(getAncestorPaths('/a', fixtureRoutes)).toEqual([])
+    expect(walk('/a')).toEqual([])
   })
 
   it('returns the parent for a two-level route', () => {
-    expect(getAncestorPaths('/a/b', fixtureRoutes)).toEqual(['/a'])
+    expect(walk('/a/b')).toEqual(['/a'])
   })
 
   it('returns the chain for a three-level route', () => {
-    expect(getAncestorPaths('/a/nested/deep', fixtureRoutes)).toEqual([
-      '/a',
-      '/a/nested',
-    ])
+    expect(walk('/a/nested/deep')).toEqual(['/a', '/a/nested'])
   })
 
-  it('excludes /mount from the chain', () => {
-    expect(getAncestorPaths('/mount', fixtureRoutes)).toEqual([])
+  it('excludes the alreadyInHistory path from the chain', () => {
+    expect(walk('/mount')).toEqual([])
   })
 
   it('strips query string before walking segments', () => {
-    expect(getAncestorPaths('/a/b?from=settings', fixtureRoutes)).toEqual([
-      '/a',
-    ])
+    expect(walk('/a/b?from=settings')).toEqual(['/a'])
   })
 
   it('strips hash fragment before walking segments', () => {
-    expect(getAncestorPaths('/a/b#anchor', fixtureRoutes)).toEqual(['/a'])
+    expect(walk('/a/b#anchor')).toEqual(['/a'])
   })
 
   it('strips both query and hash', () => {
-    expect(getAncestorPaths('/a/b?x=1#y', fixtureRoutes)).toEqual(['/a'])
+    expect(walk('/a/b?x=1#y')).toEqual(['/a'])
   })
 
   it('does not split on / inside a query string', () => {
-    expect(getAncestorPaths('/a/b?next=/c/d', fixtureRoutes)).toEqual(['/a'])
+    expect(walk('/a/b?next=/c/d')).toEqual(['/a'])
   })
 
   it('skips intermediate segments that do not resolve to routes', () => {
-    expect(getAncestorPaths('/a/ghost/b', fixtureRoutes)).toEqual(['/a'])
+    expect(walk('/a/ghost/b')).toEqual(['/a'])
   })
 
   it('returns [] for the root path', () => {
-    expect(getAncestorPaths('/', fixtureRoutes)).toEqual([])
+    expect(walk('/')).toEqual([])
   })
 
-  it('handles trailing slashes via Boolean filter on segments', () => {
-    expect(getAncestorPaths('/a/b/', fixtureRoutes)).toEqual(['/a'])
+  it('normalizes trailing slashes', () => {
+    expect(walk('/a/b/')).toEqual(['/a'])
   })
 
   it('walks /options/advanced against the real popup routes', () => {
-    expect(getAncestorPaths('/options/advanced', popupRoutes)).toEqual([
-      '/options',
-    ])
+    expect(
+      getAncestorPaths('/options/advanced', popupRoutes, POPUP_DEFAULT_ROUTE)
+    ).toEqual(['/options'])
   })
 
   it('walks /config/integration-policy/edit against the real popup routes', () => {
     expect(
-      getAncestorPaths('/config/integration-policy/edit', popupRoutes)
+      getAncestorPaths(
+        '/config/integration-policy/edit',
+        popupRoutes,
+        POPUP_DEFAULT_ROUTE
+      )
     ).toEqual(['/config', '/config/integration-policy'])
   })
 
   it('returns [] for /styles against the real popup routes', () => {
-    expect(getAncestorPaths('/styles', popupRoutes)).toEqual([])
+    expect(
+      getAncestorPaths('/styles', popupRoutes, POPUP_DEFAULT_ROUTE)
+    ).toEqual([])
   })
 })

--- a/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.ts
+++ b/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.ts
@@ -1,16 +1,9 @@
 import { matchRoutes, type RouteObject } from 'react-router'
 
 /**
- * Walk the URL hierarchy of `target` and return the intermediate paths that
- * resolve to real routes, excluding `alreadyInHistory` (the path that occupies
- * the current history entry, so PUSHing it would create a duplicate) and the
- * target itself. Search and hash fragments are stripped before splitting so a
- * '/' inside a query (e.g. ?next=/foo) can't be mistaken for a path segment;
- * a trailing slash is normalized so '/a/b' and '/a/b/' identify the same
- * route.
- *
- * Used by the popup route restore flow to PUSH each ancestor before the final
- * target so the in-page back button steps back through the URL tree.
+ * Return route-resolving ancestors of `target`, excluding `alreadyInHistory`
+ * (would dupe the current entry) and the target itself. Search/hash are
+ * stripped and trailing slashes normalized before walking.
  */
 export function getAncestorPaths(
   target: string,

--- a/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.ts
+++ b/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.ts
@@ -2,28 +2,30 @@ import { matchRoutes, type RouteObject } from 'react-router'
 
 /**
  * Walk the URL hierarchy of `target` and return the intermediate paths that
- * resolve to real routes, excluding /mount (the initial popup entry) and the
+ * resolve to real routes, excluding `alreadyInHistory` (the path that occupies
+ * the current history entry, so PUSHing it would create a duplicate) and the
  * target itself. Search and hash fragments are stripped before splitting so a
- * '/' inside a query (e.g. ?next=/foo) can't be mistaken for a path segment.
+ * '/' inside a query (e.g. ?next=/foo) can't be mistaken for a path segment;
+ * a trailing slash is normalized so '/a/b' and '/a/b/' identify the same
+ * route.
  *
  * Used by the popup route restore flow to PUSH each ancestor before the final
  * target so the in-page back button steps back through the URL tree.
  */
 export function getAncestorPaths(
   target: string,
-  routes: RouteObject[]
+  routes: RouteObject[],
+  alreadyInHistory: string
 ): string[] {
   const queryIdx = target.search(/[?#]/)
   const raw = queryIdx >= 0 ? target.slice(0, queryIdx) : target
-  // Normalize trailing slash so '/a/b' and '/a/b/' identify the same route
-  // and the target isn't mistaken for one of its own ancestors.
   const pathname = raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw
   const segments = pathname.split('/').filter(Boolean)
   const paths: string[] = []
   let current = ''
   for (const seg of segments) {
     current += `/${seg}`
-    if (current === pathname || current === '/mount') {
+    if (current === pathname || current === alreadyInHistory) {
       continue
     }
     if (matchRoutes(routes, current)) {

--- a/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.ts
+++ b/packages/danmaku-anywhere/src/popup/router/getAncestorPaths.ts
@@ -1,0 +1,34 @@
+import { matchRoutes, type RouteObject } from 'react-router'
+
+/**
+ * Walk the URL hierarchy of `target` and return the intermediate paths that
+ * resolve to real routes, excluding /mount (the initial popup entry) and the
+ * target itself. Search and hash fragments are stripped before splitting so a
+ * '/' inside a query (e.g. ?next=/foo) can't be mistaken for a path segment.
+ *
+ * Used by the popup route restore flow to PUSH each ancestor before the final
+ * target so the in-page back button steps back through the URL tree.
+ */
+export function getAncestorPaths(
+  target: string,
+  routes: RouteObject[]
+): string[] {
+  const queryIdx = target.search(/[?#]/)
+  const raw = queryIdx >= 0 ? target.slice(0, queryIdx) : target
+  // Normalize trailing slash so '/a/b' and '/a/b/' identify the same route
+  // and the target isn't mistaken for one of its own ancestors.
+  const pathname = raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw
+  const segments = pathname.split('/').filter(Boolean)
+  const paths: string[] = []
+  let current = ''
+  for (const seg of segments) {
+    current += `/${seg}`
+    if (current === pathname || current === '/mount') {
+      continue
+    }
+    if (matchRoutes(routes, current)) {
+      paths.push(current)
+    }
+  }
+  return paths
+}

--- a/packages/danmaku-anywhere/src/popup/router/router.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/router.tsx
@@ -23,6 +23,7 @@ import { SearchPage } from '../pages/search/SearchPage'
 import { StylesPage } from '../pages/styles/StylesPage'
 
 export const POPUP_ROUTE_STORAGE_KEY = 'popup:lastRoute'
+export const POPUP_DEFAULT_ROUTE = '/mount'
 
 export const routes: RouteObject[] = [
   {
@@ -31,7 +32,7 @@ export const routes: RouteObject[] = [
     children: [
       {
         index: true,
-        loader: () => redirect('/mount'),
+        loader: () => redirect(POPUP_DEFAULT_ROUTE),
       },
       {
         path: 'mount',

--- a/packages/danmaku-anywhere/src/popup/router/router.tsx
+++ b/packages/danmaku-anywhere/src/popup/router/router.tsx
@@ -1,10 +1,4 @@
-import {
-  createHashRouter,
-  matchRoutes,
-  type RouteObject,
-  redirect,
-} from 'react-router'
-import { getStorageArea } from '@/common/storage/getStorageArea'
+import { createHashRouter, type RouteObject, redirect } from 'react-router'
 import { ImportConfigPage } from '@/popup/pages/config/pages/import/ImportConfigPage'
 import { FilterPage } from '@/popup/pages/filterPage/FilterPage'
 import { AdvancedOptions } from '@/popup/pages/options/pages/advanced/AdvancedOptions'
@@ -30,20 +24,6 @@ import { StylesPage } from '../pages/styles/StylesPage'
 
 export const POPUP_ROUTE_STORAGE_KEY = 'popup:lastRoute'
 
-async function restoreRoute() {
-  const storage = getStorageArea('session')
-  const data = await storage.get(POPUP_ROUTE_STORAGE_KEY).catch(() => null)
-  const persisted = data?.[POPUP_ROUTE_STORAGE_KEY]
-  if (typeof persisted !== 'string' || persisted === '' || persisted === '/') {
-    return redirect('/mount')
-  }
-  if (!matchRoutes(routes, persisted)) {
-    void storage.remove(POPUP_ROUTE_STORAGE_KEY).catch(() => undefined)
-    return redirect('/mount')
-  }
-  return redirect(persisted)
-}
-
 export const routes: RouteObject[] = [
   {
     path: '/',
@@ -51,7 +31,7 @@ export const routes: RouteObject[] = [
     children: [
       {
         index: true,
-        loader: restoreRoute,
+        loader: () => redirect('/mount'),
       },
       {
         path: 'mount',


### PR DESCRIPTION
## Summary
- Move persisted-route restoration from the index-route `loader` (REPLACE) to a one-shot effect in `RootRouter` that calls `router.navigate` after the initial `/mount` redirect lands (PUSH).
- The popup history stack now has a real `/mount` entry under the restored page, so the in-page back arrow (which calls `navigate(-1)`) returns to `/mount` instead of dead-ending.
- The index route's loader is now a simple `redirect('/mount')`; persistence write-side, `matchRoutes` validation, and stale-key cleanup all preserved.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm --filter @mr-quin/danmaku-anywhere test`
- [x] `pnpm --filter @mr-quin/danmaku-anywhere exec playwright test e2e/specs/lifecycle/popupRoute.spec.ts` — both existing specs pass, plus the new back-button assertion
- [x] Manual via `dev:browser` MCP: navigated to `/options/auth`, closed and reopened popup → landed on `/options/auth`, `history.back()` returned to `/mount`; also confirmed the invalid-route fallback still clears the stale key.

Fixes #416.