### PR TITLE
(extension) fix search chip font fallback and dark-mode history text [DA-577]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
@@ -41,6 +41,10 @@ export class SearchPage {
     return this.page.locator(`[data-testid="source-chip-${impl}"]`)
   }
 
+  historyOption(text: string): Locator {
+    return this.page.getByRole('option', { name: text })
+  }
+
   seasonCard(provider: string): Locator {
     return this.page.locator(SELECTORS.seasonCardForProvider(provider)).first()
   }

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
@@ -17,7 +17,7 @@ import { applyProfile } from '../../setup/profile'
 
 function relativeLuminance(color: string): number {
   const match = color.match(/\d+(\.\d+)?/g)
-  if (!match) {
+  if (!match || match.length < 3) {
     throw new Error(`unparseable color: ${color}`)
   }
   const [r, g, b] = match.slice(0, 3).map((c) => {

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
@@ -1,0 +1,101 @@
+import { expect } from '@playwright/test'
+import { ColorMode } from '../../../src/common/theme/enums'
+import { mockBilibiliXml } from '../../network/bilibili'
+import { mockDandanplay } from '../../network/dandanplay'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { test } from '../../setup/fixtures'
+import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Search page styling regressions. The source filter chip must render with
+ * the theme typography font instead of inheriting the UA serif fallback, and
+ * the search history dropdown text must stay readable (light) in dark mode
+ * rather than inheriting near-black and vanishing on the dark paper.
+ */
+
+function relativeLuminance(color: string): number {
+  const match = color.match(/\d+(\.\d+)?/g)
+  if (!match) {
+    throw new Error(`unparseable color: ${color}`)
+  }
+  const [r, g, b] = match.slice(0, 3).map((c) => {
+    const channel = Number(c) / 255
+    return channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+test('source filter chip uses the theme font, not the UA serif fallback', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: {
+      dandanplay: { enabled: true },
+      bilibili: { enabled: true },
+    },
+    network: [
+      mockDandanplay({
+        search: loadJsonFixture('ddp-search.json'),
+        bangumi: loadJsonFixture('ddp-bangumi.json'),
+        comments: loadJsonFixture('ddp-comments.json'),
+      }),
+      ...mockBilibiliXml({
+        searchBangumi: loadJsonFixture('bilibili-search-bangumi.json'),
+        searchFt: loadJsonFixture('bilibili-search-ft.json'),
+        season: loadJsonFixture('bilibili-season.json'),
+        xml: loadTextFixture('bilibili-xml.xml'),
+      }),
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+
+  const chip = popup.search.sourceChip('DanDanPlay')
+  await expect(chip).toBeVisible()
+
+  const fontFamily = await chip.evaluate(
+    (el) => getComputedStyle(el).fontFamily
+  )
+  expect(fontFamily).toContain('Plus Jakarta Sans')
+})
+
+test('search history dropdown text is readable in dark mode', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    extensionOptions: { theme: { colorMode: ColorMode.Dark } },
+    providers: {
+      dandanplay: { enabled: true },
+    },
+    network: [
+      mockDandanplay({
+        search: loadJsonFixture('ddp-search.json'),
+        bangumi: loadJsonFixture('ddp-bangumi.json'),
+        comments: loadJsonFixture('ddp-comments.json'),
+      }),
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+  await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
+
+  await popup.search.input.click()
+
+  const option = page.getByRole('option', { name: 'frieren' })
+  await expect(option).toBeVisible()
+
+  const color = await option.evaluate((el) => getComputedStyle(el).color)
+  expect(relativeLuminance(color)).toBeGreaterThan(0.5)
+})

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
@@ -93,7 +93,7 @@ test('search history dropdown text is readable in dark mode', async ({
 
   await popup.search.input.click()
 
-  const option = page.getByRole('option', { name: 'frieren' })
+  const option = popup.search.historyOption('frieren')
   await expect(option).toBeVisible()
 
   const color = await option.evaluate((el) => getComputedStyle(el).color)

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
@@ -1,35 +1,49 @@
-import { expect } from '@playwright/test'
 import { ColorMode } from '../../../src/common/theme/enums'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { mockDandanplay } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
 import { getDaClient } from '../../setup/da-client'
-import { test } from '../../setup/fixtures'
+import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Search page styling regressions. The source filter chip must render with
- * the theme typography font instead of inheriting the UA serif fallback, and
- * the search history dropdown text must stay readable (light) in dark mode
- * rather than inheriting near-black and vanishing on the dark paper.
+ * Search page styling regressions, asserted against what actually paints.
+ * The source filter chip text must be painted by a bundled theme font (read
+ * via CDP CSS.getPlatformFontsForNode, the same source as DevTools' Rendered
+ * Fonts panel) rather than the UA serif fallback. The history dropdown must
+ * establish its own readable text color so it survives a context that strips
+ * inherited color, as the content-script shadow root does.
  */
 
-function relativeLuminance(color: string): number {
-  const match = color.match(/\d+(\.\d+)?/g)
-  if (!match || match.length < 3) {
+function parseRgb(color: string): [number, number, number] {
+  const channels = color.match(/\d+(\.\d+)?/g)
+  if (!channels || channels.length < 3) {
     throw new Error(`unparseable color: ${color}`)
   }
-  const [r, g, b] = match.slice(0, 3).map((c) => {
-    const channel = Number(c) / 255
+  return [Number(channels[0]), Number(channels[1]), Number(channels[2])]
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const [lr, lg, lb] = [r, g, b].map((c) => {
+    const channel = c / 255
     return channel <= 0.03928
       ? channel / 12.92
       : ((channel + 0.055) / 1.055) ** 2.4
   })
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb
 }
 
-test('source filter chip uses the theme font, not the UA serif fallback', async ({
+function contrastRatio(
+  a: [number, number, number],
+  b: [number, number, number]
+): number {
+  const lighter = Math.max(relativeLuminance(a), relativeLuminance(b))
+  const darker = Math.min(relativeLuminance(a), relativeLuminance(b))
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+test('source filter chip text is painted by the bundled theme font, not a serif fallback', async ({
   context,
   page,
   extensionId,
@@ -60,14 +74,32 @@ test('source filter chip uses the theme font, not the UA serif fallback', async 
 
   const chip = popup.search.sourceChip('DanDanPlay')
   await expect(chip).toBeVisible()
+  await page.evaluate(() => document.fonts.ready)
 
-  const fontFamily = await chip.evaluate(
-    (el) => getComputedStyle(el).fontFamily
-  )
-  expect(fontFamily).toContain('Plus Jakarta Sans')
+  const cdp = await page.context().newCDPSession(page)
+  await cdp.send('DOM.enable')
+  await cdp.send('CSS.enable')
+  const { root } = await cdp.send('DOM.getDocument', {
+    depth: -1,
+    pierce: true,
+  })
+  const { nodeId } = await cdp.send('DOM.querySelector', {
+    nodeId: root.nodeId,
+    selector: '[data-testid="source-chip-DanDanPlay"]',
+  })
+  const { fonts } = await cdp.send('CSS.getPlatformFontsForNode', { nodeId })
+  await cdp.detach()
+
+  expect(fonts.length, 'chip text rendered no fonts').toBeGreaterThan(0)
+  const dominant = fonts.reduce((a, b) => (b.glyphCount > a.glyphCount ? b : a))
+  expect(
+    dominant.isCustomFont,
+    `chip should paint with the bundled woff2, got: ${JSON.stringify(fonts)}`
+  ).toBe(true)
+  expect(dominant.familyName).toContain('Jakarta')
 })
 
-test('search history dropdown text is readable in dark mode', async ({
+test('search history dropdown text stays readable when ambient color is stripped', async ({
   context,
   page,
   extensionId,
@@ -91,11 +123,39 @@ test('search history dropdown text is readable in dark mode', async ({
   await popup.search.submit('frieren')
   await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
 
+  // The content-script controller portals this dropdown into its shadow root,
+  // where shadow.css `all: initial` strips inherited color. The popup keeps an
+  // ambient light color the dropdown would otherwise lean on, so neutralize
+  // the portal root's color to exercise the same condition: the dropdown must
+  // supply its own readable text rather than depend on what it inherits.
+  await page.evaluate(() => {
+    document.body.style.setProperty('color', 'rgb(0, 0, 0)')
+  })
+
   await popup.search.input.click()
 
   const option = popup.search.historyOption('frieren')
   await expect(option).toBeVisible()
 
-  const color = await option.evaluate((el) => getComputedStyle(el).color)
-  expect(relativeLuminance(color)).toBeGreaterThan(0.5)
+  const { color, background } = await option.evaluate((el) => {
+    // Walk to the first fully opaque background: the visible color behind the
+    // text is the paper, not the highlighted option's alpha overlay.
+    let node: HTMLElement | null = el
+    let resolved = 'rgb(255, 255, 255)'
+    while (node) {
+      const bg = getComputedStyle(node).backgroundColor
+      const channels = bg.match(/[\d.]+/g)
+      if (channels && (channels.length === 3 || Number(channels[3]) === 1)) {
+        resolved = bg
+        break
+      }
+      node = node.parentElement
+    }
+    return { color: getComputedStyle(el).color, background: resolved }
+  })
+
+  expect(
+    contrastRatio(parseRgb(color), parseRgb(background)),
+    `history text ${color} is not readable on ${background}`
+  ).toBeGreaterThan(4.5)
 })

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchInput.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchInput.tsx
@@ -10,7 +10,13 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { type SyntheticEvent, useEffect, useMemo, useRef } from 'react'
+import {
+  forwardRef,
+  type SyntheticEvent,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { getScrollBarProps } from '@/common/components/layout/ScrollBox'
 import { formatHotkeyCombo } from '@/common/options/extensionOptions/hotkeys'
@@ -289,16 +295,18 @@ interface HistoryDropdownPaperProps
   hasEntries?: boolean
 }
 
-function HistoryDropdownPaper({
-  onClearHistory,
-  hasEntries,
-  children,
-  ...rest
-}: HistoryDropdownPaperProps) {
+const HistoryDropdownPaper = forwardRef<
+  HTMLDivElement,
+  HistoryDropdownPaperProps
+>(function HistoryDropdownPaper(
+  { onClearHistory, hasEntries, children, ...rest },
+  ref
+) {
   const { t } = useTranslation()
 
   return (
     <Box
+      ref={ref}
       {...rest}
       sx={(theme) => ({
         backgroundColor: theme.palette.background.paper,
@@ -353,4 +361,4 @@ function HistoryDropdownPaper({
       {children}
     </Box>
   )
-}
+})

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchInput.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchInput.tsx
@@ -302,6 +302,7 @@ function HistoryDropdownPaper({
       {...rest}
       sx={(theme) => ({
         backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
         border: `1px solid ${theme.palette.divider}`,
         borderRadius: 1,
         boxShadow: '0 12px 32px -16px rgba(10,5,20,.25)',

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -24,7 +24,7 @@ const Chip = styled(ButtonBase, {
   padding: '0 9px',
   borderRadius: 999,
   flexShrink: 0,
-  fontFamily: 'inherit',
+  fontFamily: theme.typography.fontFamily,
   fontSize: 12,
   fontWeight: 600,
   letterSpacing: 0.1,


### PR DESCRIPTION
## Summary
- Source filter chips on the search page rendered with the wrong font (serif fallback in the content-script shadow DOM, off in the popup). The chip is a `styled(ButtonBase)` native `<button>` with `fontFamily: 'inherit'`; with no `CssBaseline` applying the theme font to any ancestor, it inherited the UA default. Now set to `theme.typography.fontFamily`.
- Search history dropdown text was invisible in dark mode. The controller portals the dropdown into its shadow root, where `shadow.css`'s `all: initial` strips inherited `color`; `HistoryDropdownPaper` (a bare `Box` replacing MUI `Paper`, which normally sets `color: text.primary`) supplied none, so option text fell back to near-black on the dark paper. Now sets `color: text.primary` on the paper root.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e specs/sources/search-styling.spec.ts`
- The font spec asserts the chip's **actually-rendered** font via CDP `CSS.getPlatformFontsForNode` (the DevTools Rendered Fonts source), so a serif/system fallback fails it.
- The dark-mode spec neutralizes the dropdown's inherited color to reproduce the shadow-root condition, so the option must supply its own readable color (asserted by contrast ratio against the real opaque background).
- Both specs were verified to **fail when their fix is reverted** (font → `Droid Sans Fallback`/`Noto Sans`; color → black text on dark paper), confirming they are real regression guards rather than declaration echoes.

## Notes
- The popup alone does not reproduce either bug faithfully (it carries an ambient light color and the UA default font), which is why the font spec reads the rendered font and the color spec strips the ambient color. Content-script shadow-DOM font availability is already covered by `e2e/specs/baseline/fonts.spec.ts`.