### PR TITLE
(extension) bookmark-driven preload next episode [DA-572]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -30,6 +30,10 @@ export class MountPage {
     return this.episodeItem(episodeId).getByTestId('comment-count')
   }
 
+  episodeItems(): Locator {
+    return this.page.locator(SELECTORS.treeItemPrefix('episode-'))
+  }
+
   stubItem(seasonId: number, indexedId: string): Locator {
     return this.page.locator(
       SELECTORS.treeItem(`stub-${seasonId}-${indexedId}`)

--- a/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
@@ -96,7 +96,7 @@ test('mount tree: bookmark-driven preload caches the next episode', async ({
   await expect(nextStub).toBeHidden()
   await expect(seasonItem).not.toContainText(/\+\d+/)
 
-  const episodeItems = page.locator('[data-testid^="tree-item-episode-"]')
+  const episodeItems = popup.mount.episodeItems()
   await expect(episodeItems).toHaveCount(2)
 
   const episodeIds = await episodeItems.evaluateAll((els) =>

--- a/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
@@ -1,0 +1,116 @@
+import {
+  DanmakuSourceType,
+  type EpisodeInsert,
+  type SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
+import { mockBilibiliXml } from '../../network/bilibili'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Bookmark-driven preload of the next episode. Bookmarks a season whose
+ * upstream list has 2 episodes but only episode 1 is fetched, leaving episode
+ * 2 as a stub. Invokes the production episodePreloadNext RPC (the transport
+ * the player fires at 50% playback) for episode 1, then asserts the episode-2
+ * stub row is replaced by a fetched episode row with a non-zero comment count.
+ */
+
+const SEASON: SeasonInsert = {
+  provider: DanmakuSourceType.Bilibili,
+  providerIds: { seasonId: 41410, mediaId: 28219412 },
+  providerConfigId: 'builtin:bilibili',
+  indexedId: '41410',
+  title: '葬送的芙莉莲',
+  type: '番剧',
+  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
+  episodeCount: 28,
+  year: 2023,
+  schemaVersion: 1,
+}
+
+function makeEpisode(seasonId: number): EpisodeInsert {
+  // indexedId matches the season fixture's first episode (cid 1300001), so the
+  // bookmark snapshot leaves only the second episode as an unfetched stub.
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
+    indexedId: '1300001',
+    title: 'Ep1',
+    episodeNumber: '1',
+    seasonId,
+    comments: [],
+    commentCount: 0,
+    schemaVersion: 4,
+    lastChecked: 0,
+  }
+}
+
+test('mount tree: bookmark-driven preload caches the next episode', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+    network: mockBilibiliXml({
+      searchBangumi: loadJsonFixture('bilibili-search-bangumi.json'),
+      searchFt: loadJsonFixture('bilibili-search-ft.json'),
+      season: loadJsonFixture('bilibili-season.json'),
+      xml: loadTextFixture('bilibili-xml.xml'),
+    }),
+  })
+
+  const season = await da.season.add(SEASON)
+  const episode = await da.episode.add(makeEpisode(season.id))
+
+  const popup = await Popup.open(page, extensionId, '/mount')
+  const seasonItem = await popup.mount.waitForSeason(season.id)
+
+  await popup.mount.openItemMenu(seasonItem, 'bookmarkAdd')
+  await expect(seasonItem).toContainText(/\+1/)
+
+  await popup.mount.expandSeason(season.id)
+  const nextStub = popup.mount.stubItem(season.id, '1300002')
+  await expect(nextStub).toBeVisible()
+
+  // Invoke the production RPC the player fires at 50% playback, sending the
+  // currently playing episode (ep1). The 50% timer itself needs a mounted
+  // video and is out of scope; the unit under test is the background handler.
+  await page.evaluate((meta) => {
+    return chrome.runtime.sendMessage({
+      method: 'episodePreloadNext',
+      input: meta,
+    })
+  }, episode)
+
+  // Preload caches in the background while the popup is closed in real use, so
+  // reopen to read the post-preload DB state the user would next see.
+  await page.reload()
+  await popup.mount.waitForSeason(season.id)
+  await popup.mount.expandSeason(season.id)
+
+  await expect(nextStub).toBeHidden()
+  await expect(seasonItem).not.toContainText(/\+\d+/)
+
+  const episodeItems = page.locator('[data-testid^="tree-item-episode-"]')
+  await expect(episodeItems).toHaveCount(2)
+
+  const episodeIds = await episodeItems.evaluateAll((els) =>
+    els.map((el) =>
+      Number(el.getAttribute('data-testid')?.replace('tree-item-episode-', ''))
+    )
+  )
+  const nextEpisodeId = episodeIds.find((id) => id !== episode.id) as number
+
+  await expect(popup.mount.episodeCommentCount(nextEpisodeId)).not.toHaveText(
+    '0'
+  )
+
+  await expect
+    .poll(async () => (await da.episode.get(nextEpisodeId))?.commentCount)
+    .toBeGreaterThan(0)
+})

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -215,12 +215,18 @@ export class RpcManager {
           return result
         },
         episodePreloadNext: async (data) => {
-          const { autoBookmark } = await this.extensionOptionsService.get()
-          await this.bookmarkService.preloadNextEpisode(
-            data,
-            this.providerService,
-            autoBookmark
-          )
+          // Best-effort background optimization: swallow failures so a network
+          // or DB error does not bubble up as an unhandled RPC error.
+          try {
+            const { autoBookmark } = await this.extensionOptionsService.get()
+            await this.bookmarkService.preloadNextEpisode(
+              data,
+              this.providerService,
+              autoBookmark
+            )
+          } catch (e) {
+            this.logger.warn('Failed to preload next episode:', e)
+          }
         },
         episodeImport: async (data, sender) => {
           const result = await this.danmakuService.import(data)

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -219,11 +219,16 @@ export class RpcManager {
           // or DB error does not bubble up as an unhandled RPC error.
           try {
             const { autoBookmark } = await this.extensionOptionsService.get()
-            await this.bookmarkService.preloadNextEpisode(
+            const bookmarked = await this.bookmarkService.preloadNextEpisode(
               data,
               this.providerService,
               autoBookmark
             )
+            // Auto-bookmark happens in the background, so refresh content
+            // scripts (incl. the playing tab) to update bookmark UI.
+            if (bookmarked) {
+              void invalidateContentScriptData()
+            }
           } catch (e) {
             this.logger.warn('Failed to preload next episode:', e)
           }

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -27,6 +27,7 @@ import { AuthClientService } from '@/common/auth/AuthClientService'
 import type { EpisodeFetchBySeasonParams } from '@/common/danmaku/dto'
 import { DanmakuAnywhereDb } from '@/common/db/db'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
+import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import { MountConfigService } from '@/common/options/mountConfig/service'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type { TabRPCClientMethod } from '@/common/rpc/client'
@@ -79,7 +80,9 @@ export class RpcManager {
     @inject(BookmarkService)
     private bookmarkService: BookmarkService,
     @inject(OcclusionModelService)
-    private occlusionModelService: OcclusionModelService
+    private occlusionModelService: OcclusionModelService,
+    @inject(ExtensionOptionsService)
+    private extensionOptionsService: ExtensionOptionsService
   ) {
     this.logger = logger.sub('[RpcManager]')
   }
@@ -211,8 +214,13 @@ export class RpcManager {
           void invalidateContentScriptData(sender.tab?.id)
           return result
         },
-        episodePreloadNext: async (data, sender) => {
-          return await this.providerService.preloadNextEpisode(data)
+        episodePreloadNext: async (data) => {
+          const { autoBookmark } = await this.extensionOptionsService.get()
+          await this.bookmarkService.preloadNextEpisode(
+            data,
+            this.providerService,
+            autoBookmark
+          )
         },
         episodeImport: async (data, sender) => {
           const result = await this.danmakuService.import(data)

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.test.ts
@@ -5,7 +5,7 @@ import type {
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProviderService } from '@/background/services/providers/ProviderService'
 import type { DanmakuAnywhereDb } from '@/common/db/db'
 import { BookmarkService } from './BookmarkService'
@@ -44,6 +44,10 @@ describe('BookmarkService.preloadNextEpisode', () => {
   beforeEach(() => {
     service = new BookmarkService({} as DanmakuAnywhereDb)
     provider = { getDanmaku: vi.fn(), fetchEpisodesBySeason: vi.fn() }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   const run = (autoBookmark: boolean) =>

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.test.ts
@@ -1,0 +1,123 @@
+import type {
+  Bookmark,
+  EpisodeMeta,
+  EpisodeStub,
+  WithSeason,
+} from '@danmaku-anywhere/danmaku-converter'
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderService } from '@/background/services/providers/ProviderService'
+import type { DanmakuAnywhereDb } from '@/common/db/db'
+import { BookmarkService } from './BookmarkService'
+
+const stub = (indexedId: string, episodeNumber?: number): EpisodeStub => ({
+  provider: DanmakuSourceType.DanDanPlay,
+  providerIds: {},
+  title: `ep ${indexedId}`,
+  episodeNumber,
+  indexedId,
+})
+
+const current = {
+  indexedId: 'a',
+  episodeNumber: 1,
+  seasonId: 7,
+} as WithSeason<EpisodeMeta>
+
+const bookmark = (episodes: EpisodeStub[]): Bookmark => ({
+  id: 1,
+  seasonId: 7,
+  providerConfigId: 'DanDanPlay',
+  episodes,
+  lastRefreshed: 0,
+  timeUpdated: 0,
+  version: 1,
+})
+
+describe('BookmarkService.preloadNextEpisode', () => {
+  let service: BookmarkService
+  let provider: {
+    getDanmaku: ReturnType<typeof vi.fn>
+    fetchEpisodesBySeason: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    service = new BookmarkService({} as DanmakuAnywhereDb)
+    provider = { getDanmaku: vi.fn(), fetchEpisodesBySeason: vi.fn() }
+  })
+
+  const run = (autoBookmark: boolean) =>
+    service.preloadNextEpisode(
+      current,
+      provider as unknown as ProviderService,
+      autoBookmark
+    )
+
+  it('does nothing when not bookmarked and autoBookmark is off', async () => {
+    vi.spyOn(service, 'getBySeason').mockResolvedValue(undefined)
+    const add = vi.spyOn(service, 'add')
+    await run(false)
+    expect(add).not.toHaveBeenCalled()
+    expect(provider.getDanmaku).not.toHaveBeenCalled()
+  })
+
+  it('auto-bookmarks then preloads when not bookmarked and autoBookmark is on', async () => {
+    vi.spyOn(service, 'getBySeason').mockResolvedValue(undefined)
+    vi.spyOn(service, 'add').mockResolvedValue(
+      bookmark([stub('a', 1), stub('b', 2)])
+    )
+    vi.spyOn(service, 'isStale').mockReturnValue(false)
+    await run(true)
+    expect(service.add).toHaveBeenCalledWith(7, provider)
+    expect(provider.getDanmaku).toHaveBeenCalledWith({
+      type: 'by-stub',
+      stub: stub('b', 2),
+      seasonId: 7,
+    })
+  })
+
+  it('preloads the next stub for a bookmarked show', async () => {
+    vi.spyOn(service, 'getBySeason').mockResolvedValue(
+      bookmark([stub('a', 1), stub('b', 2)])
+    )
+    vi.spyOn(service, 'isStale').mockReturnValue(false)
+    await run(false)
+    expect(provider.getDanmaku).toHaveBeenCalledWith({
+      type: 'by-stub',
+      stub: stub('b', 2),
+      seasonId: 7,
+    })
+  })
+
+  it('does not refresh or fetch when next is missing but bookmark is fresh', async () => {
+    vi.spyOn(service, 'getBySeason').mockResolvedValue(bookmark([stub('a', 1)]))
+    vi.spyOn(service, 'isStale').mockReturnValue(false)
+    const refresh = vi.spyOn(service, 'refresh')
+    await run(false)
+    expect(refresh).not.toHaveBeenCalled()
+    expect(provider.getDanmaku).not.toHaveBeenCalled()
+  })
+
+  it('refreshes once and retries when next is missing and bookmark is stale', async () => {
+    vi.spyOn(service, 'getBySeason').mockResolvedValue(bookmark([stub('a', 1)]))
+    vi.spyOn(service, 'isStale').mockReturnValue(true)
+    vi.spyOn(service, 'refresh').mockResolvedValue(
+      bookmark([stub('a', 1), stub('b', 2)])
+    )
+    await run(false)
+    expect(service.refresh).toHaveBeenCalledWith(1, provider)
+    expect(provider.getDanmaku).toHaveBeenCalledWith({
+      type: 'by-stub',
+      stub: stub('b', 2),
+      seasonId: 7,
+    })
+  })
+
+  it('does not fetch when next is still missing after refresh', async () => {
+    vi.spyOn(service, 'getBySeason').mockResolvedValue(bookmark([stub('a', 1)]))
+    vi.spyOn(service, 'isStale').mockReturnValue(true)
+    vi.spyOn(service, 'refresh').mockResolvedValue(bookmark([stub('a', 1)]))
+    await run(false)
+    expect(provider.getDanmaku).not.toHaveBeenCalled()
+  })
+})

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.test.ts
@@ -60,7 +60,7 @@ describe('BookmarkService.preloadNextEpisode', () => {
   it('does nothing when not bookmarked and autoBookmark is off', async () => {
     vi.spyOn(service, 'getBySeason').mockResolvedValue(undefined)
     const add = vi.spyOn(service, 'add')
-    await run(false)
+    expect(await run(false)).toBe(false)
     expect(add).not.toHaveBeenCalled()
     expect(provider.getDanmaku).not.toHaveBeenCalled()
   })
@@ -71,7 +71,7 @@ describe('BookmarkService.preloadNextEpisode', () => {
       bookmark([stub('a', 1), stub('b', 2)])
     )
     vi.spyOn(service, 'isStale').mockReturnValue(false)
-    await run(true)
+    expect(await run(true)).toBe(true)
     expect(service.add).toHaveBeenCalledWith(7, provider)
     expect(provider.getDanmaku).toHaveBeenCalledWith({
       type: 'by-stub',
@@ -80,12 +80,12 @@ describe('BookmarkService.preloadNextEpisode', () => {
     })
   })
 
-  it('preloads the next stub for a bookmarked show', async () => {
+  it('preloads the next stub for a bookmarked show without reporting a new bookmark', async () => {
     vi.spyOn(service, 'getBySeason').mockResolvedValue(
       bookmark([stub('a', 1), stub('b', 2)])
     )
     vi.spyOn(service, 'isStale').mockReturnValue(false)
-    await run(false)
+    expect(await run(false)).toBe(false)
     expect(provider.getDanmaku).toHaveBeenCalledWith({
       type: 'by-stub',
       stub: stub('b', 2),

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
@@ -5,6 +5,7 @@ import type {
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { inject, injectable } from 'inversify'
+import { findNextStub } from '@/background/services/providers/common/findNextStub'
 import type { ProviderService } from '@/background/services/providers/ProviderService'
 import { BOOKMARK_REFRESH_TTL_MS } from '@/common/bookmark/constants'
 import { DanmakuAnywhereDb } from '@/common/db/db'
@@ -127,5 +128,31 @@ export class BookmarkService {
 
   isStale(bookmark: Bookmark): boolean {
     return Date.now() - bookmark.lastRefreshed > BOOKMARK_REFRESH_TTL_MS
+  }
+
+  async preloadNextEpisode(
+    current: WithSeason<EpisodeMeta>,
+    providerService: ProviderService,
+    autoBookmark: boolean
+  ): Promise<void> {
+    const { seasonId } = current
+    let bookmark = await this.getBySeason(seasonId)
+    if (!bookmark) {
+      if (!autoBookmark) {
+        return
+      }
+      bookmark = await this.add(seasonId, providerService)
+    }
+
+    let next = findNextStub(bookmark.episodes, current)
+    if (!next && this.isStale(bookmark)) {
+      bookmark = await this.refresh(bookmark.id, providerService)
+      next = findNextStub(bookmark.episodes, current)
+    }
+    if (!next) {
+      return
+    }
+
+    await providerService.getDanmaku({ type: 'by-stub', stub: next, seasonId })
   }
 }

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
@@ -130,18 +130,24 @@ export class BookmarkService {
     return Date.now() - bookmark.lastRefreshed > BOOKMARK_REFRESH_TTL_MS
   }
 
+  /**
+   * Returns true when this call created a new bookmark (autoBookmark), so the
+   * caller can invalidate bookmark-dependent UI in other contexts.
+   */
   async preloadNextEpisode(
     current: WithSeason<EpisodeMeta>,
     providerService: ProviderService,
     autoBookmark: boolean
-  ): Promise<void> {
+  ): Promise<boolean> {
     const { seasonId } = current
     let bookmark = await this.getBySeason(seasonId)
+    let bookmarked = false
     if (!bookmark) {
       if (!autoBookmark) {
-        return
+        return false
       }
       bookmark = await this.add(seasonId, providerService)
+      bookmarked = true
     }
 
     let next = findNextStub(bookmark.episodes, current)
@@ -149,10 +155,14 @@ export class BookmarkService {
       bookmark = await this.refresh(bookmark.id, providerService)
       next = findNextStub(bookmark.episodes, current)
     }
-    if (!next) {
-      return
+    if (next) {
+      await providerService.getDanmaku({
+        type: 'by-stub',
+        stub: next,
+        seasonId,
+      })
     }
 
-    await providerService.getDanmaku({ type: 'by-stub', stub: next, seasonId })
+    return bookmarked
   }
 }

--- a/packages/danmaku-anywhere/src/background/services/providers/IDanmakuProvider.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/IDanmakuProvider.ts
@@ -35,8 +35,6 @@ export interface IDanmakuProvider {
 
   getDanmaku(request: DanmakuFetchByMeta): Promise<CommentEntity[]>
 
-  preloadNextEpisode?(request: DanmakuFetchByMeta): Promise<void>
-
   findEpisode?(
     season: Season,
     episodeNumber: number

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -130,23 +130,6 @@ export class ProviderService {
     }
   }
 
-  async preloadNextEpisode(request: DanmakuFetchRequest): Promise<void> {
-    const resolved = await this.resolveMeta(request)
-    const config = await this.providerConfigService.mustGet(
-      resolved.meta.season.providerConfigId
-    )
-
-    const service = this.danmakuProviderFactory(config)
-
-    if (service.preloadNextEpisode) {
-      return service.preloadNextEpisode(resolved)
-    }
-
-    this.logger.warn(
-      `Preloading next episode is not supported for provider: ${config.impl}`
-    )
-  }
-
   private async resolveMeta(
     request: DanmakuFetchRequest
   ): Promise<DanmakuFetchByMeta> {

--- a/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.test.ts
@@ -32,6 +32,11 @@ describe('findNextStub', () => {
     expect(findNextStub(gapped, stub('a', 1))?.indexedId).toBe('b')
   })
 
+  it('extracts a leading number from a stub title with trailing text', () => {
+    const titled = [stub('a', '1 第一集'), stub('b', '2 第二集')]
+    expect(findNextStub(titled, stub('a', '1 第一集'))?.indexedId).toBe('b')
+  })
+
   it('falls back to position when numbers are non-numeric', () => {
     const named = [stub('a', 'OVA'), stub('b', 'Special')]
     expect(findNextStub(named, named[0])?.indexedId).toBe('b')

--- a/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.test.ts
@@ -1,0 +1,47 @@
+import type { EpisodeStub } from '@danmaku-anywhere/danmaku-converter'
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { describe, expect, it } from 'vitest'
+import { findNextStub } from './findNextStub'
+
+const stub = (
+  indexedId: string,
+  episodeNumber?: number | string,
+  title = `ep ${indexedId}`
+): EpisodeStub => ({
+  provider: DanmakuSourceType.DanDanPlay,
+  providerIds: {},
+  title,
+  episodeNumber,
+  indexedId,
+})
+
+describe('findNextStub', () => {
+  const list = [stub('a', 1), stub('b', 2), stub('c', 3)]
+
+  it('finds the episode whose number is current + 1', () => {
+    expect(findNextStub(list, stub('a', 1))?.indexedId).toBe('b')
+  })
+
+  it('matches numbers across number/string types', () => {
+    const mixed = [stub('a', '1'), stub('b', 2)]
+    expect(findNextStub(mixed, stub('a', 1))?.indexedId).toBe('b')
+  })
+
+  it('skips a non-sequential gap by number, not position', () => {
+    const gapped = [stub('a', 1), stub('special', 99), stub('b', 2)]
+    expect(findNextStub(gapped, stub('a', 1))?.indexedId).toBe('b')
+  })
+
+  it('falls back to position when numbers are non-numeric', () => {
+    const named = [stub('a', 'OVA'), stub('b', 'Special')]
+    expect(findNextStub(named, named[0])?.indexedId).toBe('b')
+  })
+
+  it('returns null when current is the last stub', () => {
+    expect(findNextStub(list, stub('c', 3))).toBeNull()
+  })
+
+  it('returns null when current is not in the list', () => {
+    expect(findNextStub(list, stub('z', 42))).toBeNull()
+  })
+})

--- a/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.ts
@@ -4,11 +4,17 @@ function toEpisodeNumber(value: number | string | undefined): number | null {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null
   }
-  if (typeof value === 'string' && value.trim() !== '') {
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : null
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null
   }
-  return null
+  const direct = Number(value)
+  if (Number.isFinite(direct)) {
+    return direct
+  }
+  // Providers often store the number with trailing text (e.g. "2 标题"), so
+  // fall back to the leading integer before giving up.
+  const leading = value.match(/^\s*(\d+)/)
+  return leading ? Number(leading[1]) : null
 }
 
 export function findNextStub(

--- a/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.ts
@@ -11,8 +11,7 @@ function toEpisodeNumber(value: number | string | undefined): number | null {
   if (Number.isFinite(direct)) {
     return direct
   }
-  // Providers often store the number with trailing text (e.g. "2 标题"), so
-  // fall back to the leading integer before giving up.
+  // Try to extract a number from the episode
   const leading = value.match(/^\s*(\d+)/)
   return leading ? Number(leading[1]) : null
 }

--- a/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/common/findNextStub.ts
@@ -1,0 +1,34 @@
+import type { EpisodeStub } from '@danmaku-anywhere/danmaku-converter'
+
+function toEpisodeNumber(value: number | string | undefined): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+export function findNextStub(
+  stubs: EpisodeStub[],
+  current: Pick<EpisodeStub, 'episodeNumber' | 'indexedId'>
+): EpisodeStub | null {
+  const currentNumber = toEpisodeNumber(current.episodeNumber)
+  if (currentNumber !== null) {
+    const byNumber = stubs.find(
+      (stub) => toEpisodeNumber(stub.episodeNumber) === currentNumber + 1
+    )
+    if (byNumber) {
+      return byNumber
+    }
+  }
+
+  const index = stubs.findIndex((stub) => stub.indexedId === current.indexedId)
+  if (index !== -1 && stubs[index + 1]) {
+    return stubs[index + 1]
+  }
+
+  return null
+}

--- a/packages/danmaku-anywhere/src/common/hooks/useInvalidateSeasonAndEpisode.ts
+++ b/packages/danmaku-anywhere/src/common/hooks/useInvalidateSeasonAndEpisode.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { publishDataChange } from '@/common/messaging/dataChangeChannel'
 import {
+  bookmarkQueryKeys,
   customEpisodeQueryKeys,
   episodeQueryKeys,
   seasonQueryKeys,
@@ -15,6 +16,7 @@ export const useInvalidateSeasonAndEpisode = () => {
       seasonQueryKeys.all(),
       episodeQueryKeys.all(),
       customEpisodeQueryKeys.all(),
+      bookmarkQueryKeys.all(),
     ]
     for (const key of keys) {
       void queryClient.invalidateQueries({ queryKey: key })

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -470,6 +470,7 @@
       "signUp": "Sign Up",
       "signUpSuccess": "Sign up successful"
     },
+    "autoBookmark": "Auto bookmark shows when preloading",
     "backup": {
       "alert": {
         "exportSuccess": "Export success",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -455,7 +455,7 @@
       "signUp": "注册",
       "signUpSuccess": "注册成功"
     },
-    "autoBookmark": "预加载时自动收藏剧集",
+    "autoBookmark": "预加载时自动关注剧集",
     "backup": {
       "alert": {
         "exportSuccess": "成功导出备份",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -455,6 +455,7 @@
       "signUp": "注册",
       "signUpSuccess": "注册成功"
     },
+    "autoBookmark": "预加载时自动收藏剧集",
     "backup": {
       "alert": {
         "exportSuccess": "成功导出备份",

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/constant.ts
@@ -46,4 +46,5 @@ export const defaultExtensionOptions: ExtensionOptions = {
   id: undefined,
   restrictInitiatorDomain: true,
   showFloatingButton: true,
+  autoBookmark: false,
 }

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/schema.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/schema.ts
@@ -152,6 +152,12 @@ export const extensionOptionsSchema = z.object({
    * Whether to show the floating action button on video pages
    */
   showFloatingButton: z.boolean(),
+
+  /**
+   * Auto-bookmark a show when preloading its next episode, so non-bookmarked
+   * shows can preload. Off by default.
+   */
+  autoBookmark: z.boolean(),
 })
 
 export type ExtensionOptions = z.infer<typeof extensionOptionsSchema>

--- a/packages/danmaku-anywhere/src/common/options/extensionOptions/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/extensionOptions/service.ts
@@ -271,6 +271,12 @@ export class ExtensionOptionsService implements IStoreService {
             }
           }),
       })
+      .version(26, {
+        upgrade: (data) =>
+          produce<ExtensionOptions>(data, (draft) => {
+            draft.autoBookmark = false
+          }),
+      })
   }
 
   async get() {

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -122,7 +122,7 @@ export type BackgroundMethods = {
   episodeFilterLite: RPCDef<EpisodeQueryFilter, WithSeason<EpisodeLite>[]>
   episodeFilter: RPCDef<EpisodeQueryFilter, WithSeason<Episode>[]>
   episodeFetch: RPCDef<DanmakuFetchDto, WithSeason<Episode>>
-  episodePreloadNext: RPCDef<DanmakuFetchDto, void>
+  episodePreloadNext: RPCDef<WithSeason<EpisodeMeta>, void>
   episodeDelete: RPCDef<EpisodeQueryFilter, void>
   episodeFilterCustom: RPCDef<CustomEpisodeQueryFilter, CustomEpisode[]>
   episodeFilterCustomLite: RPCDef<CustomEpisodeQueryFilter, CustomEpisodeLite[]>

--- a/packages/danmaku-anywhere/src/common/settings/settingConfigs.ts
+++ b/packages/danmaku-anywhere/src/common/settings/settingConfigs.ts
@@ -110,6 +110,15 @@ const advancedSettings: SettingConfig<ExtensionOptions>[] = [
     getValue: (options) => options.showFloatingButton,
     createUpdate: (_, newValue) => ({ showFloatingButton: newValue }),
   },
+  {
+    id: 'toggle.autoBookmark',
+    label: () =>
+      i18n.t('optionsPage.autoBookmark', 'Auto bookmark shows when preloading'),
+    category: 'advanced',
+    type: 'toggle',
+    getValue: (options) => options.autoBookmark,
+    createUpdate: (_, newValue) => ({ autoBookmark: newValue }),
+  },
 ]
 
 const playerSettings: SettingConfig<ExtensionOptions>[] = [

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
@@ -1,4 +1,4 @@
-import type { Episode, WithSeason } from '@danmaku-anywhere/danmaku-converter'
+import { isNotCustom } from '@/common/danmaku/utils'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { useStore } from '@/content/controller/store/store'
 
@@ -13,7 +13,15 @@ export const usePreloadNextEpisode = () => {
     if (!episodes || episodes.length !== 1) {
       return
     }
-    await chromeRpcClient.episodePreloadNext(episodes[0] as WithSeason<Episode>)
+    const episode = episodes[0]
+    // Custom (local) episodes have no season, so there is no bookmark to
+    // preload from. Provider-agnostic otherwise.
+    if (!isNotCustom(episode)) {
+      return
+    }
+    // Best-effort background optimization: a failed preload should not surface
+    // an error to the user mid-playback.
+    await chromeRpcClient.episodePreloadNext(episode, { optional: true })
   }
 
   return { canLoadNext, preloadNext }

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
@@ -14,14 +14,13 @@ export const usePreloadNextEpisode = () => {
       return
     }
     const episode = episodes[0]
-    // Custom (local) episodes have no season, so there is no bookmark to
-    // preload from. Provider-agnostic otherwise.
+    // Custom episodes have no season to preload from.
     if (!isNotCustom(episode)) {
       return
     }
-    // Best-effort background optimization: a failed preload should not surface
-    // an error to the user mid-playback.
-    await chromeRpcClient.episodePreloadNext(episode, { optional: true })
+    // Drop comments so the message stays small; preload is best-effort.
+    const { comments: _, ...meta } = episode
+    await chromeRpcClient.episodePreloadNext(meta, { optional: true })
   }
 
   return { canLoadNext, preloadNext }

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
@@ -1,9 +1,4 @@
-import {
-  DanmakuSourceType,
-  type Episode,
-  type WithSeason,
-} from '@danmaku-anywhere/danmaku-converter'
-import { isProvider } from '@/common/danmaku/utils'
+import type { Episode, WithSeason } from '@danmaku-anywhere/danmaku-converter'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { useStore } from '@/content/controller/store/store'
 
@@ -18,15 +13,7 @@ export const usePreloadNextEpisode = () => {
     if (!episodes || episodes.length !== 1) {
       return
     }
-
-    const episode = episodes[0]
-
-    if (isProvider(episode, DanmakuSourceType.DanDanPlay)) {
-      await chromeRpcClient.episodePreloadNext({
-        type: 'by-meta',
-        meta: episode as WithSeason<Episode>,
-      })
-    }
+    await chromeRpcClient.episodePreloadNext(episodes[0] as WithSeason<Episode>)
   }
 
   return { canLoadNext, preloadNext }


### PR DESCRIPTION
## Summary
- Rebuild "preload next episode" as a provider-agnostic, bookmark-driven lookup. At 50% playback the next episode's danmaku is fetched and cached into the local DB (no auto-switch).
- `findNextStub` (pure, unit-tested): hybrid match (episodeNumber+1, else position) over a bookmark's stored stub snapshot.
- `BookmarkService.preloadNextEpisode`: reads the bookmark, optionally auto-bookmarks (new `autoBookmark` setting, default off), refreshes-on-miss when stale (24h TTL), then `getDanmaku` by-stub.
- New `autoBookmark` extension option (schema + default + v26 migration + settings toggle + i18n en/zh). Off by default: non-bookmarked shows do nothing unless the user opts in.
- Rewire: `episodePreloadNext` RPC retyped from `DanmakuFetchDto` to `WithSeason<EpisodeMeta>`; `RpcManager` injects `ExtensionOptionsService` and drives the relay event through `BookmarkService`. Removed dead `ProviderService.preloadNextEpisode` and the optional `IDanmakuProvider.preloadNextEpisode` (no provider implemented it post manifest-engine migration).
- Content hook only sends real provider episodes (custom/local episodes have no season), and the call is best-effort so a failed preload never toasts the user mid-playback.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` — unit: `findNextStub` (6 cases) + `BookmarkService.preloadNextEpisode` (6 branch cases).
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` — incl. `packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts` (bookmark a season, fire the production preload RPC, assert the next episode's stub becomes a cached episode with a non-zero comment count).
- [ ] Manual: with a bookmarked airing show, watch past 50%, confirm the next episode's danmaku is cached. With `autoBookmark` off and a non-bookmarked show, confirm nothing is bookmarked and nothing preloads. Toggle `autoBookmark` on and confirm a non-bookmarked show gets followed + preloaded.

## Notes
- Verified the 50% relay path is thin glue; the e2e drives the production `episodePreloadNext` RPC directly (the timer needs a full video mount and is out of scope). Browser-verified the v26 migration default and RPC wiring.
- `autoBookmark` ON triggers an automatic provider episode-list fetch for shows watched but not yet bookmarked. This is the documented opt-in; off by default.
- Known limitation: preload reads the stored snapshot; refresh-on-miss bounds staleness to the 24h TTL, but within that window a freshly aired next episode may not preload until the snapshot refreshes.