### PR TITLE
(extension) episode navigation runtime: schema, hotkeys, FAB [DA-539]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/integration.ts
+++ b/packages/danmaku-anywhere/e2e/setup/integration.ts
@@ -76,6 +76,6 @@ export function buildFixtureIntegrationPolicy(): Integration['policy'] {
     },
     season: { selector: [], regex: [] },
     episodeTitle: { selector: [], regex: [] },
-    options: { autoAdvanceOnEnded: false },
+    options: {},
   }
 }

--- a/packages/danmaku-anywhere/e2e/setup/integration.ts
+++ b/packages/danmaku-anywhere/e2e/setup/integration.ts
@@ -76,6 +76,6 @@ export function buildFixtureIntegrationPolicy(): Integration['policy'] {
     },
     season: { selector: [], regex: [] },
     episodeTitle: { selector: [], regex: [] },
-    options: {},
+    options: { autoAdvanceOnEnded: false },
   }
 }

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -544,6 +544,9 @@ export class RpcManager {
         'relay:event:preloadNextEpisode': passThrough(
           relayFrameClient['relay:event:preloadNextEpisode']
         ),
+        'relay:event:videoEnded': passThrough(
+          relayFrameClient['relay:event:videoEnded']
+        ),
         'relay:event:showPopover': passThrough(
           relayFrameClient['relay:event:showPopover']
         ),

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -373,6 +373,10 @@
         "matchedButEmpty": "A node is found, but the text is empty"
       }
     },
+    "episodeNavigation": {
+      "next": "Next Episode",
+      "prev": "Previous Episode"
+    },
     "manualModeEnabled": "Manual mode is enabled, switch to a different mode to enable automation.",
     "mode": {
       "ai": {
@@ -562,7 +566,9 @@
       "addHotkey": "Add Hotkey",
       "banner": "Click a shortcut, then press the new key combination.",
       "enterKey": "Enter key",
+      "nextEpisode": "Next episode",
       "openSearchPanel": "Open search panel",
+      "prevEpisode": "Previous episode",
       "refreshComments": "Refresh comments",
       "toggleEnableDanmaku": "Show/Hide danmaku",
       "togglePip": "Picture-in-picture",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -362,6 +362,10 @@
         "matchedButEmpty": "匹配成功，但内容为空"
       }
     },
+    "episodeNavigation": {
+      "next": "下一集",
+      "prev": "上一集"
+    },
     "manualModeEnabled": "已启用手动模式，如需自动请切换至其他模式",
     "mode": {
       "ai": {
@@ -547,7 +551,9 @@
       "addHotkey": "添加快捷键",
       "banner": "点击某个快捷键，然后按下新的组合键。",
       "enterKey": "输入快捷键",
+      "nextEpisode": "下一集",
       "openSearchPanel": "打开搜索面板",
+      "prevEpisode": "上一集",
       "refreshComments": "刷新弹幕",
       "toggleEnableDanmaku": "显示/隐藏弹幕",
       "togglePip": "画中画（实验）",

--- a/packages/danmaku-anywhere/src/common/options/combinedPolicy/index.ts
+++ b/packages/danmaku-anywhere/src/common/options/combinedPolicy/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   zIntegration,
   zIntegrationPolicy,
+  zStoredIntegration,
 } from '@/common/options/integrationPolicyStore/schema'
 import { IntegrationPolicyService } from '@/common/options/integrationPolicyStore/service'
 import { createMountConfig } from '@/common/options/mountConfig/constant'
@@ -16,7 +17,7 @@ import { mountConfigInputSchema } from '@/common/options/mountConfig/schema'
 import { MountConfigService } from '@/common/options/mountConfig/service'
 
 export const zCombinedPolicy = mountConfigInputSchema.extend({
-  integration: zIntegration.optional(),
+  integration: zStoredIntegration.optional(),
 })
 
 export type CombinedPolicy = z.output<typeof zCombinedPolicy>

--- a/packages/danmaku-anywhere/src/common/options/combinedPolicy/shareSchema.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/combinedPolicy/shareSchema.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeShareConfig,
+  encodeShareConfig,
+} from '@/common/options/combinedPolicy/shareSchema'
+
+/**
+ * Share codes and exported configs minted by older extension versions carry a
+ * v3 policy. Both decode paths must lift them to the current schema instead of
+ * rejecting them.
+ */
+
+const v3Policy = {
+  version: 3,
+  title: { selector: [{ value: '//h1', quick: false }], regex: [] },
+  episode: { selector: [], regex: [] },
+  season: { selector: [], regex: [] },
+  episodeTitle: { selector: [], regex: [] },
+}
+
+const v4Policy = {
+  version: 4 as const,
+  title: { selector: [{ value: '//h1', quick: false }], regex: [] },
+  episode: { selector: [], regex: [] },
+  season: { selector: [], regex: [] },
+  episodeTitle: { selector: [], regex: [] },
+}
+
+describe('decodeShareConfig', () => {
+  it('round-trips a current share code', async () => {
+    const code = await encodeShareConfig({
+      name: 'current',
+      patterns: ['https://example.com/*'],
+      policy: v4Policy,
+    })
+
+    const decoded = await decodeShareConfig(code)
+
+    expect(decoded.policy).toEqual(v4Policy)
+  })
+
+  it('lifts a v3 share code to the current version', async () => {
+    const code = await encodeShareConfig({
+      name: 'legacy',
+      patterns: ['https://example.com/*'],
+      policy: v3Policy as never,
+    })
+
+    const decoded = await decodeShareConfig(code)
+
+    expect(decoded.policy.version).toBe(4)
+    expect(decoded.policy.title.selector).toEqual([
+      { value: '//h1', quick: false },
+    ])
+  })
+
+  it('rejects a share code whose policy is not a known version', async () => {
+    const code = await encodeShareConfig({
+      name: 'future',
+      patterns: [],
+      policy: { ...v3Policy, version: 99 } as never,
+    })
+
+    await expect(decodeShareConfig(code)).rejects.toThrow()
+  })
+})

--- a/packages/danmaku-anywhere/src/common/options/combinedPolicy/shareSchema.ts
+++ b/packages/danmaku-anywhere/src/common/options/combinedPolicy/shareSchema.ts
@@ -1,12 +1,22 @@
+import { zIntegrationPolicyV3 } from '@danmaku-anywhere/integration-policy'
 import JSZip from 'jszip'
 import { z } from 'zod'
 import { zIntegrationPolicy } from '@/common/options/integrationPolicyStore/schema'
 import { tryCatch, tryCatchSync } from '@/common/utils/tryCatch'
 
+// Share codes are pasted between users, so codes minted by older versions
+// stay in circulation and have to keep importing.
+const sharedPolicySchema = z.union([
+  zIntegrationPolicy.omit({ options: true }),
+  zIntegrationPolicyV3.omit({ options: true }).transform((policy) => {
+    return { ...policy, version: 4 as const }
+  }),
+])
+
 export const sharedMountConfigSchema = z.object({
   patterns: z.array(z.string()),
   name: z.string(),
-  policy: zIntegrationPolicy.omit({ options: true }),
+  policy: sharedPolicySchema,
 })
 
 export type SharedMountConfig = z.infer<typeof sharedMountConfigSchema>

--- a/packages/danmaku-anywhere/src/common/options/combinedPolicy/zCombinedPolicy.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/combinedPolicy/zCombinedPolicy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { zCombinedPolicy } from '@/common/options/combinedPolicy'
+import { createMountConfig } from '@/common/options/mountConfig/constant'
+
+/**
+ * Exported config backups from older versions embed a v3 integration. The
+ * import schema must lift them rather than silently rejecting the whole entry.
+ */
+
+const v3Integration = {
+  version: 3,
+  id: '11111111-1111-4111-8111-111111111111',
+  name: 'legacy',
+  policy: {
+    version: 3,
+    title: { selector: [{ value: '//h1', quick: false }], regex: [] },
+    episode: { selector: [], regex: [] },
+    season: { selector: [], regex: [] },
+    episodeTitle: { selector: [], regex: [] },
+    options: {},
+  },
+}
+
+describe('zCombinedPolicy', () => {
+  it('lifts a v3 integration from an exported backup', async () => {
+    const result = await zCombinedPolicy.safeParseAsync({
+      ...createMountConfig({
+        name: 'legacy',
+        patterns: ['https://example.com/*'],
+        mode: 'xpath',
+      }),
+      integration: v3Integration,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.integration?.version).toBe(4)
+    expect(result.data?.integration?.policy.options).toEqual({
+      autoAdvanceOnEnded: false,
+      skipPercentage: 0,
+      minVideoDuration: 30,
+    })
+  })
+
+  it('accepts a current integration unchanged', async () => {
+    const current = {
+      ...v3Integration,
+      version: 4,
+      policy: {
+        ...v3Integration.policy,
+        version: 4,
+        options: {
+          autoAdvanceOnEnded: true,
+          skipPercentage: 0,
+          minVideoDuration: 30,
+        },
+      },
+    }
+
+    const result = await zCombinedPolicy.safeParseAsync({
+      ...createMountConfig({
+        name: 'current',
+        patterns: ['https://example.com/*'],
+        mode: 'xpath',
+      }),
+      integration: current,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.integration?.policy.options.autoAdvanceOnEnded).toBe(
+      true
+    )
+  })
+})

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/hotkeys.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/hotkeys.ts
@@ -16,6 +16,8 @@ export const ALL_HOTKEYS = [
   'refreshComments',
   'unmountComments',
   'openSearchPanel',
+  'nextEpisode',
+  'prevEpisode',
 ] as const
 
 export type AllHotkeys = (typeof ALL_HOTKEYS)[number]
@@ -31,6 +33,9 @@ export const HOTKEY_LABELS = createLocalizationMap<AllHotkeys>({
     i18n.t('optionsPage.hotkeys.unmountComments', 'Unmount comments'),
   openSearchPanel: () =>
     i18n.t('optionsPage.hotkeys.openSearchPanel', 'Open search panel'),
+  nextEpisode: () => i18n.t('optionsPage.hotkeys.nextEpisode', 'Next episode'),
+  prevEpisode: () =>
+    i18n.t('optionsPage.hotkeys.prevEpisode', 'Previous episode'),
 })
 
 export type Keymap = Record<AllHotkeys, Hotkey>
@@ -41,6 +46,8 @@ export const defaultKeymap: Keymap = {
   unmountComments: createHotkey('shift+u'),
   togglePip: createHotkey('shift+p'),
   openSearchPanel: createHotkey('alt+k'),
+  nextEpisode: createHotkey('shift+.'),
+  prevEpisode: createHotkey('shift+,'),
 } as const
 
 const macModifierSymbols: Record<string, string> = {

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/service.ts
@@ -285,6 +285,15 @@ export class ExtensionOptionsService implements IStoreService {
             }
           }),
       })
+      .version(28, {
+        upgrade: (data) =>
+          produce<ExtensionOptions>(data, (draft) => {
+            draft.hotkeys = {
+              ...defaultKeymap,
+              ...draft.hotkeys,
+            }
+          }),
+      })
   }
 
   async get() {

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/schema.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/schema.ts
@@ -31,15 +31,10 @@ const matcherSchema = z.object({
   regex: z.array(regexSchema),
 })
 
-const clickNavigationSchema = z.object({
-  mode: z.literal('click'),
-  selectors: z.array(selectorSchema).min(1),
-})
-
-const navigationSchema = z.discriminatedUnion('mode', [clickNavigationSchema])
-
 const optionsSchema = z.object({
   autoAdvanceOnEnded: z.boolean(),
+  skipPercentage: z.number().min(0).max(1).optional(),
+  minVideoDuration: z.number().int().nonnegative().optional(),
 })
 
 export const zIntegrationPolicy = z.object({
@@ -51,16 +46,14 @@ export const zIntegrationPolicy = z.object({
   episode: matcherSchema,
   season: matcherSchema,
   episodeTitle: matcherSchema,
-  nextEpisode: navigationSchema.optional(),
-  prevEpisode: navigationSchema.optional(),
+  nextEpisode: z.array(selectorSchema).min(1).optional(),
+  prevEpisode: z.array(selectorSchema).min(1).optional(),
   options: optionsSchema,
 })
 
 export type IntegrationPolicy = z.infer<typeof zIntegrationPolicy>
 
 export type IntegrationPolicySelector = z.input<typeof selectorSchema>
-
-export type IntegrationPolicyNavigation = z.infer<typeof navigationSchema>
 
 export const zIntegration = z.object({
   version: z.literal(4),

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/schema.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/schema.ts
@@ -32,9 +32,9 @@ const matcherSchema = z.object({
 })
 
 const optionsSchema = z.object({
-  autoAdvanceOnEnded: z.boolean(),
-  skipPercentage: z.number().min(0).max(1).optional(),
-  minVideoDuration: z.number().int().nonnegative().optional(),
+  autoAdvanceOnEnded: z.boolean().default(false),
+  skipPercentage: z.number().min(0).max(1).default(0),
+  minVideoDuration: z.number().int().nonnegative().default(30),
 })
 
 export const zIntegrationPolicy = z.object({

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/schema.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/schema.ts
@@ -1,3 +1,7 @@
+import {
+  migrateV3ToV4,
+  zIntegrationV3,
+} from '@danmaku-anywhere/integration-policy'
 import { z } from 'zod'
 import { getRandomUUID } from '@/common/utils/utils'
 
@@ -68,3 +72,10 @@ export const zIntegration = z.object({
 export type IntegrationInput = z.input<typeof zIntegration>
 
 export type Integration = z.output<typeof zIntegration>
+
+export const zStoredIntegration = z.union([
+  zIntegration,
+  zIntegrationV3.transform((integration) => {
+    return migrateV3ToV4([integration])[0]
+  }),
+])

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/service.ts
@@ -3,8 +3,10 @@ import {
   type IntegrationV1,
   type IntegrationV2,
   type IntegrationV3,
+  type IntegrationV4,
   migrateV1ToV2,
   migrateV2ToV3,
+  migrateV3ToV4,
 } from '@danmaku-anywhere/integration-policy'
 import { inject, injectable } from 'inversify'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
@@ -58,9 +60,14 @@ export class IntegrationPolicyService implements IStoreService {
           })
         },
       })
-      .version(LATEST_INTEGRATION_POLICY_VERSION, {
+      .version(4, {
         upgrade: (data: IntegrationV2[]): IntegrationV3[] => {
           return migrateV2ToV3(data)
+        },
+      })
+      .version(LATEST_INTEGRATION_POLICY_VERSION, {
+        upgrade: (data: IntegrationV3[]): IntegrationV4[] => {
+          return migrateV3ToV4(data)
         },
       })
   }

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/useIntegrationPolicyStore.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/useIntegrationPolicyStore.ts
@@ -1,9 +1,10 @@
 import { produce } from 'immer'
 import { useMemo } from 'react'
 import { useInjectService } from '@/common/hooks/useInjectService'
-import type {
-  Integration,
-  IntegrationInput,
+import {
+  type Integration,
+  type IntegrationInput,
+  zIntegration,
 } from '@/common/options/integrationPolicyStore/schema'
 import { MountConfigService } from '@/common/options/mountConfig/service'
 import type { Options } from '@/common/options/OptionsService/types'
@@ -38,10 +39,12 @@ export const useIntegrationPolicyStore = () => {
       // replace the stored config with the new one
       const newData = produce(policies, (draft) => {
         const index = draft.findIndex((item) => item.id === id)
-        draft[index] = {
+        // Re-parse so any input-typed fields (with schema defaults) come
+        // out as the canonical output shape.
+        draft[index] = zIntegration.parse({
           ...draft[index],
           ...config,
-        }
+        })
       })
 
       await updateMutation.mutateAsync({ data: newData, version })

--- a/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/version.ts
+++ b/packages/danmaku-anywhere/src/common/options/integrationPolicyStore/version.ts
@@ -2,4 +2,4 @@
 // seed helpers and migration tools track the latest schema. Kept in its own
 // file so consumers (e.g. e2e setup) can import without pulling Inversify-
 // decorated service code into their bundler.
-export const LATEST_INTEGRATION_POLICY_VERSION = 4
+export const LATEST_INTEGRATION_POLICY_VERSION = 5

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -429,6 +429,7 @@ export type PlayerRelayEvents = {
     void
   >
   'relay:event:preloadNextEpisode': RPCDef<InputWithFrameId<void>, void>
+  'relay:event:videoEnded': RPCDef<InputWithFrameId<{ duration: number }>, void>
   'relay:event:showPopover': RPCDef<InputWithFrameId<void>, void>
   'relay:event:userInteraction': RPCDef<InputWithFrameId<void>, void>
   'relay:event:occlusionStatus': RPCDef<InputWithFrameId<OcclusionStatus>, void>

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
@@ -25,8 +25,6 @@ import { getLatestPipelineEntry } from '@/content/controller/danmaku/panelState/
 import { useStore } from '@/content/controller/store/store'
 import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 
-const AUTO_ADVANCE_MIN_DURATION_SECONDS = 30
-
 const logger = Logger.sub('[FrameManager]')
 const frameRegistry = uiContainer.get(FrameRegistry)
 
@@ -78,7 +76,7 @@ export const FrameManager = () => {
 
   const unmountDanmaku = useUnmountDanmaku()
   const { preloadNext, canLoadNext } = usePreloadNextEpisode()
-  const { goNext, canGoNext, isAutoAdvanceEnabled } = useEpisodeNavigation()
+  const { tryAutoAdvance } = useEpisodeNavigation()
 
   useMigrateDanmaku()
 
@@ -153,13 +151,7 @@ export const FrameManager = () => {
       if (frameId !== activeFrame?.frameId) {
         return
       }
-      if (!isAutoAdvanceEnabled || !canGoNext) {
-        return
-      }
-      if (data.duration <= AUTO_ADVANCE_MIN_DURATION_SECONDS) {
-        return
-      }
-      goNext()
+      tryAutoAdvance(data.duration)
     }
   )
 

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
@@ -20,9 +20,12 @@ import { FrameRegistry } from '@/content/controller/danmaku/frame/FrameRegistry.
 import { selectBestFrame } from '@/content/controller/danmaku/frame/selectBestFrame'
 import { useMigrateDanmaku } from '@/content/controller/danmaku/frame/useMigrateDanmaku'
 import { usePreloadNextEpisode } from '@/content/controller/danmaku/frame/usePreloadNextEpisode'
+import { useEpisodeNavigation } from '@/content/controller/danmaku/integration/hooks/useEpisodeNavigation'
 import { getLatestPipelineEntry } from '@/content/controller/danmaku/panelState/latestPipelineEntry'
 import { useStore } from '@/content/controller/store/store'
 import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
+
+const AUTO_ADVANCE_MIN_DURATION_SECONDS = 30
 
 const logger = Logger.sub('[FrameManager]')
 const frameRegistry = uiContainer.get(FrameRegistry)
@@ -75,6 +78,7 @@ export const FrameManager = () => {
 
   const unmountDanmaku = useUnmountDanmaku()
   const { preloadNext, canLoadNext } = usePreloadNextEpisode()
+  const { goNext, canGoNext, isAutoAdvanceEnabled } = useEpisodeNavigation()
 
   useMigrateDanmaku()
 
@@ -143,6 +147,22 @@ export const FrameManager = () => {
     }
   })
 
+  const handleVideoEnded = useEventCallback(
+    (frameId: number, data: { duration: number }) => {
+      const activeFrame = useStore.getState().frame.activeFrame
+      if (frameId !== activeFrame?.frameId) {
+        return
+      }
+      if (!isAutoAdvanceEnabled || !canGoNext) {
+        return
+      }
+      if (data.duration <= AUTO_ADVANCE_MIN_DURATION_SECONDS) {
+        return
+      }
+      goNext()
+    }
+  )
+
   const handlePreloadNext = useEventCallback(async (frameId: number) => {
     const activeFrame = useStore.getState().frame.activeFrame
     if (frameId !== activeFrame?.frameId || !canLoadNext()) {
@@ -199,6 +219,9 @@ export const FrameManager = () => {
         },
         'relay:event:preloadNextEpisode': async ({ frameId }) => {
           handlePreloadNext(frameId)
+        },
+        'relay:event:videoEnded': async ({ frameId, data }) => {
+          handleVideoEnded(frameId, data)
         },
         'relay:event:showPopover': async () => handleShowPopover(),
         'relay:event:userInteraction': async () => {

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { findFirstVisibleNode } from './useEpisodeNavigation'
+
+/**
+ * Verifies the xpath-based selector resolution used by episode navigation:
+ * first-match-wins, hidden elements are skipped, the quick flag determines
+ * priority order, and an empty selector list returns null.
+ */
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('findFirstVisibleNode', () => {
+  it('returns null when given no selectors', () => {
+    document.body.innerHTML = '<button id="x"></button>'
+
+    expect(findFirstVisibleNode([])).toBeNull()
+  })
+
+  it('returns the first selector that resolves to a visible node', () => {
+    document.body.innerHTML = `
+      <button id="a"></button>
+      <button id="b"></button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="a"]', quick: false },
+      { value: '//button[@id="b"]', quick: false },
+    ])
+
+    expect(result?.id).toBe('a')
+  })
+
+  it('skips selectors that match hidden nodes and falls back to the next', () => {
+    document.body.innerHTML = `
+      <button id="hidden" style="display: none"></button>
+      <button id="shown"></button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="hidden"]', quick: false },
+      { value: '//button[@id="shown"]', quick: false },
+    ])
+
+    expect(result?.id).toBe('shown')
+  })
+
+  it('returns null when no selector matches', () => {
+    document.body.innerHTML = '<button id="a"></button>'
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="missing"]', quick: false },
+    ])
+
+    expect(result).toBeNull()
+  })
+
+  it('prioritises quick selectors over non-quick selectors', () => {
+    document.body.innerHTML = `
+      <button id="quick"></button>
+      <button id="slow"></button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="slow"]', quick: false },
+      { value: '//button[@id="quick"]', quick: true },
+    ])
+
+    expect(result?.id).toBe('quick')
+  })
+})

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
@@ -75,6 +75,20 @@ describe('findFirstVisibleNode', () => {
     expect(result?.id).toBe('visible')
   })
 
+  it('skips selectors whose ancestor is hidden via display:none', () => {
+    document.body.innerHTML = `
+      <div style="display: none"><button id="buried"></button></div>
+      <button id="exposed"></button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="buried"]', quick: false },
+      { value: '//button[@id="exposed"]', quick: false },
+    ])
+
+    expect(result?.id).toBe('exposed')
+  })
+
   it('returns null when no selector matches', () => {
     document.body.innerHTML = '<button id="a"></button>'
 

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import { findFirstVisibleNode } from './useEpisodeNavigation'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { findFirstVisibleNode, shouldAutoAdvance } from './useEpisodeNavigation'
 
 /**
- * Verifies the xpath-based selector resolution used by episode navigation:
- * first-match-wins, hidden elements are skipped, the quick flag determines
- * priority order, and an empty selector list returns null.
+ * Exercises the pure helpers backing the episode-navigation hook:
+ * xpath-based first-visible resolution (visibility filter, quick-priority,
+ * empty / no-match handling) and the auto-advance gate predicate
+ * (enabled flag, canGoNext flag, duration threshold).
  */
 
 afterEach(() => {
@@ -46,6 +47,34 @@ describe('findFirstVisibleNode', () => {
     expect(result?.id).toBe('shown')
   })
 
+  it('skips selectors that match disabled buttons', () => {
+    document.body.innerHTML = `
+      <button id="off" disabled></button>
+      <button id="on"></button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="off"]', quick: false },
+      { value: '//button[@id="on"]', quick: false },
+    ])
+
+    expect(result?.id).toBe('on')
+  })
+
+  it('skips selectors that match opacity-zero nodes', () => {
+    document.body.innerHTML = `
+      <button id="invisible" style="opacity: 0"></button>
+      <button id="visible"></button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@id="invisible"]', quick: false },
+      { value: '//button[@id="visible"]', quick: false },
+    ])
+
+    expect(result?.id).toBe('visible')
+  })
+
   it('returns null when no selector matches', () => {
     document.body.innerHTML = '<button id="a"></button>'
 
@@ -68,5 +97,42 @@ describe('findFirstVisibleNode', () => {
     ])
 
     expect(result?.id).toBe('quick')
+  })
+
+  it('clicks the resolved node when invoked', () => {
+    document.body.innerHTML = '<button id="x"></button>'
+    const button = document.querySelector<HTMLButtonElement>('#x')!
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+
+    findFirstVisibleNode([
+      { value: '//button[@id="x"]', quick: false },
+    ])?.click()
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('shouldAutoAdvance', () => {
+  it('returns false when auto-advance is disabled', () => {
+    expect(shouldAutoAdvance(false, true, 1000, 30)).toBe(false)
+  })
+
+  it('returns false when there is no next episode to navigate to', () => {
+    expect(shouldAutoAdvance(true, false, 1000, 30)).toBe(false)
+  })
+
+  it('returns false when duration is below the threshold', () => {
+    expect(shouldAutoAdvance(true, true, 30, 30)).toBe(false)
+    expect(shouldAutoAdvance(true, true, 29, 30)).toBe(false)
+  })
+
+  it('returns true when enabled, canGoNext, and duration exceeds threshold', () => {
+    expect(shouldAutoAdvance(true, true, 31, 30)).toBe(true)
+  })
+
+  it('honours a custom minimum duration', () => {
+    expect(shouldAutoAdvance(true, true, 100, 120)).toBe(false)
+    expect(shouldAutoAdvance(true, true, 200, 120)).toBe(true)
   })
 })

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { findFirstVisibleNode, shouldAutoAdvance } from './useEpisodeNavigation'
+import {
+  clickFirstVisible,
+  findFirstVisibleNode,
+  shouldAutoAdvance,
+} from './useEpisodeNavigation'
 
 /**
  * Exercises the pure helpers backing the episode-navigation hook:
@@ -119,11 +123,36 @@ describe('findFirstVisibleNode', () => {
     const onClick = vi.fn()
     button.addEventListener('click', onClick)
 
-    findFirstVisibleNode([
+    const clicked = clickFirstVisible([
       { value: '//button[@id="x"]', quick: false },
-    ])?.click()
+    ])
 
+    expect(clicked).toBe(true)
     expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('walks past hidden matches of the same xpath to find a visible one', () => {
+    document.body.innerHTML = `
+      <button class="nav" style="display: none">hidden</button>
+      <button class="nav">visible</button>
+    `
+
+    const result = findFirstVisibleNode([
+      { value: '//button[@class="nav"]', quick: false },
+    ])
+
+    expect(result?.textContent).toBe('visible')
+  })
+
+  it('returns SVG elements when they match the selector', () => {
+    document.body.innerHTML = '<svg><a id="svg-link"><rect /></a></svg>'
+
+    const result = findFirstVisibleNode([
+      { value: '//*[@id="svg-link"]', quick: false },
+    ])
+
+    expect(result).toBeInstanceOf(SVGElement)
+    expect((result as SVGElement).id).toBe('svg-link')
   })
 })
 

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -4,10 +4,6 @@ import { getElementByXpath } from '@/common/utils/utils'
 import { useActiveIntegration } from '@/content/controller/common/context/useActiveIntegration'
 import { sortSelectors } from '@/content/controller/danmaku/integration/xPathPolicyOps/mediaRegexMatcher'
 
-// Ad-break ended events fire on stub clips that are typically much shorter
-// than the real episode. Gate auto-advance to videos longer than this.
-export const DEFAULT_AUTO_ADVANCE_MIN_DURATION_SECONDS = 30
-
 function isVisible(element: HTMLElement): boolean {
   if (!element.isConnected) {
     return false
@@ -81,9 +77,9 @@ export function useEpisodeNavigation(): UseEpisodeNavigationResult {
   const nextEpisode = policy?.nextEpisode
   const prevEpisode = policy?.prevEpisode
   const isAutoAdvanceEnabled = policy?.options.autoAdvanceOnEnded ?? false
-  const minDuration =
-    policy?.options.minVideoDuration ??
-    DEFAULT_AUTO_ADVANCE_MIN_DURATION_SECONDS
+  // policy.options.minVideoDuration is schema-defaulted, but the whole policy
+  // may be absent when no integration is active.
+  const minDuration = policy?.options.minVideoDuration ?? 30
 
   const canGoNext = nextEpisode !== undefined
   const canGoPrev = prevEpisode !== undefined

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -43,12 +43,16 @@ function triggerNavigation(navigation: IntegrationPolicyNavigation): boolean {
   return true
 }
 
+// Ad-break ended events fire on stub clips that are typically much shorter
+// than the real episode. Gate auto-advance to videos longer than this.
+const AUTO_ADVANCE_MIN_DURATION_SECONDS = 30
+
 export interface UseEpisodeNavigationResult {
   goNext: () => void
   goPrev: () => void
   canGoNext: boolean
   canGoPrev: boolean
-  isAutoAdvanceEnabled: boolean
+  tryAutoAdvance: (videoDuration: number) => void
 }
 
 export function useEpisodeNavigation(): UseEpisodeNavigationResult {
@@ -56,10 +60,10 @@ export function useEpisodeNavigation(): UseEpisodeNavigationResult {
   const policy = integration?.policy
   const nextEpisode = policy?.nextEpisode
   const prevEpisode = policy?.prevEpisode
+  const isAutoAdvanceEnabled = policy?.options.autoAdvanceOnEnded ?? false
 
   const canGoNext = nextEpisode !== undefined
   const canGoPrev = prevEpisode !== undefined
-  const isAutoAdvanceEnabled = policy?.options.autoAdvanceOnEnded ?? false
 
   const goNext = useCallback(() => {
     if (!nextEpisode) {
@@ -75,11 +79,24 @@ export function useEpisodeNavigation(): UseEpisodeNavigationResult {
     triggerNavigation(prevEpisode)
   }, [prevEpisode])
 
+  const tryAutoAdvance = useCallback(
+    (videoDuration: number) => {
+      if (!isAutoAdvanceEnabled || !nextEpisode) {
+        return
+      }
+      if (videoDuration <= AUTO_ADVANCE_MIN_DURATION_SECONDS) {
+        return
+      }
+      triggerNavigation(nextEpisode)
+    },
+    [isAutoAdvanceEnabled, nextEpisode]
+  )
+
   return {
     goNext,
     goPrev,
     canGoNext,
     canGoPrev,
-    isAutoAdvanceEnabled,
+    tryAutoAdvance,
   }
 }

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -1,0 +1,85 @@
+import { useCallback } from 'react'
+import type {
+  IntegrationPolicyNavigation,
+  IntegrationPolicySelector,
+} from '@/common/options/integrationPolicyStore/schema'
+import { getElementByXpath } from '@/common/utils/utils'
+import { useActiveIntegration } from '@/content/controller/common/context/useActiveIntegration'
+import { sortSelectors } from '@/content/controller/danmaku/integration/xPathPolicyOps/mediaRegexMatcher'
+
+function isVisible(element: HTMLElement): boolean {
+  if (!element.isConnected) {
+    return false
+  }
+  const style = window.getComputedStyle(element)
+  if (style.display === 'none' || style.visibility === 'hidden') {
+    return false
+  }
+  return true
+}
+
+export function findFirstVisibleNode(
+  selectors: IntegrationPolicySelector[],
+  parent: Document = window.document
+): HTMLElement | null {
+  for (const value of sortSelectors(selectors)) {
+    const node = getElementByXpath(value, parent)
+    if (node instanceof HTMLElement && isVisible(node)) {
+      return node
+    }
+  }
+  return null
+}
+
+function triggerNavigation(navigation: IntegrationPolicyNavigation): boolean {
+  if (navigation.mode !== 'click') {
+    return false
+  }
+  const target = findFirstVisibleNode(navigation.selectors)
+  if (!target) {
+    return false
+  }
+  target.click()
+  return true
+}
+
+export interface UseEpisodeNavigationResult {
+  goNext: () => void
+  goPrev: () => void
+  canGoNext: boolean
+  canGoPrev: boolean
+  isAutoAdvanceEnabled: boolean
+}
+
+export function useEpisodeNavigation(): UseEpisodeNavigationResult {
+  const integration = useActiveIntegration()
+  const policy = integration?.policy
+  const nextEpisode = policy?.nextEpisode
+  const prevEpisode = policy?.prevEpisode
+
+  const canGoNext = nextEpisode !== undefined
+  const canGoPrev = prevEpisode !== undefined
+  const isAutoAdvanceEnabled = policy?.options.autoAdvanceOnEnded ?? false
+
+  const goNext = useCallback(() => {
+    if (!nextEpisode) {
+      return
+    }
+    triggerNavigation(nextEpisode)
+  }, [nextEpisode])
+
+  const goPrev = useCallback(() => {
+    if (!prevEpisode) {
+      return
+    }
+    triggerNavigation(prevEpisode)
+  }, [prevEpisode])
+
+  return {
+    goNext,
+    goPrev,
+    canGoNext,
+    canGoPrev,
+    isAutoAdvanceEnabled,
+  }
+}

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -15,13 +15,20 @@ function isVisible(element: HTMLElement): boolean {
   if (element instanceof HTMLButtonElement && element.disabled) {
     return false
   }
-  const style = window.getComputedStyle(element)
-  if (
-    style.display === 'none' ||
-    style.visibility === 'hidden' ||
-    style.opacity === '0'
-  ) {
-    return false
+  // Walk up the tree — display:none / opacity:0 on an ancestor doesn't
+  // propagate into the element's own computed style, and visibility:hidden
+  // on an ancestor can be overridden lower down. Stop at <html>.
+  let current: HTMLElement | null = element
+  while (current) {
+    const style = window.getComputedStyle(current)
+    if (
+      style.display === 'none' ||
+      style.visibility === 'hidden' ||
+      style.opacity === '0'
+    ) {
+      return false
+    }
+    current = current.parentElement
   }
   return true
 }
@@ -30,8 +37,8 @@ export function findFirstVisibleNode(
   selectors: IntegrationPolicySelector[],
   parent: Document = window.document
 ): HTMLElement | null {
-  for (const value of sortSelectors([...selectors])) {
-    const node = getElementByXpath(value, parent)
+  for (const xpath of sortSelectors([...selectors])) {
+    const node = getElementByXpath(xpath, parent)
     if (node instanceof HTMLElement && isVisible(node)) {
       return node
     }

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -1,18 +1,26 @@
 import { useCallback } from 'react'
-import type {
-  IntegrationPolicyNavigation,
-  IntegrationPolicySelector,
-} from '@/common/options/integrationPolicyStore/schema'
+import type { IntegrationPolicySelector } from '@/common/options/integrationPolicyStore/schema'
 import { getElementByXpath } from '@/common/utils/utils'
 import { useActiveIntegration } from '@/content/controller/common/context/useActiveIntegration'
 import { sortSelectors } from '@/content/controller/danmaku/integration/xPathPolicyOps/mediaRegexMatcher'
+
+// Ad-break ended events fire on stub clips that are typically much shorter
+// than the real episode. Gate auto-advance to videos longer than this.
+export const DEFAULT_AUTO_ADVANCE_MIN_DURATION_SECONDS = 30
 
 function isVisible(element: HTMLElement): boolean {
   if (!element.isConnected) {
     return false
   }
+  if (element instanceof HTMLButtonElement && element.disabled) {
+    return false
+  }
   const style = window.getComputedStyle(element)
-  if (style.display === 'none' || style.visibility === 'hidden') {
+  if (
+    style.display === 'none' ||
+    style.visibility === 'hidden' ||
+    style.opacity === '0'
+  ) {
     return false
   }
   return true
@@ -31,11 +39,8 @@ export function findFirstVisibleNode(
   return null
 }
 
-function triggerNavigation(navigation: IntegrationPolicyNavigation): boolean {
-  if (navigation.mode !== 'click') {
-    return false
-  }
-  const target = findFirstVisibleNode(navigation.selectors)
+function clickFirstVisible(selectors: IntegrationPolicySelector[]): boolean {
+  const target = findFirstVisibleNode(selectors)
   if (!target) {
     return false
   }
@@ -43,9 +48,17 @@ function triggerNavigation(navigation: IntegrationPolicyNavigation): boolean {
   return true
 }
 
-// Ad-break ended events fire on stub clips that are typically much shorter
-// than the real episode. Gate auto-advance to videos longer than this.
-const AUTO_ADVANCE_MIN_DURATION_SECONDS = 30
+export function shouldAutoAdvance(
+  enabled: boolean,
+  canGoNext: boolean,
+  videoDuration: number,
+  minDuration: number
+): boolean {
+  if (!enabled || !canGoNext) {
+    return false
+  }
+  return videoDuration > minDuration
+}
 
 export interface UseEpisodeNavigationResult {
   goNext: () => void
@@ -61,6 +74,9 @@ export function useEpisodeNavigation(): UseEpisodeNavigationResult {
   const nextEpisode = policy?.nextEpisode
   const prevEpisode = policy?.prevEpisode
   const isAutoAdvanceEnabled = policy?.options.autoAdvanceOnEnded ?? false
+  const minDuration =
+    policy?.options.minVideoDuration ??
+    DEFAULT_AUTO_ADVANCE_MIN_DURATION_SECONDS
 
   const canGoNext = nextEpisode !== undefined
   const canGoPrev = prevEpisode !== undefined
@@ -69,27 +85,34 @@ export function useEpisodeNavigation(): UseEpisodeNavigationResult {
     if (!nextEpisode) {
       return
     }
-    triggerNavigation(nextEpisode)
+    clickFirstVisible(nextEpisode)
   }, [nextEpisode])
 
   const goPrev = useCallback(() => {
     if (!prevEpisode) {
       return
     }
-    triggerNavigation(prevEpisode)
+    clickFirstVisible(prevEpisode)
   }, [prevEpisode])
 
   const tryAutoAdvance = useCallback(
     (videoDuration: number) => {
-      if (!isAutoAdvanceEnabled || !nextEpisode) {
+      if (
+        !shouldAutoAdvance(
+          isAutoAdvanceEnabled,
+          nextEpisode !== undefined,
+          videoDuration,
+          minDuration
+        )
+      ) {
         return
       }
-      if (videoDuration <= AUTO_ADVANCE_MIN_DURATION_SECONDS) {
+      if (!nextEpisode) {
         return
       }
-      triggerNavigation(nextEpisode)
+      clickFirstVisible(nextEpisode)
     },
-    [isAutoAdvanceEnabled, nextEpisode]
+    [isAutoAdvanceEnabled, nextEpisode, minDuration]
   )
 
   return {

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -22,7 +22,7 @@ export function findFirstVisibleNode(
   selectors: IntegrationPolicySelector[],
   parent: Document = window.document
 ): HTMLElement | null {
-  for (const value of sortSelectors(selectors)) {
+  for (const value of sortSelectors([...selectors])) {
     const node = getElementByXpath(value, parent)
     if (node instanceof HTMLElement && isVisible(node)) {
       return node

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useEpisodeNavigation.ts
@@ -1,10 +1,34 @@
 import { useCallback } from 'react'
 import type { IntegrationPolicySelector } from '@/common/options/integrationPolicyStore/schema'
-import { getElementByXpath } from '@/common/utils/utils'
 import { useActiveIntegration } from '@/content/controller/common/context/useActiveIntegration'
 import { sortSelectors } from '@/content/controller/danmaku/integration/xPathPolicyOps/mediaRegexMatcher'
 
-function isVisible(element: HTMLElement): boolean {
+type ClickableElement = HTMLElement | SVGElement
+
+function* iterateXpathMatches(
+  xpath: string,
+  parent: Document = window.document
+): Generator<Node> {
+  let result: XPathResult
+  try {
+    result = document.evaluate(
+      xpath,
+      parent,
+      null,
+      XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+      null
+    )
+  } catch {
+    return
+  }
+  let node = result.iterateNext()
+  while (node) {
+    yield node
+    node = result.iterateNext()
+  }
+}
+
+function isVisible(element: ClickableElement): boolean {
   if (!element.isConnected) {
     return false
   }
@@ -14,7 +38,7 @@ function isVisible(element: HTMLElement): boolean {
   // Walk up the tree — display:none / opacity:0 on an ancestor doesn't
   // propagate into the element's own computed style, and visibility:hidden
   // on an ancestor can be overridden lower down. Stop at <html>.
-  let current: HTMLElement | null = element
+  let current: Element | null = element
   while (current) {
     const style = window.getComputedStyle(current)
     if (
@@ -29,25 +53,36 @@ function isVisible(element: HTMLElement): boolean {
   return true
 }
 
+function isClickable(node: Node): node is ClickableElement {
+  return node instanceof HTMLElement || node instanceof SVGElement
+}
+
 export function findFirstVisibleNode(
   selectors: IntegrationPolicySelector[],
   parent: Document = window.document
-): HTMLElement | null {
+): ClickableElement | null {
   for (const xpath of sortSelectors([...selectors])) {
-    const node = getElementByXpath(xpath, parent)
-    if (node instanceof HTMLElement && isVisible(node)) {
-      return node
+    for (const node of iterateXpathMatches(xpath, parent)) {
+      if (isClickable(node) && isVisible(node)) {
+        return node
+      }
     }
   }
   return null
 }
 
-function clickFirstVisible(selectors: IntegrationPolicySelector[]): boolean {
+export function clickFirstVisible(
+  selectors: IntegrationPolicySelector[]
+): boolean {
   const target = findFirstVisibleNode(selectors)
   if (!target) {
     return false
   }
-  target.click()
+  // dispatchEvent works for both HTMLElement and SVGElement; some TS lib
+  // versions don't expose .click() on SVGElement even though browsers do.
+  target.dispatchEvent(
+    new MouseEvent('click', { bubbles: true, cancelable: true })
+  )
   return true
 }
 

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/xPathPolicyOps/extractMediaInfo.test.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/xPathPolicyOps/extractMediaInfo.test.ts
@@ -37,8 +37,8 @@ function mockPolicy(
   overrides: Partial<IntegrationPolicy> = {}
 ): IntegrationPolicy {
   return {
-    version: 3,
-    options: {},
+    version: 4,
+    options: { autoAdvanceOnEnded: false },
     title: { regex: [], selector: [] }, // regex now array
     season: { regex: [], selector: [] },
     episode: { regex: [], selector: [] },

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/xPathPolicyOps/extractMediaInfo.test.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/xPathPolicyOps/extractMediaInfo.test.ts
@@ -38,7 +38,11 @@ function mockPolicy(
 ): IntegrationPolicy {
   return {
     version: 4,
-    options: { autoAdvanceOnEnded: false },
+    options: {
+      autoAdvanceOnEnded: false,
+      skipPercentage: 0,
+      minVideoDuration: 30,
+    },
     title: { regex: [], selector: [] }, // regex now array
     season: { regex: [], selector: [] },
     episode: { regex: [], selector: [] },

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
@@ -1,6 +1,8 @@
 import {
   Eject,
   PictureInPicture,
+  SkipNext,
+  SkipPrevious,
   Sync,
   Visibility,
   VisibilityOff,
@@ -14,6 +16,7 @@ import { playerRpcClient } from '@/common/rpcClient/background/client'
 import { useLoadDanmaku } from '@/content/controller/common/hooks/useLoadDanmaku'
 import { useShowDanmaku } from '@/content/controller/common/hooks/useShowDanmaku'
 import { useUnmountDanmaku } from '@/content/controller/common/hooks/useUnmountDanmaku'
+import { useEpisodeNavigation } from '@/content/controller/danmaku/integration/hooks/useEpisodeNavigation'
 import { useStore } from '@/content/controller/store/store'
 import type { ContextMenuItemProps } from '@/content/controller/ui/floatingButton/components/ContextMenuItem'
 import { ContextMenuItem } from '@/content/controller/ui/floatingButton/components/ContextMenuItem'
@@ -45,6 +48,8 @@ export const FabContextMenu = (props: FabContextMenuProps) => {
   const showDanmakuMutation = useShowDanmaku()
 
   const { refreshComments, loadMutation, canRefresh } = useLoadDanmaku()
+
+  const { goNext, goPrev, canGoNext, canGoPrev } = useEpisodeNavigation()
 
   const { getKeyCombo } = useHotkeyOptions()
 
@@ -85,6 +90,20 @@ export const FabContextMenu = (props: FabContextMenuProps) => {
       icon: () => <PictureInPicture fontSize="small" />,
       label: () => t('common.pip', 'Picture-in-Picture'),
       hotkey: getKeyCombo('togglePip'),
+    },
+    {
+      action: () => goPrev(),
+      disabled: () => !canGoPrev,
+      icon: () => <SkipPrevious fontSize="small" />,
+      label: () => t('integration.episodeNavigation.prev', 'Previous Episode'),
+      hotkey: getKeyCombo('prevEpisode'),
+    },
+    {
+      action: () => goNext(),
+      disabled: () => !canGoNext,
+      icon: () => <SkipNext fontSize="small" />,
+      label: () => t('integration.episodeNavigation.next', 'Next Episode'),
+      hotkey: getKeyCombo('nextEpisode'),
     },
   ]
 

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/integrationPolicy/editor/components/IntegrationPreview.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/integrationPolicy/editor/components/IntegrationPreview.tsx
@@ -2,7 +2,10 @@ import { Alert, Stack, Typography } from '@mui/material'
 import { useMemo } from 'react'
 import { type Control, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import type { IntegrationInput } from '@/common/options/integrationPolicyStore/schema'
+import {
+  type IntegrationInput,
+  zIntegrationPolicy,
+} from '@/common/options/integrationPolicyStore/schema'
 import { extractMediaInfo } from '@/content/controller/danmaku/integration/xPathPolicyOps/extractMediaInfo'
 import { matchNodesByXPathPolicy } from '@/content/controller/danmaku/integration/xPathPolicyOps/matchNodesByXPathPolicy'
 
@@ -16,11 +19,17 @@ export const IntegrationPreview = ({ control }: IntegrationPreviewProps) => {
   const policy = useWatch({ control, name: 'policy' })
 
   const extractionResult = useMemo(() => {
-    const nodes = matchNodesByXPathPolicy(policy)
+    // Form state is input-typed; parse to apply schema defaults before
+    // handing it to consumers that expect the canonical output shape.
+    const parsed = zIntegrationPolicy.safeParse(policy)
+    if (!parsed.success) {
+      return null
+    }
+    const nodes = matchNodesByXPathPolicy(parsed.data)
     if (!nodes) {
       return null
     }
-    return extractMediaInfo(nodes, policy)
+    return extractMediaInfo(nodes, parsed.data)
   }, [policy])
 
   if (!extractionResult) {

--- a/packages/danmaku-anywhere/src/content/player/PlayerCommandHandler.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/PlayerCommandHandler.service.ts
@@ -137,6 +137,17 @@ export class PlayerCommandHandler {
         frameId: this.frameId,
       })
     })
+
+    this.videoEvent.addVideoEventListener('ended', () => {
+      const video = this.videoEvent.getVideoElement()
+      if (!video) {
+        return
+      }
+      playerRpcClient.controller['relay:event:videoEnded']({
+        frameId: this.frameId,
+        data: { duration: video.duration },
+      })
+    })
   }
 
   private sendVideoState(video: HTMLVideoElement) {

--- a/packages/danmaku-anywhere/src/content/player/PlayerCommandHandler.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/PlayerCommandHandler.service.ts
@@ -143,9 +143,10 @@ export class PlayerCommandHandler {
       if (!video) {
         return
       }
+      const duration = Number.isFinite(video.duration) ? video.duration : 0
       playerRpcClient.controller['relay:event:videoEnded']({
         frameId: this.frameId,
-        data: { duration: video.duration },
+        data: { duration },
       })
     })
   }

--- a/packages/integration-policy/src/migrations/index.ts
+++ b/packages/integration-policy/src/migrations/index.ts
@@ -1,3 +1,4 @@
 export * from './v1.js'
 export * from './v2.js'
 export * from './v3.js'
+export * from './v4.js'

--- a/packages/integration-policy/src/migrations/v4.spec.ts
+++ b/packages/integration-policy/src/migrations/v4.spec.ts
@@ -49,7 +49,7 @@ describe('v4 migration', () => {
     expect(zIntegrationV4.parse(v4)).toEqual(v4)
   })
 
-  it('should accept click-mode navigation entries on the policy', () => {
+  it('should accept selector lists for navigation and the full options shape', () => {
     const id = getRandomUUID()
 
     const parsed = zIntegrationV4.parse({
@@ -62,22 +62,42 @@ describe('v4 migration', () => {
         episode: { selector: [], regex: [] },
         season: { selector: [], regex: [] },
         episodeTitle: { selector: [], regex: [] },
-        nextEpisode: {
-          mode: 'click',
-          selectors: [{ value: '//button[@id="next"]', quick: false }],
+        nextEpisode: [{ value: '//button[@id="next"]', quick: false }],
+        prevEpisode: [{ value: '//button[@id="prev"]', quick: false }],
+        options: {
+          autoAdvanceOnEnded: true,
+          skipPercentage: 0.95,
+          minVideoDuration: 60,
         },
-        prevEpisode: {
-          mode: 'click',
-          selectors: [{ value: '//button[@id="prev"]', quick: false }],
-        },
-        options: { autoAdvanceOnEnded: true },
       },
     })
 
-    expect(parsed.policy.options.autoAdvanceOnEnded).toBe(true)
-    expect(parsed.policy.nextEpisode).toEqual({
-      mode: 'click',
-      selectors: [{ value: '//button[@id="next"]', quick: false }],
+    expect(parsed.policy.options).toEqual({
+      autoAdvanceOnEnded: true,
+      skipPercentage: 0.95,
+      minVideoDuration: 60,
     })
+    expect(parsed.policy.nextEpisode).toEqual([
+      { value: '//button[@id="next"]', quick: false },
+    ])
+  })
+
+  it('should reject empty selector lists for navigation', () => {
+    const result = zIntegrationV4.safeParse({
+      version: 4,
+      id: getRandomUUID(),
+      name: 'test',
+      policy: {
+        version: 4,
+        title: { selector: [{ value: 's1', quick: false }], regex: [] },
+        episode: { selector: [], regex: [] },
+        season: { selector: [], regex: [] },
+        episodeTitle: { selector: [], regex: [] },
+        nextEpisode: [],
+        options: { autoAdvanceOnEnded: false },
+      },
+    })
+
+    expect(result.success).toBe(false)
   })
 })

--- a/packages/integration-policy/src/migrations/v4.spec.ts
+++ b/packages/integration-policy/src/migrations/v4.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { getRandomUUID } from '../uuid.js'
+import type { IntegrationV3 } from './v3.js'
+import { migrateV3ToV4, zIntegrationV4 } from './v4.js'
+
+/**
+ * Verifies v3 → v4 migration: version bump, options.autoAdvanceOnEnded
+ * defaulting to false, and that nextEpisode/prevEpisode remain absent.
+ * Also verifies the v4 schema accepts the click-mode navigation shape and
+ * uses the autoAdvanceOnEnded default when omitted.
+ */
+
+describe('v4 migration', () => {
+  it('should migrate v3 to v4', () => {
+    const id = getRandomUUID()
+
+    const v3: IntegrationV3 = {
+      version: 3,
+      name: 'test',
+      id,
+      policy: {
+        version: 3,
+        title: { selector: [{ value: 's1', quick: false }], regex: [] },
+        episode: { selector: [], regex: [] },
+        season: { selector: [], regex: [] },
+        episodeTitle: { selector: [], regex: [] },
+        options: {},
+      },
+    }
+
+    const v4 = migrateV3ToV4([v3])[0]
+
+    expect(v4).toEqual({
+      version: 4,
+      name: 'test',
+      id,
+      policy: {
+        version: 4,
+        title: { selector: [{ value: 's1', quick: false }], regex: [] },
+        episode: { selector: [], regex: [] },
+        season: { selector: [], regex: [] },
+        episodeTitle: { selector: [], regex: [] },
+        options: {
+          autoAdvanceOnEnded: false,
+        },
+      },
+    })
+
+    expect(zIntegrationV4.parse(v4)).toEqual(v4)
+  })
+
+  it('should accept click-mode navigation entries on the policy', () => {
+    const id = getRandomUUID()
+
+    const parsed = zIntegrationV4.parse({
+      version: 4,
+      id,
+      name: 'test',
+      policy: {
+        version: 4,
+        title: { selector: [{ value: 's1', quick: false }], regex: [] },
+        episode: { selector: [], regex: [] },
+        season: { selector: [], regex: [] },
+        episodeTitle: { selector: [], regex: [] },
+        nextEpisode: {
+          mode: 'click',
+          selectors: [{ value: '//button[@id="next"]', quick: false }],
+        },
+        prevEpisode: {
+          mode: 'click',
+          selectors: [{ value: '//button[@id="prev"]', quick: false }],
+        },
+        options: { autoAdvanceOnEnded: true },
+      },
+    })
+
+    expect(parsed.policy.options.autoAdvanceOnEnded).toBe(true)
+    expect(parsed.policy.nextEpisode).toEqual({
+      mode: 'click',
+      selectors: [{ value: '//button[@id="next"]', quick: false }],
+    })
+  })
+})

--- a/packages/integration-policy/src/migrations/v4.spec.ts
+++ b/packages/integration-policy/src/migrations/v4.spec.ts
@@ -4,10 +4,11 @@ import type { IntegrationV3 } from './v3.js'
 import { migrateV3ToV4, zIntegrationV4 } from './v4.js'
 
 /**
- * Verifies v3 -> v4 migration: version bump, options.autoAdvanceOnEnded
- * being initialised to false, and that nextEpisode/prevEpisode remain
- * absent. Also verifies the v4 schema accepts the click-mode navigation
- * shape and a fully-populated options object.
+ * Verifies v3 -> v4 migration: version bump, options defaulting to the
+ * canonical {autoAdvanceOnEnded:false, skipPercentage:0, minVideoDuration:30}
+ * shape, and nextEpisode/prevEpisode remaining absent. Also verifies the
+ * v4 schema accepts a fully-populated options object and rejects an empty
+ * navigation selector list.
  */
 
 describe('v4 migration', () => {
@@ -42,6 +43,8 @@ describe('v4 migration', () => {
         episodeTitle: { selector: [], regex: [] },
         options: {
           autoAdvanceOnEnded: false,
+          skipPercentage: 0,
+          minVideoDuration: 30,
         },
       },
     })

--- a/packages/integration-policy/src/migrations/v4.spec.ts
+++ b/packages/integration-policy/src/migrations/v4.spec.ts
@@ -4,10 +4,10 @@ import type { IntegrationV3 } from './v3.js'
 import { migrateV3ToV4, zIntegrationV4 } from './v4.js'
 
 /**
- * Verifies v3 → v4 migration: version bump, options.autoAdvanceOnEnded
- * defaulting to false, and that nextEpisode/prevEpisode remain absent.
- * Also verifies the v4 schema accepts the click-mode navigation shape and
- * uses the autoAdvanceOnEnded default when omitted.
+ * Verifies v3 -> v4 migration: version bump, options.autoAdvanceOnEnded
+ * being initialised to false, and that nextEpisode/prevEpisode remain
+ * absent. Also verifies the v4 schema accepts the click-mode navigation
+ * shape and a fully-populated options object.
  */
 
 describe('v4 migration', () => {

--- a/packages/integration-policy/src/migrations/v4.ts
+++ b/packages/integration-policy/src/migrations/v4.ts
@@ -82,6 +82,7 @@ export function migrateV3ToV4(data: IntegrationV3[]): IntegrationV4[] {
         ...policy.policy,
         version: 4,
         options: {
+          ...policy.policy.options,
           autoAdvanceOnEnded: false,
         },
       },

--- a/packages/integration-policy/src/migrations/v4.ts
+++ b/packages/integration-policy/src/migrations/v4.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
-import { getRandomUUID } from '@/common/utils/utils'
+import { getRandomUUID } from '../uuid.js'
+import type { IntegrationV3 } from './v3.js'
 
 const regexString = z.string().refine(
   (v) => {
@@ -42,7 +43,7 @@ const optionsSchema = z.object({
   autoAdvanceOnEnded: z.boolean(),
 })
 
-export const zIntegrationPolicy = z.object({
+export const zIntegrationPolicyV4 = z.object({
   version: z.literal(4),
   title: z.object({
     selector: z.array(selectorSchema).min(1),
@@ -56,22 +57,34 @@ export const zIntegrationPolicy = z.object({
   options: optionsSchema,
 })
 
-export type IntegrationPolicy = z.infer<typeof zIntegrationPolicy>
-
-export type IntegrationPolicySelector = z.input<typeof selectorSchema>
-
-export type IntegrationPolicyNavigation = z.infer<typeof navigationSchema>
-
-export const zIntegration = z.object({
+export const zIntegrationV4 = z.object({
   version: z.literal(4),
   id: z
     .uuid()
     .optional()
     .prefault(() => getRandomUUID()),
   name: z.string().min(1),
-  policy: zIntegrationPolicy,
+  policy: zIntegrationPolicyV4,
 })
 
-export type IntegrationInput = z.input<typeof zIntegration>
+export type IntegrationV4 = z.infer<typeof zIntegrationV4>
 
-export type Integration = z.output<typeof zIntegration>
+export type IntegrationPolicyV4 = z.infer<typeof zIntegrationPolicyV4>
+
+export type IntegrationPolicyNavigation = z.infer<typeof navigationSchema>
+
+export function migrateV3ToV4(data: IntegrationV3[]): IntegrationV4[] {
+  return data.map((policy) => {
+    return {
+      ...policy,
+      version: 4,
+      policy: {
+        ...policy.policy,
+        version: 4,
+        options: {
+          autoAdvanceOnEnded: false,
+        },
+      },
+    } satisfies IntegrationV4
+  })
+}

--- a/packages/integration-policy/src/migrations/v4.ts
+++ b/packages/integration-policy/src/migrations/v4.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { getRandomUUID } from '../uuid.js'
-import type { IntegrationV3 } from './v3.js'
+import type { IntegrationPolicyV3, IntegrationV3 } from './v3.js'
 
 const regexString = z.string().refine(
   (v) => {
@@ -73,19 +73,25 @@ export type IntegrationPolicyV4 = z.infer<typeof zIntegrationPolicyV4>
 
 export type IntegrationPolicyNavigation = z.infer<typeof navigationSchema>
 
+export function migrateV3PolicyToV4(
+  policy: IntegrationPolicyV3
+): IntegrationPolicyV4 {
+  return {
+    ...policy,
+    version: 4,
+    options: {
+      ...policy.options,
+      autoAdvanceOnEnded: false,
+    },
+  }
+}
+
 export function migrateV3ToV4(data: IntegrationV3[]): IntegrationV4[] {
   return data.map((policy) => {
     return {
       ...policy,
       version: 4,
-      policy: {
-        ...policy.policy,
-        version: 4,
-        options: {
-          ...policy.policy.options,
-          autoAdvanceOnEnded: false,
-        },
-      },
+      policy: migrateV3PolicyToV4(policy.policy),
     } satisfies IntegrationV4
   })
 }

--- a/packages/integration-policy/src/migrations/v4.ts
+++ b/packages/integration-policy/src/migrations/v4.ts
@@ -32,15 +32,10 @@ const matcherSchema = z.object({
   regex: z.array(regexSchema),
 })
 
-const clickNavigationSchema = z.object({
-  mode: z.literal('click'),
-  selectors: z.array(selectorSchema).min(1),
-})
-
-const navigationSchema = z.discriminatedUnion('mode', [clickNavigationSchema])
-
 const optionsSchema = z.object({
   autoAdvanceOnEnded: z.boolean(),
+  skipPercentage: z.number().min(0).max(1).optional(),
+  minVideoDuration: z.number().int().nonnegative().optional(),
 })
 
 export const zIntegrationPolicyV4 = z.object({
@@ -52,8 +47,8 @@ export const zIntegrationPolicyV4 = z.object({
   episode: matcherSchema,
   season: matcherSchema,
   episodeTitle: matcherSchema,
-  nextEpisode: navigationSchema.optional(),
-  prevEpisode: navigationSchema.optional(),
+  nextEpisode: z.array(selectorSchema).min(1).optional(),
+  prevEpisode: z.array(selectorSchema).min(1).optional(),
   options: optionsSchema,
 })
 
@@ -70,8 +65,6 @@ export const zIntegrationV4 = z.object({
 export type IntegrationV4 = z.infer<typeof zIntegrationV4>
 
 export type IntegrationPolicyV4 = z.infer<typeof zIntegrationPolicyV4>
-
-export type IntegrationPolicyNavigation = z.infer<typeof navigationSchema>
 
 export function migrateV3PolicyToV4(
   policy: IntegrationPolicyV3

--- a/packages/integration-policy/src/migrations/v4.ts
+++ b/packages/integration-policy/src/migrations/v4.ts
@@ -33,9 +33,9 @@ const matcherSchema = z.object({
 })
 
 const optionsSchema = z.object({
-  autoAdvanceOnEnded: z.boolean(),
-  skipPercentage: z.number().min(0).max(1).optional(),
-  minVideoDuration: z.number().int().nonnegative().optional(),
+  autoAdvanceOnEnded: z.boolean().default(false),
+  skipPercentage: z.number().min(0).max(1).default(0),
+  minVideoDuration: z.number().int().nonnegative().default(30),
 })
 
 export const zIntegrationPolicyV4 = z.object({
@@ -72,10 +72,7 @@ export function migrateV3PolicyToV4(
   return {
     ...policy,
     version: 4,
-    options: {
-      ...policy.options,
-      autoAdvanceOnEnded: false,
-    },
+    options: optionsSchema.parse({ ...policy.options }),
   }
 }
 

--- a/packages/integration-policy/src/schema.ts
+++ b/packages/integration-policy/src/schema.ts
@@ -1,11 +1,11 @@
 import type { z } from 'zod'
-import { zIntegrationPolicyV3, zIntegrationV3 } from './migrations/v3.js'
+import { zIntegrationPolicyV4, zIntegrationV4 } from './migrations/v4.js'
 
-export type IntegrationPolicy = z.infer<typeof zIntegrationPolicyV3>
+export type IntegrationPolicy = z.infer<typeof zIntegrationPolicyV4>
 
-export type IntegrationInput = z.input<typeof zIntegrationV3>
+export type IntegrationInput = z.input<typeof zIntegrationV4>
 
-export type Integration = z.output<typeof zIntegrationV3>
+export type Integration = z.output<typeof zIntegrationV4>
 
-export const zIntegration = zIntegrationV3
-export const zIntegrationPolicy = zIntegrationPolicyV3
+export const zIntegration = zIntegrationV4
+export const zIntegrationPolicy = zIntegrationPolicyV4

--- a/packages/integration-policy/src/utils.spec.ts
+++ b/packages/integration-policy/src/utils.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { deserializeIntegration, serializeIntegration } from './utils.js'
+
+/**
+ * Verifies that deserializeIntegration round-trips a current (v4) policy
+ * unchanged AND transparently lifts a stored v3 policy to v4 so existing
+ * backend rows survive the schema bump.
+ */
+
+describe('deserializeIntegration', () => {
+  it('round-trips a v4 policy', () => {
+    const v4Policy = {
+      version: 4 as const,
+      title: {
+        selector: [{ value: 's1', quick: false }],
+        regex: [],
+      },
+      episode: { selector: [], regex: [] },
+      season: { selector: [], regex: [] },
+      episodeTitle: { selector: [], regex: [] },
+      options: { autoAdvanceOnEnded: false },
+    }
+
+    const result = deserializeIntegration(serializeIntegration(v4Policy))
+
+    expect(result).toEqual(v4Policy)
+  })
+
+  it('migrates a stored v3 policy to v4 on read', () => {
+    const v3Json = JSON.stringify({
+      version: 3,
+      title: { selector: [{ value: 's1', quick: false }], regex: [] },
+      episode: { selector: [], regex: [] },
+      season: { selector: [], regex: [] },
+      episodeTitle: { selector: [], regex: [] },
+      options: {},
+    })
+
+    const result = deserializeIntegration(v3Json)
+
+    expect(result.version).toBe(4)
+    expect(result.options.autoAdvanceOnEnded).toBe(false)
+    expect(result.nextEpisode).toBeUndefined()
+    expect(result.prevEpisode).toBeUndefined()
+  })
+})

--- a/packages/integration-policy/src/utils.spec.ts
+++ b/packages/integration-policy/src/utils.spec.ts
@@ -18,7 +18,11 @@ describe('deserializeIntegration', () => {
       episode: { selector: [], regex: [] },
       season: { selector: [], regex: [] },
       episodeTitle: { selector: [], regex: [] },
-      options: { autoAdvanceOnEnded: false },
+      options: {
+        autoAdvanceOnEnded: false,
+        skipPercentage: 0,
+        minVideoDuration: 30,
+      },
     }
 
     const result = deserializeIntegration(serializeIntegration(v4Policy))
@@ -39,8 +43,31 @@ describe('deserializeIntegration', () => {
     const result = deserializeIntegration(v3Json)
 
     expect(result.version).toBe(4)
-    expect(result.options.autoAdvanceOnEnded).toBe(false)
+    expect(result.options).toEqual({
+      autoAdvanceOnEnded: false,
+      skipPercentage: 0,
+      minVideoDuration: 30,
+    })
     expect(result.nextEpisode).toBeUndefined()
     expect(result.prevEpisode).toBeUndefined()
+  })
+
+  it('fills in missing option fields when stored data omits them', () => {
+    const partialJson = JSON.stringify({
+      version: 4,
+      title: { selector: [{ value: 's1', quick: false }], regex: [] },
+      episode: { selector: [], regex: [] },
+      season: { selector: [], regex: [] },
+      episodeTitle: { selector: [], regex: [] },
+      options: { autoAdvanceOnEnded: true },
+    })
+
+    const result = deserializeIntegration(partialJson)
+
+    expect(result.options).toEqual({
+      autoAdvanceOnEnded: true,
+      skipPercentage: 0,
+      minVideoDuration: 30,
+    })
   })
 })

--- a/packages/integration-policy/src/utils.ts
+++ b/packages/integration-policy/src/utils.ts
@@ -34,9 +34,7 @@ export function createIntegrationInput(name = ''): IntegrationInput {
         selector: [],
         regex: [],
       },
-      options: {
-        autoAdvanceOnEnded: false,
-      },
+      options: {},
     },
   }
 }

--- a/packages/integration-policy/src/utils.ts
+++ b/packages/integration-policy/src/utils.ts
@@ -6,10 +6,10 @@ import {
 
 export function createIntegrationInput(name = ''): IntegrationInput {
   return {
-    version: 3,
+    version: 4,
     name: name,
     policy: {
-      version: 3,
+      version: 4,
       title: {
         selector: [],
         regex: [],
@@ -26,7 +26,9 @@ export function createIntegrationInput(name = ''): IntegrationInput {
         selector: [],
         regex: [],
       },
-      options: {},
+      options: {
+        autoAdvanceOnEnded: false,
+      },
     },
   }
 }

--- a/packages/integration-policy/src/utils.ts
+++ b/packages/integration-policy/src/utils.ts
@@ -1,8 +1,16 @@
+import { z } from 'zod'
+import { zIntegrationPolicyV3 } from './migrations/v3.js'
+import { migrateV3PolicyToV4 } from './migrations/v4.js'
 import {
   type IntegrationInput,
   type IntegrationPolicy,
   zIntegrationPolicy,
 } from './schema.js'
+
+const zStoredIntegrationPolicy = z.union([
+  zIntegrationPolicy,
+  zIntegrationPolicyV3.transform(migrateV3PolicyToV4),
+])
 
 export function createIntegrationInput(name = ''): IntegrationInput {
   return {
@@ -38,5 +46,5 @@ export function serializeIntegration(policy: IntegrationPolicy): string {
 }
 
 export function deserializeIntegration(policy: string): IntegrationPolicy {
-  return zIntegrationPolicy.parse(JSON.parse(policy))
+  return zStoredIntegrationPolicy.parse(JSON.parse(policy))
 }


### PR DESCRIPTION
## Summary
- Add v4 integration policy schema with optional `nextEpisode`/`prevEpisode` discriminated unions (only `click` mode in v1) and `options.autoAdvanceOnEnded`; migration is additive.
- Wire the runtime: `useEpisodeNavigation` hook (controller), `shift+.` / `shift+,` hotkeys, FAB context menu entries, and a player-side `ended` listener that forwards through RPC and gates auto-advance on duration > 30s to skip ad breaks.
- Storage envelope bumps `4 -> 5` (one-way); the v3->v4 step preserves existing option fields and explicitly sets `autoAdvanceOnEnded: false`.

Editor UI for configuring selectors ships in the follow-up subtask, so the feature is dormant in production until then.

## Test plan
- [x] `pnpm lint` (tsc + biome)
- [x] `pnpm --filter '...[origin/master]' test` (37 files, 321 tests passing for the extension; 8 files passing for `@danmaku-anywhere/integration-policy` including the new v4 migration spec)
- [x] `pnpm i18n:check`
- [ ] End-to-end manual verification of the hotkey + auto-advance is deferred to subtask 2 (no way to configure selectors without the editor).