### PR TITLE
(extension) persist search source-chip selection, overflow into +N menu [DA-578]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -29,10 +29,14 @@ export class Popup {
   static async open(
     page: Page,
     extensionId: string,
-    hashRoute = '/search'
+    hashRoute = '/search',
+    opts: { detached?: boolean } = {}
   ): Promise<Popup> {
+    // detached=1 makes the popup fill the viewport instead of its fixed 500px
+    // box, so a narrow viewport can exercise width-dependent layout.
+    const query = opts.detached ? '?detached=1' : ''
     await page.goto(
-      `chrome-extension://${extensionId}/pages/popup.html#${hashRoute}`
+      `chrome-extension://${extensionId}/pages/popup.html${query}#${hashRoute}`
     )
     await page.locator('#root').waitFor({ state: 'visible' })
     return new Popup(page)

--- a/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
@@ -41,6 +41,17 @@ export class SearchPage {
     return this.page.locator(`[data-testid="source-chip-${impl}"]`)
   }
 
+  get overflowChip(): Locator {
+    return this.page.locator('[data-testid="source-chip-overflow"]')
+  }
+
+  // `providerId` is the config id, e.g. 'builtin:tencent'.
+  overflowMenuItem(providerId: string): Locator {
+    return this.page.locator(
+      `[data-testid="drilldown-menu-item-${providerId}"]`
+    )
+  }
+
   historyOption(text: string): Locator {
     return this.page.getByRole('option', { name: text })
   }

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-source-chips.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-source-chips.spec.ts
@@ -1,0 +1,114 @@
+import { expect } from '@playwright/test'
+import { mockBilibiliXml } from '../../network/bilibili'
+import { mockDandanplay } from '../../network/dandanplay'
+import { mockTencent } from '../../network/tencent'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { test } from '../../setup/fixtures'
+import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Source filter chip selection survives navigation into season details and
+ * back: picking the Bilibili chip then returning keeps Bilibili active rather
+ * than resetting to the first provider. Also covers chip overflow at a narrow
+ * width: providers that don't fit collapse into a +N chip whose menu activates
+ * the hidden source and swaps it into the visible row.
+ */
+
+test('source chips: selection persists across season details navigation', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: {
+      dandanplay: { enabled: true },
+      bilibili: { enabled: true },
+    },
+    network: [
+      mockDandanplay({
+        search: loadJsonFixture('ddp-search.json'),
+        bangumi: loadJsonFixture('ddp-bangumi.json'),
+        comments: loadJsonFixture('ddp-comments.json'),
+      }),
+      ...mockBilibiliXml({
+        searchBangumi: loadJsonFixture('bilibili-search-bangumi.json'),
+        searchFt: loadJsonFixture('bilibili-search-ft.json'),
+        season: loadJsonFixture('bilibili-season.json'),
+        xml: loadTextFixture('bilibili-xml.xml'),
+      }),
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+
+  await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
+
+  await popup.search.sourceChip('Bilibili').click()
+  await expect(popup.search.sourceChip('Bilibili')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  )
+  await popup.search.openFirstResult('Bilibili')
+
+  await page.goBack()
+
+  await expect(popup.search.sourceChip('Bilibili')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  )
+  await expect(popup.search.seasonCard('Bilibili')).toBeVisible()
+})
+
+test('source chips: overflow collapses into a +N menu that activates hidden sources', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  await page.setViewportSize({ width: 240, height: 640 })
+
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: {
+      dandanplay: { enabled: true },
+      bilibili: { enabled: true },
+      tencent: { enabled: true },
+    },
+    network: [
+      mockDandanplay({
+        search: loadJsonFixture('ddp-search.json'),
+        bangumi: loadJsonFixture('ddp-bangumi.json'),
+        comments: loadJsonFixture('ddp-comments.json'),
+      }),
+      ...mockTencent({
+        search: loadJsonFixture('tencent-search.json'),
+        episodes: loadJsonFixture('tencent-episodes.json'),
+        danmakuBase: loadJsonFixture('tencent-danmaku-base.json'),
+        danmakuSegments: {
+          '0': loadJsonFixture('tencent-danmaku-segment-0.json'),
+          '30000': loadJsonFixture('tencent-danmaku-segment-30000.json'),
+        },
+      }),
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/search', {
+    detached: true,
+  })
+  await popup.search.submit('frieren')
+
+  await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
+  await expect(popup.search.overflowChip).toBeVisible()
+
+  await popup.search.overflowChip.click()
+  await popup.search.overflowMenuItem('builtin:tencent').click()
+
+  await expect(popup.search.sourceChip('Tencent')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  )
+  await expect(popup.search.seasonCard('Tencent')).toBeVisible()
+})

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/MountPageBottomBar.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/MountPageBottomBar.tsx
@@ -112,6 +112,7 @@ export const MountPageBottomBar = ({
                 dense
                 renderButton={(props) => (
                   <Button
+                    id={props.id}
                     variant="contained"
                     startIcon={<Download />}
                     onClick={props.onClick}

--- a/packages/danmaku-anywhere/src/common/components/Menu/DAMenuItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Menu/DAMenuItem.tsx
@@ -80,9 +80,11 @@ export const DAMenuItem = ({ item, onClose }: DAMenuItemProps) => {
           color={item.color}
           data-testid={`drilldown-menu-item-${item.id}`}
         >
-          <ListItemIcon>
-            {item.loading ? <CircularProgress size={24} /> : item.icon}
-          </ListItemIcon>
+          {item.loading || item.icon ? (
+            <ListItemIcon>
+              {item.loading ? <CircularProgress size={24} /> : item.icon}
+            </ListItemIcon>
+          ) : null}
           <ListItemText>{item.label}</ListItemText>
         </StyledMenuItem>
       </div>

--- a/packages/danmaku-anywhere/src/common/components/Menu/DrilldownMenu.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Menu/DrilldownMenu.tsx
@@ -26,6 +26,7 @@ type DrilldownMenuProps = PropsWithChildren & {
   dense?: boolean
   renderButton?: (props: {
     onClick: (event: MouseEvent<HTMLButtonElement>) => void
+    buttonId: string
   }) => ReactElement
 }
 
@@ -55,7 +56,7 @@ export const DrilldownMenu = ({
 
   const renderButton = () => {
     if (renderButtonProp) {
-      return renderButtonProp({ onClick: handleClick })
+      return renderButtonProp({ onClick: handleClick, buttonId })
     }
     return (
       <IconButton

--- a/packages/danmaku-anywhere/src/common/components/Menu/DrilldownMenu.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Menu/DrilldownMenu.tsx
@@ -26,7 +26,7 @@ type DrilldownMenuProps = PropsWithChildren & {
   dense?: boolean
   renderButton?: (props: {
     onClick: (event: MouseEvent<HTMLButtonElement>) => void
-    buttonId: string
+    id: string
   }) => ReactElement
 }
 
@@ -56,7 +56,7 @@ export const DrilldownMenu = ({
 
   const renderButton = () => {
     if (renderButtonProp) {
-      return renderButtonProp({ onClick: handleClick, buttonId })
+      return renderButtonProp({ onClick: handleClick, id: buttonId })
     }
     return (
       <IconButton

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -277,7 +277,7 @@ export function SearchForm({
           <SourceFilterChips
             providers={enabledProviders}
             states={chipStates}
-            activeId={activeProviderId ?? enabledProviders[0]?.id ?? ''}
+            activeId={activeProviderId ?? ''}
             onChange={onProviderIdChange}
           />
         )}

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -31,6 +31,8 @@ type SeasonOrInsert = Season | SeasonInsert | CustomSeason
 interface SearchFormProps {
   searchTerm: string
   onSearchTermChange: (term: string) => void
+  providerId?: string
+  onProviderIdChange: (id: string) => void
   onSeasonClick: (season: SeasonOrInsert, provider: ProviderConfig) => void
   onImportSuccess?: (episode: WithSeason<Episode>) => void
   focusToken?: number
@@ -39,6 +41,8 @@ interface SearchFormProps {
 export function SearchForm({
   searchTerm,
   onSearchTermChange,
+  providerId,
+  onProviderIdChange,
   onSeasonClick,
   onImportSuccess,
   focusToken,
@@ -55,14 +59,13 @@ export function SearchForm({
   )
 
   const [committedSearchTerm, setCommittedSearchTerm] = useState(searchTerm)
-  const [providerIdOverride, setProviderIdOverride] = useState<string>()
   const [parseSubmitToken, setParseSubmitToken] = useState(0)
   const [committedParseUrl, setCommittedParseUrl] = useState('')
 
   const isUrl = isParseableUrl(searchTerm)
 
   const activeProviderId =
-    enabledProviders.find((p) => p.id === providerIdOverride)?.id ??
+    enabledProviders.find((p) => p.id === providerId)?.id ??
     enabledProviders[0]?.id
 
   const unknownErrorMessage = t('error.unknown', 'Something went wrong.')
@@ -275,7 +278,7 @@ export function SearchForm({
             providers={enabledProviders}
             states={chipStates}
             activeId={activeProviderId ?? enabledProviders[0]?.id ?? ''}
-            onChange={setProviderIdOverride}
+            onChange={onProviderIdChange}
           />
         )}
 

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchPageCore.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchPageCore.tsx
@@ -24,6 +24,8 @@ export interface SearchPageCoreProps {
   onImportSuccess?: (episode: WithSeason<Episode>) => void
   searchTerm: string
   onSearchTermChange: (term: string) => void
+  providerId?: string
+  onProviderIdChange: (id: string) => void
   dragOverlayPortal?: HTMLElement | null
   ref?: RefObject<HTMLDivElement | null>
   focusToken?: number
@@ -34,6 +36,8 @@ export function SearchPageCore({
   onImportSuccess,
   searchTerm,
   onSearchTermChange,
+  providerId,
+  onProviderIdChange,
   dragOverlayPortal,
   ref,
   focusToken,
@@ -66,6 +70,8 @@ export function SearchPageCore({
       <SearchForm
         searchTerm={searchTerm}
         onSearchTermChange={onSearchTermChange}
+        providerId={providerId}
+        onProviderIdChange={onProviderIdChange}
         onSeasonClick={onSeasonClick}
         onImportSuccess={onImportSuccess}
         focusToken={focusToken}

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -120,9 +120,9 @@ export function SourceFilterChips({
     if (!el) {
       return
     }
-    setContainerWidth(el.clientWidth)
+    setContainerWidth(el.getBoundingClientRect().width)
     const observer = new ResizeObserver(() => {
-      setContainerWidth(el.clientWidth)
+      setContainerWidth(el.getBoundingClientRect().width)
     })
     observer.observe(el)
     return () => observer.disconnect()
@@ -149,14 +149,14 @@ export function SourceFilterChips({
     el.querySelectorAll<HTMLElement>('[data-measure-id]').forEach((node) => {
       const id = node.dataset.measureId
       if (id) {
-        next[id] = node.offsetWidth
+        next[id] = node.getBoundingClientRect().width
       }
     })
     const overflowNode = el.querySelector<HTMLElement>(
       '[data-measure-overflow]'
     )
     setWidths(next)
-    setOverflowWidth(overflowNode?.offsetWidth ?? 0)
+    setOverflowWidth(overflowNode?.getBoundingClientRect().width ?? 0)
   }, [measureSignature])
 
   const { visible, overflow } = useMemo(

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -176,6 +176,7 @@ export function SourceFilterChips({
     <Box
       ref={containerRef}
       sx={{
+        position: 'relative',
         display: 'flex',
         alignItems: 'center',
         gap: `${GAP}px`,

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -1,6 +1,19 @@
-import { ButtonBase, CircularProgress, Stack, styled } from '@mui/material'
+import { Box, ButtonBase, CircularProgress, styled } from '@mui/material'
+import {
+  type ReactNode,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import type { DAMenuItemConfig } from '@/common/components/Menu/DAMenuItemConfig'
+import { DrilldownMenu } from '@/common/components/Menu/DrilldownMenu'
 import { localizedDanmakuSourceType } from '@/common/danmaku/enums'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
+import { computeChipOverflow } from './computeChipOverflow'
+
+const GAP = 6
 
 export interface SourceChipState {
   isPending: boolean
@@ -24,7 +37,7 @@ const Chip = styled(ButtonBase, {
   padding: '0 9px',
   borderRadius: 999,
   flexShrink: 0,
-  fontFamily: theme.typography.fontFamily,
+  fontFamily: 'inherit',
   fontSize: 12,
   fontWeight: 600,
   letterSpacing: 0.1,
@@ -59,29 +72,120 @@ function providerLabel(provider: ProviderConfig): string {
   return provider.name
 }
 
+function chipBody(
+  provider: ProviderConfig,
+  active: boolean,
+  state: SourceChipState | undefined
+): ReactNode {
+  if (state?.isPending) {
+    return (
+      <>
+        {providerLabel(provider)}
+        <CircularProgress
+          size={9}
+          thickness={6}
+          sx={{
+            color: active ? 'primary.contrastText' : 'text.secondary',
+            ml: 0.25,
+          }}
+        />
+      </>
+    )
+  }
+  return (
+    <>
+      {providerLabel(provider)}
+      {typeof state?.count === 'number' ? (
+        <CountText active={active}>· {state.count}</CountText>
+      ) : null}
+    </>
+  )
+}
+
 export function SourceFilterChips({
   providers,
   states,
   activeId,
   onChange,
 }: SourceFilterChipsProps) {
+  const { t } = useTranslation()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const measureRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(0)
+  const [widths, setWidths] = useState<Record<string, number>>({})
+  const [overflowWidth, setOverflowWidth] = useState(0)
+
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) {
+      return
+    }
+    setContainerWidth(el.clientWidth)
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width)
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useLayoutEffect(() => {
+    const el = measureRef.current
+    if (!el) {
+      return
+    }
+    const next: Record<string, number> = {}
+    el.querySelectorAll<HTMLElement>('[data-measure-id]').forEach((node) => {
+      const id = node.dataset.measureId
+      if (id) {
+        next[id] = node.offsetWidth
+      }
+    })
+    const overflowNode = el.querySelector<HTMLElement>(
+      '[data-measure-overflow]'
+    )
+    setWidths(next)
+    setOverflowWidth(overflowNode?.offsetWidth ?? 0)
+  }, [providers, states, activeId])
+
+  const { visible, overflow } = useMemo(
+    () =>
+      computeChipOverflow({
+        items: providers,
+        activeId,
+        widths,
+        containerWidth,
+        overflowWidth,
+        gap: GAP,
+      }),
+    [providers, activeId, widths, containerWidth, overflowWidth]
+  )
+
+  const overflowItems = useMemo((): DAMenuItemConfig[] => {
+    return overflow.map((provider) => ({
+      kind: 'item',
+      id: provider.id,
+      icon: null,
+      label: providerLabel(provider),
+      onClick: () => onChange(provider.id),
+    }))
+  }, [overflow, onChange])
+
   return (
-    <Stack
-      direction="row"
-      spacing={0.75}
+    <Box
+      ref={containerRef}
       sx={{
+        display: 'flex',
         alignItems: 'center',
-        overflowX: 'auto',
+        gap: `${GAP}px`,
+        overflow: 'hidden',
         pb: 0.25,
-        '&::-webkit-scrollbar': { display: 'none' },
-        scrollbarWidth: 'none',
+        minWidth: 0,
       }}
     >
-      {providers.map((provider) => {
+      {visible.map((provider) => {
         const active = provider.id === activeId
-        const state = states[provider.id]
-        const count = state?.count
-        const label = providerLabel(provider)
         return (
           <Chip
             key={provider.id}
@@ -90,22 +194,61 @@ export function SourceFilterChips({
             aria-pressed={active}
             data-testid={`source-chip-${provider.impl}`}
           >
-            {label}
-            {state?.isPending ? (
-              <CircularProgress
-                size={9}
-                thickness={6}
-                sx={{
-                  color: active ? 'primary.contrastText' : 'text.secondary',
-                  ml: 0.25,
-                }}
-              />
-            ) : typeof count === 'number' ? (
-              <CountText active={active}>· {count}</CountText>
-            ) : null}
+            {chipBody(provider, active, states[provider.id])}
           </Chip>
         )
       })}
-    </Stack>
+
+      {overflow.length > 0 && (
+        <DrilldownMenu
+          items={overflowItems}
+          dense
+          BoxProps={{ sx: { flexShrink: 0, display: 'inline-flex' } }}
+          renderButton={({ onClick }) => (
+            <Chip
+              active={false}
+              onClick={onClick}
+              aria-haspopup="menu"
+              aria-label={t('searchPage.moreSources', 'More sources')}
+              data-testid="source-chip-overflow"
+            >
+              +{overflow.length}
+            </Chip>
+          )}
+        />
+      )}
+
+      <Box
+        ref={measureRef}
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          visibility: 'hidden',
+          pointerEvents: 'none',
+          display: 'flex',
+          gap: `${GAP}px`,
+          width: 'max-content',
+        }}
+      >
+        {providers.map((provider) => {
+          const active = provider.id === activeId
+          return (
+            <Chip
+              key={provider.id}
+              active={active}
+              tabIndex={-1}
+              data-measure-id={provider.id}
+            >
+              {chipBody(provider, active, states[provider.id])}
+            </Chip>
+          )
+        })}
+        <Chip active={false} tabIndex={-1} data-measure-overflow>
+          +{providers.length}
+        </Chip>
+      </Box>
+    </Box>
   )
 }

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -215,9 +215,9 @@ export function SourceFilterChips({
           items={overflowItems}
           dense
           BoxProps={{ sx: { flexShrink: 0, display: 'inline-flex' } }}
-          renderButton={({ onClick, buttonId }) => (
+          renderButton={({ onClick, id }) => (
             <Chip
-              id={buttonId}
+              id={id}
               active={false}
               onClick={onClick}
               aria-haspopup="menu"

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -37,12 +37,12 @@ const Chip = styled(ButtonBase, {
   padding: '0 9px',
   borderRadius: 999,
   flexShrink: 0,
-  fontFamily: 'inherit',
   fontSize: 12,
   fontWeight: 600,
   letterSpacing: 0.1,
   border: 'none',
   cursor: 'pointer',
+  fontFamily: theme.typography.fontFamily,
   transition: 'background-color 120ms ease, color 120ms ease',
   backgroundColor: active ? theme.palette.primary.main : theme.palette.paperAlt,
   color: active
@@ -121,14 +121,19 @@ export function SourceFilterChips({
       return
     }
     setContainerWidth(el.clientWidth)
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        setContainerWidth(entry.contentRect.width)
-      }
+    const observer = new ResizeObserver(() => {
+      setContainerWidth(el.clientWidth)
     })
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
+
+  // SearchForm rebuilds `states` on every render (useQueries returns a fresh
+  // array), so depend on a signature of only the width-affecting fields to
+  // keep typing in the search box from re-measuring the DOM each keystroke.
+  const statesSignature = providers
+    .map((p) => `${p.id}:${states[p.id]?.isPending}:${states[p.id]?.count}`)
+    .join('|')
 
   useLayoutEffect(() => {
     const el = measureRef.current
@@ -147,7 +152,7 @@ export function SourceFilterChips({
     )
     setWidths(next)
     setOverflowWidth(overflowNode?.offsetWidth ?? 0)
-  }, [providers, states, activeId])
+  }, [statesSignature])
 
   const { visible, overflow } = useMemo(
     () =>
@@ -205,8 +210,9 @@ export function SourceFilterChips({
           items={overflowItems}
           dense
           BoxProps={{ sx: { flexShrink: 0, display: 'inline-flex' } }}
-          renderButton={({ onClick }) => (
+          renderButton={({ onClick, buttonId }) => (
             <Chip
+              id={buttonId}
               active={false}
               onClick={onClick}
               aria-haspopup="menu"

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -129,10 +129,15 @@ export function SourceFilterChips({
   }, [])
 
   // SearchForm rebuilds `states` on every render (useQueries returns a fresh
-  // array), so depend on a signature of only the width-affecting fields to
-  // keep typing in the search box from re-measuring the DOM each keystroke.
-  const statesSignature = providers
-    .map((p) => `${p.id}:${states[p.id]?.isPending}:${states[p.id]?.count}`)
+  // array), so depend on a signature of only the width-affecting inputs (label
+  // text, pending spinner, count) to keep typing in the search box from
+  // re-measuring the DOM each keystroke, while still re-measuring when a label
+  // changes (e.g. locale switch).
+  const measureSignature = providers
+    .map(
+      (p) =>
+        `${p.id}:${providerLabel(p)}:${states[p.id]?.isPending}:${states[p.id]?.count}`
+    )
     .join('|')
 
   useLayoutEffect(() => {
@@ -152,7 +157,7 @@ export function SourceFilterChips({
     )
     setWidths(next)
     setOverflowWidth(overflowNode?.offsetWidth ?? 0)
-  }, [statesSignature])
+  }, [measureSignature])
 
   const { visible, overflow } = useMemo(
     () =>

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -121,8 +121,11 @@ export function SourceFilterChips({
       return
     }
     setContainerWidth(el.getBoundingClientRect().width)
-    const observer = new ResizeObserver(() => {
-      setContainerWidth(el.getBoundingClientRect().width)
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) {
+        setContainerWidth(entry.contentRect.width)
+      }
     })
     observer.observe(el)
     return () => observer.disconnect()

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.test.ts
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.test.ts
@@ -67,6 +67,19 @@ describe('computeChipOverflow', () => {
     expect(ids(layout.overflow)).toEqual(['b', 'c', 'd'])
   })
 
+  it('falls back to natural layout when activeId is not in items', () => {
+    const layout = computeChipOverflow({
+      items,
+      activeId: 'non-existent',
+      widths: uniformWidths,
+      containerWidth: 150,
+      overflowWidth: 30,
+      gap: 6,
+    })
+    expect(ids(layout.visible)).toEqual(['a', 'b'])
+    expect(ids(layout.overflow)).toEqual(['c', 'd', 'e'])
+  })
+
   it('returns empty layout for no items', () => {
     const layout = computeChipOverflow({
       items: [],

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.test.ts
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { computeChipOverflow } from './computeChipOverflow'
+
+/**
+ * Verifies the priority-plus chip layout: everything visible when it fits,
+ * collapse trailing chips behind an overflow slot when it doesn't, and swap
+ * the active chip into the last visible slot when it would otherwise be hidden.
+ * Also covers the pre-measurement state where widths are not yet known.
+ */
+
+const item = (id: string) => ({ id })
+const items = ['a', 'b', 'c', 'd', 'e'].map(item)
+const uniformWidths = { a: 50, b: 50, c: 50, d: 50, e: 50 }
+
+const ids = (list: { id: string }[]) => list.map((entry) => entry.id)
+
+describe('computeChipOverflow', () => {
+  it('shows everything when all chips fit', () => {
+    const layout = computeChipOverflow({
+      items,
+      activeId: 'a',
+      widths: uniformWidths,
+      containerWidth: 1000,
+      overflowWidth: 30,
+      gap: 6,
+    })
+    expect(ids(layout.visible)).toEqual(['a', 'b', 'c', 'd', 'e'])
+    expect(layout.overflow).toEqual([])
+  })
+
+  it('shows everything before widths are measured', () => {
+    const layout = computeChipOverflow({
+      items,
+      activeId: 'a',
+      widths: {},
+      containerWidth: 100,
+      overflowWidth: 30,
+      gap: 6,
+    })
+    expect(ids(layout.visible)).toEqual(['a', 'b', 'c', 'd', 'e'])
+    expect(layout.overflow).toEqual([])
+  })
+
+  it('collapses trailing chips behind the overflow slot when active fits', () => {
+    const layout = computeChipOverflow({
+      items,
+      activeId: 'a',
+      widths: uniformWidths,
+      containerWidth: 150,
+      overflowWidth: 30,
+      gap: 6,
+    })
+    expect(ids(layout.visible)).toEqual(['a', 'b'])
+    expect(ids(layout.overflow)).toEqual(['c', 'd', 'e'])
+  })
+
+  it('swaps the active chip into the last visible slot when it overflows', () => {
+    const layout = computeChipOverflow({
+      items,
+      activeId: 'e',
+      widths: uniformWidths,
+      containerWidth: 150,
+      overflowWidth: 30,
+      gap: 6,
+    })
+    expect(ids(layout.visible)).toEqual(['a', 'e'])
+    expect(ids(layout.overflow)).toEqual(['b', 'c', 'd'])
+  })
+
+  it('returns empty layout for no items', () => {
+    const layout = computeChipOverflow({
+      items: [],
+      activeId: '',
+      widths: {},
+      containerWidth: 100,
+      overflowWidth: 30,
+      gap: 6,
+    })
+    expect(layout.visible).toEqual([])
+    expect(layout.overflow).toEqual([])
+  })
+})

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.ts
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.ts
@@ -63,7 +63,7 @@ export function computeChipOverflow<T extends { id: string }>({
   )
 
   const activeIndex = items.findIndex((item) => item.id === activeId)
-  if (activeIndex < naturalCount) {
+  if (activeIndex === -1 || activeIndex < naturalCount) {
     return {
       visible: items.slice(0, naturalCount),
       overflow: items.slice(naturalCount),

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.ts
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.ts
@@ -27,10 +27,8 @@ function fitCount(widths: number[], available: number, gap: number): number {
 }
 
 /**
- * Greedily fits chips into a single row in order. When they overflow, reserves
- * room for a trailing overflow chip and collapses the rest. If the active chip
- * lands in the overflow set, it is swapped into the last visible slot so the
- * current selection is always shown.
+ * If the active chip lands in the overflow set, it is swapped into the last
+ * visible slot so the current selection is always shown.
  */
 export function computeChipOverflow<T extends { id: string }>({
   items,

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.ts
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/computeChipOverflow.ts
@@ -1,0 +1,87 @@
+interface ComputeChipOverflowArgs<T> {
+  items: T[]
+  activeId: string
+  widths: Record<string, number>
+  containerWidth: number
+  overflowWidth: number
+  gap: number
+}
+
+export interface ChipOverflowLayout<T> {
+  visible: T[]
+  overflow: T[]
+}
+
+function fitCount(widths: number[], available: number, gap: number): number {
+  let used = 0
+  let count = 0
+  for (const width of widths) {
+    const next = count > 0 ? used + gap + width : width
+    if (next > available) {
+      break
+    }
+    used = next
+    count += 1
+  }
+  return count
+}
+
+/**
+ * Greedily fits chips into a single row in order. When they overflow, reserves
+ * room for a trailing overflow chip and collapses the rest. If the active chip
+ * lands in the overflow set, it is swapped into the last visible slot so the
+ * current selection is always shown.
+ */
+export function computeChipOverflow<T extends { id: string }>({
+  items,
+  activeId,
+  widths,
+  containerWidth,
+  overflowWidth,
+  gap,
+}: ComputeChipOverflowArgs<T>): ChipOverflowLayout<T> {
+  if (items.length === 0) {
+    return { visible: [], overflow: [] }
+  }
+
+  const hasAllWidths = items.every((item) => widths[item.id] !== undefined)
+  if (!containerWidth || !hasAllWidths) {
+    return { visible: items, overflow: [] }
+  }
+
+  const totalWidth = items.reduce(
+    (sum, item, index) => sum + widths[item.id] + (index > 0 ? gap : 0),
+    0
+  )
+  if (totalWidth <= containerWidth) {
+    return { visible: items, overflow: [] }
+  }
+
+  const reserved = overflowWidth + gap
+  const naturalCount = fitCount(
+    items.map((item) => widths[item.id]),
+    containerWidth - reserved,
+    gap
+  )
+
+  const activeIndex = items.findIndex((item) => item.id === activeId)
+  if (activeIndex < naturalCount) {
+    return {
+      visible: items.slice(0, naturalCount),
+      overflow: items.slice(naturalCount),
+    }
+  }
+
+  const activeItem = items[activeIndex]
+  const leading = items.filter((item) => item.id !== activeId)
+  const leadAvailable = containerWidth - reserved - widths[activeId] - gap
+  const leadCount = fitCount(
+    leading.map((item) => widths[item.id]),
+    leadAvailable,
+    gap
+  )
+  return {
+    visible: [...leading.slice(0, leadCount), activeItem],
+    overflow: leading.slice(leadCount),
+  }
+}

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -636,6 +636,7 @@
       "clear": "Clear",
       "recent": "Recent"
     },
+    "moreSources": "More sources",
     "parse": {
       "alert": {
         "importSuccess": "Import successful",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -619,6 +619,7 @@
       "clear": "清除",
       "recent": "最近"
     },
+    "moreSources": "更多来源",
     "parse": {
       "alert": {
         "importSuccess": "导入成功",

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SearchPage.tsx
@@ -36,6 +36,7 @@ export const SearchPage = (): React.ReactElement | null => {
   const [selectedProvider, setSelectedProvider] = useState<
     ProviderConfig | undefined
   >()
+  const [providerId, setProviderId] = useState<string>()
 
   const showAddSeasonMapDialog = useShowAddSeasonMapDialog()
 
@@ -113,6 +114,8 @@ export const SearchPage = (): React.ReactElement | null => {
     <SearchPageCore
       searchTerm={searchTitle}
       onSearchTermChange={setSearchTitle}
+      providerId={providerId}
+      onProviderIdChange={setProviderId}
       onSeasonClick={handleSeasonClick}
       onImportSuccess={(episode) => mountDanmaku([episode])}
       dragOverlayPortal={highlighterPortal}

--- a/packages/danmaku-anywhere/src/popup/pages/search/SearchPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/search/SearchPage.tsx
@@ -17,6 +17,8 @@ export const SearchPage = () => {
       ref={layoutRef}
       searchTerm={search.keyword}
       onSearchTermChange={search.setKeyword}
+      providerId={search.providerId}
+      onProviderIdChange={search.setProviderId}
       onSeasonClick={(season, provider) => {
         upsertSeason.mutate(season, {
           onSuccess: (persisted) => {

--- a/packages/danmaku-anywhere/src/popup/pages/search/seasonDetails/SeasonDetailsPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/search/seasonDetails/SeasonDetailsPage.tsx
@@ -44,7 +44,7 @@ export const SeasonDetailsPage = () => {
       <TabToolbar title={season.title} showBackButton onGoBack={goBack}>
         <BookmarkToggleButton season={season} />
       </TabToolbar>
-      <Stack spacing={0.75} sx={{ px: 1.25, pt: 1, pb: 0.5, flexShrink: 0 }}>
+      <Stack spacing={0.75} sx={{ px: 2, pb: 0.5, flexShrink: 0 }}>
         <TextField
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
@@ -82,7 +82,7 @@ export const SeasonDetailsPage = () => {
         </Typography>
       </Stack>
       <ScrollBox
-        sx={{ overflow: 'auto', flex: 1, minHeight: 0, px: 0.5, pb: 1 }}
+        sx={{ overflow: 'auto', flex: 1, minHeight: 0, px: 1.25, pb: 1.5 }}
       >
         <ErrorBoundary
           fallbackRender={({ error }) => (

--- a/packages/danmaku-anywhere/src/popup/store.ts
+++ b/packages/danmaku-anywhere/src/popup/store.ts
@@ -23,6 +23,8 @@ interface StoreState {
     setSearchParams: (params?: SearchEpisodesQuery) => void
     keyword: string
     setKeyword: (keyword: string) => void
+    providerId?: string
+    setProviderId: (providerId: string) => void
     season?: Season | CustomSeason
     setSeason: (season: Season | CustomSeason) => void
     provider?: ProviderConfig
@@ -81,6 +83,12 @@ const useStoreBase = create<StoreState>()(
       setKeyword: (keyword: string) => {
         set((state) => {
           state.search.keyword = keyword
+        })
+      },
+      providerId: undefined,
+      setProviderId: (providerId: string) => {
+        set((state) => {
+          state.search.providerId = providerId
         })
       },
       season: undefined,


### PR DESCRIPTION
## Summary
- Selecting a source chip, opening a season's details, then going back no longer resets the selection to the first provider. The selected provider id is lifted out of `SearchForm` local state into controlled parent state: the popup persists it in the zustand store, the content floating panel in its surviving local state.
- The source-chip row no longer hides its scrollbar on overflow. It now uses a priority-plus layout: chip widths are measured (hidden ghost row + `ResizeObserver`), `computeChipOverflow` decides which chips fit, and the rest collapse into a `+N` chip that opens the existing `DrilldownMenu`. When the active source would overflow, it is swapped into the last visible slot so the current selection stays on screen.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere exec vitest run src/common/components/SearchPageCore/computeChipOverflow.test.ts` (pure overflow/swap logic)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e e2e/specs/sources/search-source-chips.spec.ts` covers both behaviors:
  - selection persists across season-details navigation (`page.goBack()`)
  - overflow at a narrow width collapses into `+N`, whose menu activates a hidden source and swaps it into the visible row
- [ ] `pnpm type-check && pnpm lint`

## Notes
- Sources are lazy-fetched (only the active provider runs a search), so only the active chip shows a result count and overflow-menu items are bare labels.
- The overflow e2e opens the popup with `?detached=1` so it fills a narrow viewport instead of its fixed 500px box, which is how the layout is driven into overflow.