### PR TITLE
(proxy) DDP proxy: additive transparent /api passthrough [DA-574]

### DIFF
--- a/backend/proxy/src/routes/api/ddp/danDanPlay.test.ts
+++ b/backend/proxy/src/routes/api/ddp/danDanPlay.test.ts
@@ -129,6 +129,20 @@ describe('DanDanPlay API', () => {
     )
   })
 
+  it('transparent route strips client-supplied da-authenticated header when not signed in', async () => {
+    const app = createAppWithUser(null)
+    const request = new Request(
+      createTestUrl('/ddp/api/v2/search/anime', {
+        query: { keyword: 'nichijou' },
+      }),
+      { headers: { 'da-authenticated': '1' } }
+    )
+    await makeUnitTestRequest(request, { app })
+
+    const forwardedRequest = fetchMock.mock.calls[0][0]
+    expect(forwardedRequest.headers.get('da-authenticated')).toBeNull()
+  })
+
   it('transparent route sets da-authenticated when the user is signed in', async () => {
     const app = createAppWithUser({ id: 'user-1' } as AuthUser)
     const request = new Request(

--- a/backend/proxy/src/routes/api/ddp/danDanPlay.test.ts
+++ b/backend/proxy/src/routes/api/ddp/danDanPlay.test.ts
@@ -112,4 +112,33 @@ describe('DanDanPlay API', () => {
     const forwardedRequest = fetchMock.mock.calls[0][0]
     expect(forwardedRequest.headers.get('da-authenticated')).toBeNull()
   })
+
+  it('transparent /api/* forwards the stripped path to the DDP service', async () => {
+    const request = new Request(
+      createTestUrl('/ddp/api/v2/search/anime', {
+        query: { keyword: 'nichijou' },
+      })
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const forwardedRequest = fetchMock.mock.calls[0][0]
+    expect(forwardedRequest.url).toBe(
+      'http://example.com/api/v2/search/anime?keyword=nichijou'
+    )
+  })
+
+  it('transparent route sets da-authenticated when the user is signed in', async () => {
+    const app = createAppWithUser({ id: 'user-1' } as AuthUser)
+    const request = new Request(
+      createTestUrl('/ddp/api/v2/search/anime', {
+        query: { keyword: 'nichijou' },
+      })
+    )
+    await makeUnitTestRequest(request, { app })
+
+    const forwardedRequest = fetchMock.mock.calls[0][0]
+    expect(forwardedRequest.headers.get('da-authenticated')).toBe('1')
+  })
 })

--- a/backend/proxy/src/routes/api/ddp/router.ts
+++ b/backend/proxy/src/routes/api/ddp/router.ts
@@ -1,6 +1,8 @@
 import { factory } from '@/factory'
 import { danDanPlay } from './danDanPlay'
+import { ddpTransparent } from './transparent'
 
 export const ddpRouter = factory.createApp()
 
 ddpRouter.route('/v1', danDanPlay)
+ddpRouter.route('/api', ddpTransparent)

--- a/backend/proxy/src/routes/api/ddp/transparent.ts
+++ b/backend/proxy/src/routes/api/ddp/transparent.ts
@@ -2,14 +2,11 @@ import { factory } from '@/factory'
 
 export const ddpTransparent = factory.createApp()
 
-// Transparent passthrough to the DDP microservice's /api/* route. The dango
-// builtin:dandanplay manifest targets {host}/ddp/api/v2/...; we forward the
-// path minus the /ddp mount prefix straight to the service (no ?path= rewrite).
-// The legacy /ddp/v1?path= route is untouched.
 ddpTransparent.all('*', async (c) => {
   const service = c.env.DDP_SERVICE
 
   const target = new URL(c.req.url)
+  // Drop the /ddp mount prefix; the service routes on the upstream path.
   target.pathname = target.pathname.replace(/^\/ddp/, '')
 
   const request = new Request(target, c.req.raw)

--- a/backend/proxy/src/routes/api/ddp/transparent.ts
+++ b/backend/proxy/src/routes/api/ddp/transparent.ts
@@ -1,0 +1,22 @@
+import { factory } from '@/factory'
+
+export const ddpTransparent = factory.createApp()
+
+// Transparent passthrough to the DDP microservice's /api/* route. The dango
+// builtin:dandanplay manifest targets {host}/ddp/api/v2/...; we forward the
+// path minus the /ddp mount prefix straight to the service (no ?path= rewrite).
+// The legacy /ddp/v1?path= route is untouched.
+ddpTransparent.all('*', async (c) => {
+  const service = c.env.DDP_SERVICE
+
+  const target = new URL(c.req.url)
+  target.pathname = target.pathname.replace(/^\/ddp/, '')
+
+  const request = new Request(target, c.req.raw)
+  request.headers.delete('da-authenticated')
+  if (c.get('authUser')) {
+    request.headers.set('da-authenticated', '1')
+  }
+
+  return service.fetch(request)
+})


### PR DESCRIPTION
## What

Adds a transparent `/ddp/api/*` passthrough in `backend/proxy` that forwards to the `DDP_SERVICE` microservice (strips the `/ddp` mount prefix, no `?path=` rewrite), preserving the existing `da-authenticated` handling. The legacy `/ddp/v1?path=` route is **unchanged** — purely additive.

Pairs with `Mr-Quin/ddp-microservice#4` (the matching transparent `/api/*` route in the microservice).

## Why

dango's `builtin:dandanplay` is being unified into a single manifest that targets the official DDP shape (`{baseUrl}/api/v2/...`) directly. The extension's built-in DDP config will set `baseUrl` to this proxy, so we need a transparent endpoint here; the proxy/microservice keep holding the credentials so the client carries none.

## Tests / verification

- New unit tests: transparent `/api/*` forwards the stripped path to `DDP_SERVICE`; sets `da-authenticated` when signed in. Full `danDanPlay` suite: 8 pass.
- Deployed to staging and verified live: `https://api.danmaku-staging.weeblify.app/ddp/api/v2/search/anime?keyword=frieren` returns real DanDanPlay results; `/ddp/v1?path=` still works.

> No ClickUp task linked yet (opened directly per request); happy to attach one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)