### PR TITLE
(extension) default debug mode on in dev builds [DA-555]

### DIFF
--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/constant.ts
@@ -1,5 +1,6 @@
 import { DanDanChConvert } from '@danmaku-anywhere/danmaku-provider/ddp'
 
+import { IS_DA_DEV } from '@/common/constants'
 import { Language } from '@/common/localization/language'
 import { defaultKeymap } from '@/common/options/extensionOptions/hotkeys'
 import type { ExtensionOptions } from '@/common/options/extensionOptions/schema'
@@ -22,7 +23,7 @@ export const ChConvertList = [
 
 export const defaultExtensionOptions: ExtensionOptions = {
   enabled: true,
-  debug: false,
+  debug: IS_DA_DEV,
   lang: Language.zh,
   searchUsingSimplified: false,
   retentionPolicy: {


### PR DESCRIPTION
## Summary
- Default the extension's `debug` option to `IS_DA_DEV` instead of `false`, so dev builds (`DA_ENV === 'dev'`) start with debug logging/UI on without a manual toggle. Preview, prod, and e2e builds keep `debug` off by default, and users can still toggle it.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere type-check` (passes)
- e2e coverage is infeasible: the new default only applies to fresh `DA_ENV === 'dev'` installs, while e2e runs under `DA_ENV === 'e2e'` where `debug` stays `false`, so there is no observable change to assert in the suite.

## Notes
- Only affects fresh installs. Existing installs keep their stored `debug` value (migration v12 already set it), so this does not flip debug on for current dev profiles.