### PR TITLE
(proxy) route web app Bangumi API calls through backend proxy [DA-570]

### DIFF
--- a/app/web/src/app/features/bangumi/services/bangumiClient.ts
+++ b/app/web/src/app/features/bangumi/services/bangumiClient.ts
@@ -1,8 +1,9 @@
 import type { paths } from '@danmaku-anywhere/bangumi-api'
 import createClient from 'openapi-fetch'
+import { environment } from '../../../../environments/environment'
 
 export const bangumiClient = createClient<paths>({
-  baseUrl: 'https://api.bgm.tv/',
+  baseUrl: `${environment.apiRoot}/bangumi/api`,
 })
 
 bangumiClient.use({

--- a/app/web/src/app/features/bangumi/services/bangumiNextClient.ts
+++ b/app/web/src/app/features/bangumi/services/bangumiNextClient.ts
@@ -1,8 +1,9 @@
 import type { paths } from '@danmaku-anywhere/bangumi-api/next'
 import createClient from 'openapi-fetch'
+import { environment } from '../../../../environments/environment'
 
 export const bangumiNextClient = createClient<paths>({
-  baseUrl: 'https://next.bgm.tv/',
+  baseUrl: `${environment.apiRoot}/bangumi/next`,
 })
 
 bangumiNextClient.use({

--- a/backend/proxy/src/routes/api/bangumi/bangumi.test.ts
+++ b/backend/proxy/src/routes/api/bangumi/bangumi.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createTestUrl } from '@/test-utils/createTestUrl'
+import { makeUnitTestRequest } from '@/test-utils/makeUnitTestRequest'
+
+describe('Bangumi proxy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('forwards GET /next/* to next.bgm.tv preserving path and query', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+    const request = new Request(
+      createTestUrl('/bangumi/next/p1/trending/subjects', {
+        query: { type: '2', limit: '20' },
+      })
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(200)
+
+    const forwarded = fetchSpy.mock.calls[0][0] as Request
+    const forwardedUrl = new URL(forwarded.url)
+    expect(forwardedUrl.origin).toBe('https://next.bgm.tv')
+    expect(forwardedUrl.pathname).toBe('/p1/trending/subjects')
+    expect(forwardedUrl.searchParams.get('type')).toBe('2')
+    expect(forwardedUrl.searchParams.get('limit')).toBe('20')
+  })
+
+  it('forwards POST /api/* to api.bgm.tv preserving method and body', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+
+    const body = JSON.stringify({ keyword: 'test' })
+    const request = new Request(
+      createTestUrl('/bangumi/api/v0/search/subjects'),
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      }
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(200)
+
+    const forwarded = fetchSpy.mock.calls[0][0] as Request
+    const forwardedUrl = new URL(forwarded.url)
+    expect(forwarded.method).toBe('POST')
+    expect(forwardedUrl.origin).toBe('https://api.bgm.tv')
+    expect(forwardedUrl.pathname).toBe('/v0/search/subjects')
+    expect(await forwarded.text()).toBe(body)
+  })
+
+  it('strips cookies and sets a User-Agent on the upstream request', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+    const request = new Request(createTestUrl('/bangumi/next/p1/calendar'), {
+      headers: { cookie: 'session=secret' },
+    })
+    await makeUnitTestRequest(request)
+
+    const forwarded = fetchSpy.mock.calls[0][0] as Request
+    expect(forwarded.headers.get('cookie')).toBeNull()
+    expect(forwarded.headers.get('user-agent')).toContain('danmaku-anywhere')
+  })
+})

--- a/backend/proxy/src/routes/api/bangumi/bangumi.test.ts
+++ b/backend/proxy/src/routes/api/bangumi/bangumi.test.ts
@@ -55,18 +55,40 @@ describe('Bangumi proxy', () => {
     expect(await forwarded.text()).toBe(body)
   })
 
-  it('strips cookies and sets a User-Agent on the upstream request', async () => {
+  it('forwards only allowlisted headers and sets a User-Agent', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
 
     const request = new Request(createTestUrl('/bangumi/next/p1/calendar'), {
-      headers: { cookie: 'session=secret' },
+      headers: {
+        cookie: 'session=secret',
+        authorization: 'Bearer leak-me',
+        accept: 'application/json',
+      },
     })
     await makeUnitTestRequest(request)
 
     const forwarded = fetchSpy.mock.calls[0][0] as Request
     expect(forwarded.headers.get('cookie')).toBeNull()
+    expect(forwarded.headers.get('authorization')).toBeNull()
+    expect(forwarded.headers.get('accept')).toBe('application/json')
     expect(forwarded.headers.get('user-agent')).toContain('danmaku-anywhere')
+  })
+
+  it.each([
+    '/bangumi/next//evil.com/x',
+    '/bangumi/api//evil.com/x',
+    '/bangumi/next/%2f%2fevil.com/x',
+  ])('keeps the upstream origin pinned for %s', async (path) => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+
+    await makeUnitTestRequest(new Request(createTestUrl(path)))
+
+    const forwarded = fetchSpy.mock.calls[0][0] as Request
+    expect(new URL(forwarded.url).hostname).toMatch(/\.bgm\.tv$/)
+    expect(new URL(forwarded.url).hostname).not.toBe('evil.com')
   })
 })

--- a/backend/proxy/src/routes/api/bangumi/bangumi.ts
+++ b/backend/proxy/src/routes/api/bangumi/bangumi.ts
@@ -1,0 +1,35 @@
+import { describeRoute, resolver } from 'hono-openapi'
+import z from 'zod'
+import { factory } from '@/factory'
+
+const USER_AGENT =
+  'danmaku-anywhere (https://github.com/Mr-Quin/danmaku-anywhere)'
+
+const proxyDescription = describeRoute({
+  description:
+    'Transparent proxy to the external Bangumi API. The request and response bodies are passed through to/from Bangumi, so the response schema is defined by the upstream Bangumi endpoint rather than this service.',
+  responses: {
+    200: {
+      description:
+        'Successful proxy response from the external Bangumi API. The JSON payload is returned as-is from Bangumi and may vary depending on the proxied endpoint.',
+      content: {
+        'application/json': { schema: resolver(z.any()) },
+      },
+    },
+  },
+})
+
+export function bangumiProxy(upstreamOrigin: string) {
+  return factory.createHandlers(proxyDescription, async (c) => {
+    const path = c.req.param('path') ?? ''
+    const incoming = new URL(c.req.url)
+    const target = new URL(`/${path}${incoming.search}`, upstreamOrigin)
+
+    const request = new Request(target, c.req.raw)
+    request.headers.delete('cookie')
+    request.headers.delete('host')
+    request.headers.set('user-agent', USER_AGENT)
+
+    return fetch(request)
+  })
+}

--- a/backend/proxy/src/routes/api/bangumi/bangumi.ts
+++ b/backend/proxy/src/routes/api/bangumi/bangumi.ts
@@ -5,6 +5,11 @@ import { factory } from '@/factory'
 const USER_AGENT =
   'danmaku-anywhere (https://github.com/Mr-Quin/danmaku-anywhere)'
 
+// Bangumi only serves public data, so we forward a minimal anonymous header
+// set. Dropping auth/cookie keeps every upstream call identical across users,
+// which is what makes the shared response cache safe.
+const FORWARDED_HEADERS = ['accept', 'accept-language', 'content-type']
+
 const proxyDescription = describeRoute({
   description:
     'Transparent proxy to the external Bangumi API. The request and response bodies are passed through to/from Bangumi, so the response schema is defined by the upstream Bangumi endpoint rather than this service.',
@@ -21,13 +26,20 @@ const proxyDescription = describeRoute({
 
 export function bangumiProxy(upstreamOrigin: string) {
   return factory.createHandlers(proxyDescription, async (c) => {
-    const path = c.req.param('path') ?? ''
-    const incoming = new URL(c.req.url)
-    const target = new URL(`/${path}${incoming.search}`, upstreamOrigin)
+    const path = c.req.param('path')
+
+    // Assigning pathname/search on the parsed origin keeps the host pinned to
+    // upstreamOrigin even when the captured path looks like `//evil.com`.
+    const target = new URL(upstreamOrigin)
+    target.pathname = `/${path}`
+    target.search = new URL(c.req.url).search
 
     const request = new Request(target, c.req.raw)
-    request.headers.delete('cookie')
-    request.headers.delete('host')
+    for (const name of [...request.headers.keys()]) {
+      if (!FORWARDED_HEADERS.includes(name)) {
+        request.headers.delete(name)
+      }
+    }
     request.headers.set('user-agent', USER_AGENT)
 
     return fetch(request)

--- a/backend/proxy/src/routes/api/bangumi/bangumi.ts
+++ b/backend/proxy/src/routes/api/bangumi/bangumi.ts
@@ -34,13 +34,24 @@ export function bangumiProxy(upstreamOrigin: string) {
     target.pathname = `/${path}`
     target.search = new URL(c.req.url).search
 
-    const request = new Request(target, c.req.raw)
-    for (const name of [...request.headers.keys()]) {
-      if (!FORWARDED_HEADERS.includes(name)) {
-        request.headers.delete(name)
+    const headers = new Headers()
+    for (const name of FORWARDED_HEADERS) {
+      const value = c.req.header(name)
+      if (value) {
+        headers.set(name, value)
       }
     }
-    request.headers.set('user-agent', USER_AGENT)
+    headers.set('user-agent', USER_AGENT)
+
+    const hasBody = c.req.method !== 'GET' && c.req.method !== 'HEAD'
+    const request = new Request(target, {
+      method: c.req.method,
+      headers,
+      body: hasBody ? await c.req.raw.arrayBuffer() : undefined,
+      // Don't follow upstream redirects: a 3xx could point off bgm.tv and
+      // turn this into an open cross-origin proxy.
+      redirect: 'manual',
+    })
 
     return fetch(request)
   })

--- a/backend/proxy/src/routes/api/bangumi/router.ts
+++ b/backend/proxy/src/routes/api/bangumi/router.ts
@@ -1,0 +1,9 @@
+import { factory } from '@/factory'
+import { useCache } from '@/middleware/cache'
+import { bangumiProxy } from './bangumi'
+
+export const bangumiRouter = factory.createApp()
+
+bangumiRouter.use('*', useCache({ maxAge: 3600 }))
+bangumiRouter.all('/api/:path{.*}', ...bangumiProxy('https://api.bgm.tv'))
+bangumiRouter.all('/next/:path{.*}', ...bangumiProxy('https://next.bgm.tv'))

--- a/backend/proxy/src/routes/api/routes.ts
+++ b/backend/proxy/src/routes/api/routes.ts
@@ -2,6 +2,7 @@ import { factory } from '@/factory'
 import { tagService } from '@/middleware/tagService'
 import { authRouter } from './auth/router'
 import { backupRouter } from './backup/router'
+import { bangumiRouter } from './bangumi/router'
 import { configRouter } from './config/router'
 import { ddpRouter } from './ddp/router'
 import { filesRouter } from './files/router'
@@ -14,6 +15,7 @@ api.use(tagService)
 api.route('/auth', authRouter)
 api.route('/backup', backupRouter)
 api.route('/ddp', ddpRouter)
+api.route('/bangumi', bangumiRouter)
 api.route('/llm', llmRouter)
 api.route('/kazumi', kazumiRouter)
 api.route('/config', configRouter)


### PR DESCRIPTION
## Summary
- Add a transparent `/bangumi` proxy in `backend/proxy` that forwards to `api.bgm.tv` (`/bangumi/api/*`) and `next.bgm.tv` (`/bangumi/next/*`), following the existing kazumi direct-fetch pattern.
- Repoint the web app's two `openapi-fetch` Bangumi clients at the proxy via `environment.apiRoot` (no call sites or generated types change).
- Routing through the worker fixes the direct browser to bgm.tv issues users hit: CORS dependence, per-user-IP rate limiting, and regional reachability (bgm.tv is flaky/blocked on some networks). Responses originate from Cloudflare IPs and GET reads are edge-cached (`max-age=3600`).

## Security
- The upstream URL is built by assigning `pathname`/`search` on the parsed origin, so a captured path like `//evil.com` cannot repoint the proxy off bgm.tv (no SSRF / open-proxy). Covered by negative tests.
- Only an anonymous header allowlist (`accept`, `accept-language`, `content-type`) plus a `User-Agent` is forwarded upstream. Auth/cookies never reach bgm.tv, which also keeps every cached response user-independent.

## Test plan
- [x] `pnpm --filter @danmaku-anywhere/proxy test` (57 passing, incl. `src/routes/api/bangumi/bangumi.test.ts`: path/query forwarding, POST body, header allowlist, SSRF origin-pinning)
- [x] `pnpm --filter @danmaku-anywhere/proxy lint` (changed files clean)
- [x] Web app `pnpm type-check` clean
- [x] Local `wrangler dev` against real bgm.tv: calendar, trending, subject detail, POST search return valid JSON; CORS + gzip + ETag/304 + cache hit verified; SSRF attempt hits bgm.tv 404 not the injected host
- [x] Deployed to staging (`api.danmaku-staging.weeblify.app`): all four endpoint shapes return 200 with the staging web origin reflected; SSRF blocked

## Notes
- e2e: backend proxy logic is covered by Vitest unit tests; there is no Playwright e2e suite for the web app's Bangumi views.
- The web app's staging build points at the staging proxy and the prod build at the prod proxy via Angular's environment file replacement, so this needs a prod proxy deploy when merged.