### PR TITLE
(proxy) serve dango manifest catalog + files [DA-568]

### DIFF
--- a/backend/proxy/src/routes/api/manifest/router.test.ts
+++ b/backend/proxy/src/routes/api/manifest/router.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createTestUrl } from '@/test-utils/createTestUrl'
+import { makeUnitTestRequest } from '@/test-utils/makeUnitTestRequest'
+
+const dangoBaseUrl =
+  'https://raw.githubusercontent.com/Mr-Quin/dango/main/packages/dango-manifests'
+
+describe('Manifest API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('proxies the catalog from the dango repo (GET /)', async () => {
+    const mockCatalog = {
+      packageVersion: '0.2.0',
+      manifests: [
+        {
+          id: 'builtin:bilibili',
+          name: 'Bilibili',
+          version: '0.2.0',
+          apiVersion: 1,
+          file: 'src/manifests/builtin-bilibili.json',
+        },
+      ],
+    }
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockCatalog), { status: 200 })
+      )
+
+    const request = new Request(createTestUrl('/manifest'))
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledWith(`${dangoBaseUrl}/catalog.json`)
+
+    const content: any = await response.json()
+    expect(content.packageVersion).toBe('0.2.0')
+    expect(content.manifests.length).toBeGreaterThan(0)
+  })
+
+  it('proxies a manifest file from the dango repo (GET /file)', async () => {
+    const mockManifest = { id: 'builtin:bilibili', name: 'Bilibili' }
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockManifest), { status: 200 })
+      )
+
+    const request = new Request(
+      createTestUrl('/manifest/file', {
+        query: { file: 'src/manifests/builtin-bilibili.json' },
+      })
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${dangoBaseUrl}/src/manifests/builtin-bilibili.json`
+    )
+
+    const content: any = await response.json()
+    expect(content.id).toBe('builtin:bilibili')
+  })
+
+  it('returns 400 when file parameter is missing (GET /file)', async () => {
+    const request = new Request(createTestUrl('/manifest/file'))
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(400)
+
+    const content: any = await response.json()
+    expect(content.success).toBe(false)
+  })
+
+  it('rejects path traversal in the file parameter (GET /file)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const request = new Request(
+      createTestUrl('/manifest/file', {
+        query: { file: 'src/manifests/../../../../etc/passwd.json' },
+      })
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-manifest paths in the file parameter (GET /file)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const request = new Request(
+      createTestUrl('/manifest/file', {
+        query: { file: 'catalog.json' },
+      })
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects absolute URLs in the file parameter (GET /file)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const request = new Request(
+      createTestUrl('/manifest/file', {
+        query: { file: 'https://evil.example.com/payload.json' },
+      })
+    )
+    const response = await makeUnitTestRequest(request)
+
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/backend/proxy/src/routes/api/manifest/router.ts
+++ b/backend/proxy/src/routes/api/manifest/router.ts
@@ -1,0 +1,79 @@
+import { describeRoute, resolver, validator } from 'hono-openapi'
+import { z } from 'zod'
+import { factory } from '@/factory'
+import { useCache } from '@/middleware/cache'
+
+export const manifestRouter = factory.createApp()
+
+const dangoBaseUrl =
+  'https://raw.githubusercontent.com/Mr-Quin/dango/main/packages/dango-manifests'
+
+const filePattern = /^src\/manifests\/[\w.-]+\.json$/
+
+const oneHour = 60 * 60
+
+manifestRouter.get(
+  '/',
+  describeRoute({
+    description: 'Get dango manifest catalog',
+    responses: {
+      200: {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: resolver(
+              z.object({
+                packageVersion: z.string(),
+                manifests: z.array(
+                  z.object({
+                    id: z.string(),
+                    name: z.string(),
+                    version: z.string(),
+                    apiVersion: z.number(),
+                    file: z.string(),
+                  })
+                ),
+              })
+            ),
+          },
+        },
+      },
+    },
+  }),
+  useCache({
+    maxAge: oneHour,
+  }),
+  async (c) => {
+    return await fetch(`${dangoBaseUrl}/catalog.json`)
+  }
+)
+
+manifestRouter.get(
+  '/file',
+  validator(
+    'query',
+    z.object({
+      file: z.string().regex(filePattern),
+    })
+  ),
+  describeRoute({
+    description: 'Get a dango manifest file',
+    responses: {
+      200: {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: resolver(z.object({}).passthrough()),
+          },
+        },
+      },
+    },
+  }),
+  useCache({
+    maxAge: oneHour,
+  }),
+  async (c) => {
+    const { file } = c.req.valid('query')
+    return await fetch(`${dangoBaseUrl}/${file}`)
+  }
+)

--- a/backend/proxy/src/routes/api/routes.ts
+++ b/backend/proxy/src/routes/api/routes.ts
@@ -8,6 +8,7 @@ import { ddpRouter } from './ddp/router'
 import { filesRouter } from './files/router'
 import { kazumiRouter } from './kazumi/router'
 import { llmRouter } from './llm/router'
+import { manifestRouter } from './manifest/router'
 
 export const api = factory.createApp()
 
@@ -18,5 +19,6 @@ api.route('/ddp', ddpRouter)
 api.route('/bangumi', bangumiRouter)
 api.route('/llm', llmRouter)
 api.route('/kazumi', kazumiRouter)
+api.route('/manifest', manifestRouter)
 api.route('/config', configRouter)
 api.route('/files', filesRouter)


### PR DESCRIPTION
## Summary

Adds a `/api/manifest` router to the proxy backend, mirroring the existing `/api/kazumi/rules` proxy pattern. It lets clients fetch the dango manifest catalog and individual manifest files through the backend rather than hitting GitHub raw directly.

- `GET /api/manifest/` proxies `https://raw.githubusercontent.com/Mr-Quin/dango/main/packages/dango-manifests/catalog.json`. Typed via hono-openapi (`describeRoute` + `resolver` + zod): `{ packageVersion: string, manifests: Array<{ id, name, version, apiVersion, file }> }`.
- `GET /api/manifest/file?file=<path>` validates `file` against `^src/manifests/[\w.-]+\.json$` and proxies `.../dango-manifests/${file}`. The regex rejects path traversal, absolute URLs, and non-manifest paths (HTTP 400 via the zod query validator), preventing arbitrary-fetch/SSRF.
- Both routes use `useCache({ maxAge: 3600 })` (1 hour TTL) since manifests change rarely.
- Mounted at `/manifest` in `routes.ts` next to `/kazumi`.

### Conservative choices (ambiguous points)

- Used a single `router.ts` mounted directly at `/manifest` rather than the kazumi-style nested `router.ts` + `rules.ts`. Kazumi nests because `rules` is a sub-resource (`/kazumi/rules`); the manifest endpoints live directly under `/manifest`, so an extra nesting layer would be noise. The implementation otherwise mirrors kazumi exactly.
- The `/file` response schema is left as a permissive passthrough object since manifest shape is owned by the dango repo and not duplicated here.

## Test plan

- New `router.test.ts` (6 cases, mirrors `kazumi/rules.test.ts`): asserts the catalog and file routes call `fetch` with the correct upstream dango URLs, and that the `file` validator returns 400 for missing param, path traversal (`../../../../etc/passwd.json`), non-manifest paths (`catalog.json`), and absolute URLs (`https://evil.example.com/...`) without ever calling `fetch`.
- Verified upstream `catalog.json` returns HTTP 200.
- `biome check` clean on the new files and `routes.ts`.
- Full proxy vitest suite: 66 passed (13 files).

Note: `tsgo` type-check could not run in the local worktree due to a pre-existing `tsconfig.json` `baseUrl` incompatibility with the worktree's installed tsgo dev build (errors are repo-wide, not in the new code); CI runs the pinned version.