### PR TITLE
(extension) occlusion: recover cross-origin frame capture via DNR CORS bypass [DA-583]

### DIFF
--- a/packages/danmaku-anywhere/e2e/fixtures/sites/cross-origin-video.html
+++ b/packages/danmaku-anywhere/e2e/fixtures/sites/cross-origin-video.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>DA Harness - cross-origin video</title>
+    <style>
+      video {
+        display: block;
+        width: 100%;
+        max-width: 960px;
+        margin: 0 auto;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 data-testid="da-title">DA Harness Native Video</h1>
+    <span data-testid="da-episode">Episode 1</span>
+    <video
+      data-testid="da-video"
+      controls
+      autoplay
+      muted
+      loop
+      playsinline
+    ></video>
+  </body>
+</html>

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
@@ -33,8 +33,14 @@ const COMMENTS = [
   { p: '3,1,16777215,e2e-3', m: 'third' },
 ]
 
+// Real harness server (playwright webServer): the page origin and the
+// cross-origin video origin, both needed live so the canvas genuinely taints
+// and the extension's DNR rule can un-taint a real response.
 test.use({ allowedNetworkOrigins: ['localhost:8889', '127.0.0.1:8889'] })
 
+// Helpers below probe the harness page directly (taint state, mask, src swap).
+// They are specific to this cross-origin harness fixture, not the shared
+// IntegrationPage POM, so they live here rather than as POM methods.
 function maskImageOf(locator: import('@playwright/test').Locator) {
   return locator.evaluate((el) => {
     const style = getComputedStyle(el)
@@ -124,10 +130,7 @@ test('occlusion recovers a cross-origin tainted video via the DNR clone', async 
   await page.goto(PAGE_URL)
   await setVideoSrc(page, VIDEO_1)
 
-  // The scenario is a genuine cross-origin taint, not a same-origin accident.
-  await expect
-    .poll(() => videoTaintState(page), { timeout: 10_000 })
-    .toBe('SecurityError')
+  await expect.poll(() => videoTaintState(page)).toBe('SecurityError')
 
   const mirror = await da.mount.waitForMount(undefined, 15_000)
   expect(mirror.isMounted).toBe(true)
@@ -135,12 +138,8 @@ test('occlusion recovers a cross-origin tainted video via the DNR clone', async 
     timeout: 15_000,
   })
 
-  // The mask can only apply if the upfront taint probe was satisfied by the
-  // recovered (origin-clean) clone, so this asserts the full DNR recovery path.
   await expect
-    .poll(() => maskImageOf(integrationPage.danmuContainer()), {
-      timeout: 15_000,
-    })
+    .poll(() => maskImageOf(integrationPage.danmuContainer()))
     .toMatch(/^url\(/)
 })
 
@@ -156,20 +155,12 @@ test('occlusion re-recovers when the player swaps to another cross-origin src', 
   await setVideoSrc(page, VIDEO_1)
   await da.mount.waitForMount(undefined, 15_000)
   await expect
-    .poll(() => maskImageOf(integrationPage.danmuContainer()), {
-      timeout: 15_000,
-    })
+    .poll(() => maskImageOf(integrationPage.danmuContainer()))
     .toMatch(/^url\(/)
 
-  // Same element, new cross-origin source: the clone bound to the old URL is
-  // stale and must be rebuilt for the new one.
   await setVideoSrc(page, VIDEO_2)
+  await expect.poll(() => videoTaintState(page)).toBe('SecurityError')
   await expect
-    .poll(() => videoTaintState(page), { timeout: 10_000 })
-    .toBe('SecurityError')
-  await expect
-    .poll(() => maskImageOf(integrationPage.danmuContainer()), {
-      timeout: 15_000,
-    })
+    .poll(() => maskImageOf(integrationPage.danmuContainer()))
     .toMatch(/^url\(/)
 })

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
@@ -10,13 +10,11 @@ import {
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Occlusion cross-origin recovery, end to end over real network (the
- * route-fulfilled `.invalid` origins cannot, since DNR only sees real
- * responses). The page is served from localhost:8889 and the video from
- * 127.0.0.1:8889 (a distinct origin), so the capture canvas is genuinely
- * tainted. Asserts the original is tainted yet occlusion still applies a mask,
- * which is only possible if the extension's DNR rule + crossorigin clone
- * un-tainted it; also covers the player swapping to another cross-origin src.
+ * Occlusion cross-origin recovery over real network (route-fulfilled .invalid
+ * origins can't exercise DNR). Page on localhost:8889, video on 127.0.0.1:8889,
+ * so the canvas genuinely taints; asserts the original is tainted yet a mask
+ * still applies (only possible if the DNR rule + crossorigin clone un-tainted
+ * it). Also covers swapping to another cross-origin src.
  */
 
 const PAGE_ORIGIN = 'http://localhost:8889'
@@ -33,14 +31,12 @@ const COMMENTS = [
   { p: '3,1,16777215,e2e-3', m: 'third' },
 ]
 
-// Real harness server (playwright webServer): the page origin and the
-// cross-origin video origin, both needed live so the canvas genuinely taints
-// and the extension's DNR rule can un-taint a real response.
+// Both real origins (page + cross-origin video) must hit the network so the
+// DNR taint/recovery path is exercised.
 test.use({ allowedNetworkOrigins: ['localhost:8889', '127.0.0.1:8889'] })
 
-// Helpers below probe the harness page directly (taint state, mask, src swap).
-// They are specific to this cross-origin harness fixture, not the shared
-// IntegrationPage POM, so they live here rather than as POM methods.
+// Harness-fixture-specific probes (taint, mask, src swap); intentionally not
+// IntegrationPage POM methods.
 function maskImageOf(locator: import('@playwright/test').Locator) {
   return locator.evaluate((el) => {
     const style = getComputedStyle(el)

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
@@ -1,0 +1,175 @@
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { defaultDanmakuOptions } from '../../../src/common/options/danmakuOptions/constant'
+import { IntegrationPage } from '../../pom/IntegrationPage'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import {
+  buildFixtureIntegrationPolicy,
+  seedXPathIntegration,
+} from '../../setup/integration'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Occlusion cross-origin recovery, end to end over real network (the
+ * route-fulfilled `.invalid` origins cannot, since DNR only sees real
+ * responses). The page is served from localhost:8889 and the video from
+ * 127.0.0.1:8889 (a distinct origin), so the capture canvas is genuinely
+ * tainted. Asserts the original is tainted yet occlusion still applies a mask,
+ * which is only possible if the extension's DNR rule + crossorigin clone
+ * un-tainted it; also covers the player swapping to another cross-origin src.
+ */
+
+const PAGE_ORIGIN = 'http://localhost:8889'
+const MEDIA_ORIGIN = 'http://127.0.0.1:8889'
+const PAGE_URL = `${PAGE_ORIGIN}/sites/cross-origin-video.html`
+const VIDEO_1 = `${MEDIA_ORIGIN}/media/sample-motion.webm`
+const VIDEO_2 = `${MEDIA_ORIGIN}/media/person-akiyo.webm`
+const MOUNT_PATTERN = `${PAGE_ORIGIN}/*`
+
+const EPISODE_TITLE = 'DA Harness Native Video'
+const COMMENTS = [
+  { p: '1,1,16777215,e2e-1', m: 'first' },
+  { p: '2,1,16777215,e2e-2', m: 'second' },
+  { p: '3,1,16777215,e2e-3', m: 'third' },
+]
+
+test.use({ allowedNetworkOrigins: ['localhost:8889', '127.0.0.1:8889'] })
+
+function maskImageOf(locator: import('@playwright/test').Locator) {
+  return locator.evaluate((el) => {
+    const style = getComputedStyle(el)
+    return (
+      style.getPropertyValue('-webkit-mask-image') ||
+      style.getPropertyValue('mask-image')
+    )
+  })
+}
+
+function videoTaintState(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const v = document.querySelector<HTMLVideoElement>(
+      'video[data-testid="da-video"]'
+    )
+    if (!v || v.readyState < 2) {
+      return 'notready'
+    }
+    const c = document.createElement('canvas')
+    c.width = 2
+    c.height = 2
+    const ctx = c.getContext('2d')
+    if (!ctx) {
+      return 'noctx'
+    }
+    ctx.drawImage(v, 0, 0, 2, 2)
+    try {
+      ctx.getImageData(0, 0, 1, 1)
+      return 'clean'
+    } catch (e) {
+      return e instanceof DOMException ? e.name : 'error'
+    }
+  })
+}
+
+function setVideoSrc(page: import('@playwright/test').Page, src: string) {
+  return page.evaluate((url) => {
+    const v = document.querySelector<HTMLVideoElement>(
+      'video[data-testid="da-video"]'
+    )
+    if (v) {
+      v.src = url
+      v.load()
+    }
+  }, src)
+}
+
+async function seedOcclusionMount(context: Parameters<typeof getDaClient>[0]) {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    extensionOptions: { matchLocalDanmaku: true },
+    rawStorage: [
+      {
+        area: 'sync',
+        key: 'danmakuOptions',
+        value: {
+          data: { ...defaultDanmakuOptions, occlusion: true },
+          version: 10,
+        },
+      },
+    ],
+  })
+  await da.episode.addCustom({
+    provider: DanmakuSourceType.MacCMS,
+    title: EPISODE_TITLE,
+    comments: COMMENTS,
+    commentCount: COMMENTS.length,
+    schemaVersion: 4,
+  })
+  await seedXPathIntegration(da, {
+    patterns: [MOUNT_PATTERN],
+    name: 'da-e2e',
+    policy: buildFixtureIntegrationPolicy(),
+  })
+  await da.mount.waitForRegistration(MOUNT_PATTERN, 5_000)
+  return da
+}
+
+test('occlusion recovers a cross-origin tainted video via the DNR clone', async ({
+  context,
+  page,
+}) => {
+  const da = await seedOcclusionMount(context)
+  const integrationPage = new IntegrationPage(page)
+
+  await page.bringToFront()
+  await page.goto(PAGE_URL)
+  await setVideoSrc(page, VIDEO_1)
+
+  // The scenario is a genuine cross-origin taint, not a same-origin accident.
+  await expect
+    .poll(() => videoTaintState(page), { timeout: 10_000 })
+    .toBe('SecurityError')
+
+  const mirror = await da.mount.waitForMount(undefined, 15_000)
+  expect(mirror.isMounted).toBe(true)
+  await expect(integrationPage.commentElements().first()).toBeVisible({
+    timeout: 15_000,
+  })
+
+  // The mask can only apply if the upfront taint probe was satisfied by the
+  // recovered (origin-clean) clone, so this asserts the full DNR recovery path.
+  await expect
+    .poll(() => maskImageOf(integrationPage.danmuContainer()), {
+      timeout: 15_000,
+    })
+    .toMatch(/^url\(/)
+})
+
+test('occlusion re-recovers when the player swaps to another cross-origin src', async ({
+  context,
+  page,
+}) => {
+  const da = await seedOcclusionMount(context)
+  const integrationPage = new IntegrationPage(page)
+
+  await page.bringToFront()
+  await page.goto(PAGE_URL)
+  await setVideoSrc(page, VIDEO_1)
+  await da.mount.waitForMount(undefined, 15_000)
+  await expect
+    .poll(() => maskImageOf(integrationPage.danmuContainer()), {
+      timeout: 15_000,
+    })
+    .toMatch(/^url\(/)
+
+  // Same element, new cross-origin source: the clone bound to the old URL is
+  // stale and must be rebuilt for the new one.
+  await setVideoSrc(page, VIDEO_2)
+  await expect
+    .poll(() => videoTaintState(page), { timeout: 10_000 })
+    .toBe('SecurityError')
+  await expect
+    .poll(() => maskImageOf(integrationPage.danmuContainer()), {
+      timeout: 15_000,
+    })
+    .toMatch(/^url\(/)
+})

--- a/packages/danmaku-anywhere/playwright.config.ts
+++ b/packages/danmaku-anywhere/playwright.config.ts
@@ -6,6 +6,16 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
   retries: 0,
+  // Real static server for specs that need genuine cross-origin network (e.g.
+  // cross-origin video taint + DNR recovery), which route-fulfilled `.invalid`
+  // origins cannot exercise. Other specs ignore it.
+  webServer: {
+    command: 'node e2e/harness/serve.mjs --port 8889',
+    port: 8889,
+    reuseExistingServer: !isCI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
   reporter: isCI
     ? [
         ['list'],

--- a/packages/danmaku-anywhere/playwright.config.ts
+++ b/packages/danmaku-anywhere/playwright.config.ts
@@ -6,9 +6,8 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
   retries: 0,
-  // Real static server for specs that need genuine cross-origin network (e.g.
-  // cross-origin video taint + DNR recovery), which route-fulfilled `.invalid`
-  // origins cannot exercise. Other specs ignore it.
+  // Real server for specs needing genuine cross-origin network (route-fulfilled
+  // .invalid origins can't); other specs ignore it.
   webServer: {
     command: 'node e2e/harness/serve.mjs --port 8889',
     port: 8889,

--- a/packages/danmaku-anywhere/src/background/netRequest/sessionRules.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/sessionRules.ts
@@ -2,11 +2,9 @@ import { Mutex } from 'async-mutex'
 
 const mutex = new Mutex()
 
-// Monotonic per-SW-instance counter for DNR rule IDs; guarded by the mutex.
-// `undefined` triggers a one-time prime from getSessionRules: on cold start
-// or after an MV3 service-worker restart, persisted session rules from a
-// prior instance still live in chrome, and starting from 0 would collide.
-// Same prime happens when we near MAX_NUMBER_OF_SESSION_RULES (~5000).
+// Monotonic DNR rule-id counter, mutex-guarded. Primed from existing rules on
+// cold start / SW restart (persisted session rules would otherwise collide),
+// and again near the cap.
 let nextRuleIdCounter: number | undefined
 const MAX_DNR_SESSION_RULES = 4500
 
@@ -27,9 +25,8 @@ export async function removeSessionRule(ruleId: number): Promise<void> {
   })
 }
 
-// Allocates a collision-free session rule id and installs the rule built from
-// it. All session DNR rules share this single counter so independent callers
-// (request-header rewrites, media CORS bypass) never hand out the same id.
+// Shared id allocator for every session DNR rule, so independent callers
+// (request-header rewrites, media CORS bypass) can't collide on ids.
 export async function addSessionRule(
   buildRule: (id: number) => chrome.declarativeNetRequest.Rule
 ): Promise<SessionRuleHandle> {

--- a/packages/danmaku-anywhere/src/background/netRequest/sessionRules.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/sessionRules.ts
@@ -1,0 +1,61 @@
+import { Mutex } from 'async-mutex'
+
+const mutex = new Mutex()
+
+// Monotonic per-SW-instance counter for DNR rule IDs; guarded by the mutex.
+// `undefined` triggers a one-time prime from getSessionRules: on cold start
+// or after an MV3 service-worker restart, persisted session rules from a
+// prior instance still live in chrome, and starting from 0 would collide.
+// Same prime happens when we near MAX_NUMBER_OF_SESSION_RULES (~5000).
+let nextRuleIdCounter: number | undefined
+const MAX_DNR_SESSION_RULES = 4500
+
+async function primeCounterFromExisting(): Promise<number> {
+  const existing = await chrome.declarativeNetRequest.getSessionRules()
+  return existing.reduce((m, r) => Math.max(m, r.id), 0)
+}
+
+export interface SessionRuleHandle {
+  ruleId: number
+  removeRule: () => Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export async function removeSessionRule(ruleId: number): Promise<void> {
+  await chrome.declarativeNetRequest.updateSessionRules({
+    removeRuleIds: [ruleId],
+  })
+}
+
+// Allocates a collision-free session rule id and installs the rule built from
+// it. All session DNR rules share this single counter so independent callers
+// (request-header rewrites, media CORS bypass) never hand out the same id.
+export async function addSessionRule(
+  buildRule: (id: number) => chrome.declarativeNetRequest.Rule
+): Promise<SessionRuleHandle> {
+  const release = await mutex.acquire()
+  let ruleId: number
+  try {
+    if (
+      nextRuleIdCounter === undefined ||
+      nextRuleIdCounter >= MAX_DNR_SESSION_RULES
+    ) {
+      nextRuleIdCounter = await primeCounterFromExisting()
+    }
+    nextRuleIdCounter += 1
+    ruleId = nextRuleIdCounter
+    await chrome.declarativeNetRequest.updateSessionRules({
+      addRules: [buildRule(ruleId)],
+    })
+  } finally {
+    release()
+  }
+
+  return {
+    ruleId,
+    removeRule: () => removeSessionRule(ruleId),
+    async [Symbol.asyncDispose]() {
+      await removeSessionRule(ruleId)
+    },
+  }
+}

--- a/packages/danmaku-anywhere/src/background/netRequest/setMediaCorsRule.test.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/setMediaCorsRule.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { addSessionRule } from './sessionRules'
+import { setMediaCorsRule } from './setMediaCorsRule'
+
+/**
+ * Covers the media CORS-bypass session rule: it injects `Access-Control-Allow-
+ * Origin: *` as a response header on the `media` resource type with no initiator
+ * restriction, removes cleanly, and draws ids from the same shared allocator so
+ * concurrent rules never collide.
+ */
+
+describe('setMediaCorsRule', () => {
+  let rules: any[] = []
+
+  beforeEach(() => {
+    rules = []
+    vi.stubGlobal('chrome', {
+      declarativeNetRequest: {
+        getSessionRules: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          return [...rules]
+        }),
+        updateSessionRules: vi.fn().mockImplementation(async (options) => {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          if (options.addRules) {
+            rules.push(...options.addRules)
+          }
+          if (options.removeRuleIds) {
+            rules = rules.filter((r) => !options.removeRuleIds.includes(r.id))
+          }
+        }),
+      },
+      runtime: {
+        getURL: vi.fn().mockReturnValue('chrome-extension://test'),
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('adds a media ACAO response-header rule with no initiator restriction', async () => {
+    const handle = await setMediaCorsRule('https://cdn.example.com/video.mp4')
+    expect(rules).toHaveLength(1)
+    const rule = rules[0]
+    expect(rule.action.type).toBe('modifyHeaders')
+    expect(rule.action.responseHeaders).toEqual([
+      { header: 'Access-Control-Allow-Origin', operation: 'set', value: '*' },
+    ])
+    expect(rule.condition.resourceTypes).toEqual(['media'])
+    expect(rule.condition.urlFilter).toBe('|https://cdn.example.com/video.mp4')
+    expect(rule.condition.initiatorDomains).toBeUndefined()
+
+    await handle.removeRule()
+    expect(rules).toHaveLength(0)
+  })
+
+  it('removes the rule when the handle goes out of scope', async () => {
+    {
+      await using _ = await setMediaCorsRule('https://cdn.example.com/a.mp4')
+      expect(rules).toHaveLength(1)
+    }
+    expect(rules).toHaveLength(0)
+  })
+
+  it('draws collision-free ids from the shared allocator under concurrency', async () => {
+    const handles = await Promise.all([
+      setMediaCorsRule('https://cdn.example.com/1.mp4'),
+      addSessionRule((id) => ({
+        id,
+        action: { type: 'modifyHeaders', requestHeaders: [] },
+        condition: { urlFilter: '|https://api.example.com/2' },
+      })),
+      setMediaCorsRule('https://cdn.example.com/3.mp4'),
+    ])
+    const ids = rules.map((r) => r.id)
+    expect(new Set(ids).size).toBe(3)
+    await Promise.all(handles.map((h) => h.removeRule()))
+    expect(rules).toHaveLength(0)
+  })
+})

--- a/packages/danmaku-anywhere/src/background/netRequest/setMediaCorsRule.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/setMediaCorsRule.ts
@@ -1,0 +1,26 @@
+import { addSessionRule, type SessionRuleHandle } from './sessionRules'
+
+// Injects `Access-Control-Allow-Origin: *` onto a single media URL's response so
+// a `crossorigin="anonymous"` video element can load it origin-clean, letting the
+// occlusion segmenter read its frames. Unlike request-header rules this is NOT
+// restricted to the extension's own initiator: the media is fetched by the host
+// page, so the rule must match that page's request.
+export function setMediaCorsRule(matchUrl: string): Promise<SessionRuleHandle> {
+  return addSessionRule((id) => ({
+    id,
+    action: {
+      type: 'modifyHeaders',
+      responseHeaders: [
+        {
+          header: 'Access-Control-Allow-Origin',
+          operation: 'set',
+          value: '*',
+        },
+      ],
+    },
+    condition: {
+      urlFilter: `|${matchUrl}`,
+      resourceTypes: ['media'],
+    },
+  }))
+}

--- a/packages/danmaku-anywhere/src/background/netRequest/setMediaCorsRule.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/setMediaCorsRule.ts
@@ -1,10 +1,7 @@
 import { addSessionRule, type SessionRuleHandle } from './sessionRules'
 
-// Injects `Access-Control-Allow-Origin: *` onto a single media URL's response so
-// a `crossorigin="anonymous"` video element can load it origin-clean, letting the
-// occlusion segmenter read its frames. Unlike request-header rules this is NOT
-// restricted to the extension's own initiator: the media is fetched by the host
-// page, so the rule must match that page's request.
+// Adds ACAO:* to a media URL's response so a crossorigin video reads origin-clean.
+// Not initiator-restricted: the host page (not the extension) fetches the media.
 export function setMediaCorsRule(matchUrl: string): Promise<SessionRuleHandle> {
   return addSessionRule((id) => ({
     id,

--- a/packages/danmaku-anywhere/src/background/netRequest/setSessionHeader.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/setSessionHeader.ts
@@ -1,78 +1,32 @@
-import { Mutex } from 'async-mutex'
 import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import { container } from '../ioc'
 import { getSelfDomain } from './getSelfDomain'
-
-const mutex = new Mutex()
-
-// Monotonic per-SW-instance counter for DNR rule IDs; guarded by the mutex.
-// `undefined` triggers a one-time prime from getSessionRules: on cold start
-// or after an MV3 service-worker restart, persisted session rules from a
-// prior instance still live in chrome, and starting from 0 would collide.
-// Same prime happens when we near MAX_NUMBER_OF_SESSION_RULES (~5000).
-let nextRuleIdCounter: number | undefined
-const MAX_DNR_SESSION_RULES = 4500
-
-async function primeCounterFromExisting(): Promise<number> {
-  const existing = await chrome.declarativeNetRequest.getSessionRules()
-  return existing.reduce((m, r) => Math.max(m, r.id), 0)
-}
+import { addSessionRule, type SessionRuleHandle } from './sessionRules'
 
 export async function setSessionHeader(
   matchUrl: string,
   headers: Record<string, string>
-) {
-  const release = await mutex.acquire()
-  let nextRuleId: number
-  try {
-    if (
-      nextRuleIdCounter === undefined ||
-      nextRuleIdCounter >= MAX_DNR_SESSION_RULES
-    ) {
-      nextRuleIdCounter = await primeCounterFromExisting()
-    }
-    nextRuleIdCounter += 1
-    nextRuleId = nextRuleIdCounter
-    const extensionOptionsService = container.get(ExtensionOptionsService)
-    const options = await extensionOptionsService.get()
+): Promise<SessionRuleHandle> {
+  const extensionOptionsService = container.get(ExtensionOptionsService)
+  const options = await extensionOptionsService.get()
 
-    await chrome.declarativeNetRequest.updateSessionRules({
-      addRules: [
-        {
-          id: nextRuleId,
-          action: {
-            type: 'modifyHeaders',
-            requestHeaders: Object.entries(headers).map(([header, value]) => ({
-              header,
-              operation: 'set',
-              value,
-            })),
-          },
-          condition: {
-            urlFilter: `|${matchUrl}`,
-            resourceTypes: ['xmlhttprequest'],
-            initiatorDomains:
-              options.restrictInitiatorDomain !== false
-                ? [getSelfDomain()]
-                : undefined,
-          },
-        },
-      ],
-    })
-  } finally {
-    release()
-  }
-
-  async function removeRule() {
-    await chrome.declarativeNetRequest.updateSessionRules({
-      removeRuleIds: [nextRuleId],
-    })
-  }
-
-  return {
-    removeRule,
-    async [Symbol.asyncDispose]() {
-      await removeRule()
+  return addSessionRule((id) => ({
+    id,
+    action: {
+      type: 'modifyHeaders',
+      requestHeaders: Object.entries(headers).map(([header, value]) => ({
+        header,
+        operation: 'set',
+        value,
+      })),
     },
-  }
+    condition: {
+      urlFilter: `|${matchUrl}`,
+      resourceTypes: ['xmlhttprequest'],
+      initiatorDomains:
+        options.restrictInitiatorDomain !== false
+          ? [getSelfDomain()]
+          : undefined,
+    },
+  }))
 }

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -5,6 +5,8 @@ import {
 import { setRequestHeaderRule } from '@danmaku-anywhere/web-scraper'
 import { inject, injectable } from 'inversify'
 import { match } from 'ts-pattern'
+import { removeSessionRule } from '@/background/netRequest/sessionRules'
+import { setMediaCorsRule } from '@/background/netRequest/setMediaCorsRule'
 import { BackupService } from '@/background/services/Backup/BackupService.service'
 import { DataManagementService } from '@/background/services/DataManagementService'
 import { GenAIService } from '@/background/services/GenAIService'
@@ -414,6 +416,13 @@ export class RpcManager {
         },
         occlusionDeleteModel: async (data) => {
           return this.occlusionModelService.delete(data.id)
+        },
+        occlusionAddCorsRule: async (data) => {
+          const { ruleId } = await setMediaCorsRule(data.url)
+          return ruleId
+        },
+        occlusionRemoveCorsRule: async (data) => {
+          await removeSessionRule(data.ruleId)
         },
       },
       {

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -203,6 +203,8 @@ export type BackgroundMethods = {
   occlusionResolveModel: RPCDef<{ id: string }, ModelEntry>
   occlusionDownloadModel: RPCDef<{ id: string }, ModelManagementState>
   occlusionDeleteModel: RPCDef<{ id: string }, ModelManagementState>
+  occlusionAddCorsRule: RPCDef<{ url: string }, number>
+  occlusionRemoveCorsRule: RPCDef<{ ruleId: number }, void>
 }
 
 type InputWithFrameId<TInput> = TInput extends void

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
@@ -107,12 +107,11 @@ export class OcclusionService {
   private lastError: string | null = null
   private lastStatusReason?: OcclusionStatusReason
   private lastAppliedTs = 0
-  // The element frames are read from: the live video when origin-clean, or a
-  // CORS-bypassed clone when the live video is cross-origin-tainted.
+  // Element to read frames from: the live video, or a clone when it's tainted.
   private captureEl: HTMLVideoElement | null = null
   private crossOriginCapture: CrossOriginCapture | null = null
   private captureResolved = false
-  // currentSrc the capture source was resolved against; a change means re-resolve.
+  // src the capture was resolved against; a change forces a re-resolve.
   private resolvedSrc: string | null = null
 
   constructor(
@@ -330,8 +329,8 @@ export class OcclusionService {
       return
     }
 
-    // start() no-ops for an unchanged element, so a same-element src swap is
-    // detected here and forces a re-resolve (the clone is bound to the old URL).
+    // start() no-ops on an unchanged element, so catch same-element src swaps
+    // here (the clone is bound to the old URL).
     if (this.captureResolved && this.resolvedSrc !== video.currentSrc) {
       this.crossOriginCapture?.dispose()
       this.crossOriginCapture = null
@@ -375,9 +374,8 @@ export class OcclusionService {
         resizeQuality: 'medium',
       })
     } catch (e) {
-      // A tainted canvas can still surface here on engines where
-      // createImageBitmap enforces origin-clean; the upfront probe normally
-      // catches it first, so this is a fallback.
+      // Fallback: some engines do throw here; the upfront probe usually catches
+      // it first.
       if (e instanceof DOMException && e.name === 'SecurityError') {
         this.disableForTaint()
         return
@@ -473,11 +471,8 @@ export class OcclusionService {
     }
   }
 
-  // Pick the element to read frames from, once per video. An origin-clean video
-  // is captured directly; a cross-origin-tainted one with an http(s) source is
-  // recovered through a CORS-bypassed clone. Anything else (blob/DRM) disables.
-  // Reached synchronously from onFrame's readyState >= 2 gate, so the probe
-  // always has a decoded frame to test (an unready video would read as clean).
+  // Resolve the capture element once per video: live if clean, else a clone for
+  // http(s) sources, else give up. Runs under onFrame's readyState >= 2 gate.
   private async resolveCaptureSource(video: HTMLVideoElement): Promise<void> {
     this.captureResolved = true
     this.resolvedSrc = video.currentSrc

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
@@ -330,10 +330,8 @@ export class OcclusionService {
       return
     }
 
-    // The player can swap src on the same element (next episode, quality
-    // change). start() no-ops for an unchanged element, so detect it here: a
-    // changed source invalidates a clone bound to the old URL and any prior
-    // origin-clean decision, forcing a re-resolve.
+    // start() no-ops for an unchanged element, so a same-element src swap is
+    // detected here and forces a re-resolve (the clone is bound to the old URL).
     if (this.captureResolved && this.resolvedSrc !== video.currentSrc) {
       this.crossOriginCapture?.dispose()
       this.crossOriginCapture = null

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import type { ModelEntry } from '@/common/models/schema'
+import { CrossOriginCapture, isVideoOriginClean } from './crossOriginCapture'
 import { buildAlphaMask } from './maskGeometry'
 import {
   type IMaskProviderFactory,
@@ -106,6 +107,11 @@ export class OcclusionService {
   private lastError: string | null = null
   private lastStatusReason?: OcclusionStatusReason
   private lastAppliedTs = 0
+  // The element frames are read from: the live video when origin-clean, or a
+  // CORS-bypassed clone when the live video is cross-origin-tainted.
+  private captureEl: HTMLVideoElement | null = null
+  private crossOriginCapture: CrossOriginCapture | null = null
+  private captureResolved = false
 
   constructor(
     @inject(MaskProviderFactory)
@@ -212,6 +218,10 @@ export class OcclusionService {
     this.appliedOnce = false
     this.fps = null
     this.lastAppliedTs = 0
+    this.crossOriginCapture?.dispose()
+    this.crossOriginCapture = null
+    this.captureEl = null
+    this.captureResolved = false
     this.applyMask(undefined)
     this.debugView?.remove()
     this.debugView = undefined
@@ -317,6 +327,15 @@ export class OcclusionService {
       return
     }
 
+    if (!this.captureResolved) {
+      await this.resolveCaptureSource(video)
+      if (!this.running || this.video !== video || !this.captureEl) {
+        return
+      }
+    }
+    const source = this.captureEl ?? video
+    this.crossOriginCapture?.sync()
+
     const t0 = performance.now()
     let resizeWidth = this.captureSize
     let resizeHeight = this.captureSize
@@ -335,23 +354,17 @@ export class OcclusionService {
     let frame: ImageBitmap
     try {
       // Resize on the GPU during decode; avoids a main-thread canvas draw.
-      frame = await createImageBitmap(video, {
+      frame = await createImageBitmap(source, {
         resizeWidth,
         resizeHeight,
         resizeQuality: 'medium',
       })
     } catch (e) {
-      // Cross-origin-without-CORS or DRM/EME video taints the canvas; reading it
-      // back is impossible, so disable for this video instead of retrying.
+      // A tainted canvas can still surface here on engines where
+      // createImageBitmap enforces origin-clean; the upfront probe normally
+      // catches it first, so this is a fallback.
       if (e instanceof DOMException && e.name === 'SecurityError') {
-        this.debugView?.showDisabled('disabled (tainted canvas)')
-        // status() must run after stop(): stop clears running/fps but the status
-        // sets lastError, which must survive.
-        this.stop()
-        this.status(
-          'taint',
-          'disabled: video canvas is tainted (cross-origin/DRM)'
-        )
+        this.disableForTaint()
         return
       }
       this.log(`capture failed: ${e instanceof Error ? e.message : e}`)
@@ -443,6 +456,39 @@ export class OcclusionService {
     if (this.debug) {
       this.renderDebug(video, mask, result.maskSize, performance.now() - t0)
     }
+  }
+
+  // Pick the element to read frames from, once per video. An origin-clean video
+  // is captured directly; a cross-origin-tainted one with an http(s) source is
+  // recovered through a CORS-bypassed clone. Anything else (blob/DRM) disables.
+  private async resolveCaptureSource(video: HTMLVideoElement): Promise<void> {
+    this.captureResolved = true
+    if (isVideoOriginClean(video)) {
+      this.captureEl = video
+      return
+    }
+    const recovery = new CrossOriginCapture(video)
+    const clone = await recovery.setup()
+    if (!this.running || this.video !== video) {
+      recovery.dispose()
+      return
+    }
+    if (clone && isVideoOriginClean(clone)) {
+      this.crossOriginCapture = recovery
+      this.captureEl = clone
+      this.log('cross-origin video recovered via CORS-bypassed clone')
+      return
+    }
+    recovery.dispose()
+    this.disableForTaint()
+  }
+
+  private disableForTaint(): void {
+    this.debugView?.showDisabled('disabled (tainted canvas)')
+    // status() must run after stop(): stop clears running/fps but the status
+    // sets lastError, which must survive.
+    this.stop()
+    this.status('taint', 'disabled: video canvas is tainted (cross-origin/DRM)')
   }
 
   private renderDebug(

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
@@ -112,6 +112,8 @@ export class OcclusionService {
   private captureEl: HTMLVideoElement | null = null
   private crossOriginCapture: CrossOriginCapture | null = null
   private captureResolved = false
+  // currentSrc the capture source was resolved against; a change means re-resolve.
+  private resolvedSrc: string | null = null
 
   constructor(
     @inject(MaskProviderFactory)
@@ -222,6 +224,7 @@ export class OcclusionService {
     this.crossOriginCapture = null
     this.captureEl = null
     this.captureResolved = false
+    this.resolvedSrc = null
     this.applyMask(undefined)
     this.debugView?.remove()
     this.debugView = undefined
@@ -327,13 +330,27 @@ export class OcclusionService {
       return
     }
 
+    // The player can swap src on the same element (next episode, quality
+    // change). start() no-ops for an unchanged element, so detect it here: a
+    // changed source invalidates a clone bound to the old URL and any prior
+    // origin-clean decision, forcing a re-resolve.
+    if (this.captureResolved && this.resolvedSrc !== video.currentSrc) {
+      this.crossOriginCapture?.dispose()
+      this.crossOriginCapture = null
+      this.captureEl = null
+      this.captureResolved = false
+    }
+
     if (!this.captureResolved) {
       await this.resolveCaptureSource(video)
-      if (!this.running || this.video !== video || !this.captureEl) {
+      if (!this.running || this.video !== video) {
         return
       }
     }
-    const source = this.captureEl ?? video
+    const source = this.captureEl
+    if (!source) {
+      return
+    }
     this.crossOriginCapture?.sync()
 
     const t0 = performance.now()
@@ -461,8 +478,11 @@ export class OcclusionService {
   // Pick the element to read frames from, once per video. An origin-clean video
   // is captured directly; a cross-origin-tainted one with an http(s) source is
   // recovered through a CORS-bypassed clone. Anything else (blob/DRM) disables.
+  // Reached synchronously from onFrame's readyState >= 2 gate, so the probe
+  // always has a decoded frame to test (an unready video would read as clean).
   private async resolveCaptureSource(video: HTMLVideoElement): Promise<void> {
     this.captureResolved = true
+    this.resolvedSrc = video.currentSrc
     if (isVideoOriginClean(video)) {
       this.captureEl = video
       return

--- a/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
@@ -1,12 +1,9 @@
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 
-// A cross-origin video loaded without CORS taints the capture canvas, so the
-// segmenter cannot read its frames. createImageBitmap does not reliably throw on
-// such a video (the taint only surfaces at the later pixel read), so probe with
-// an actual getImageData and treat SecurityError as the taint signal.
+// createImageBitmap doesn't reliably throw on a tainted video (the taint
+// surfaces only at the later pixel read), so probe with getImageData.
 export function isVideoOriginClean(video: HTMLVideoElement): boolean {
-  // drawImage is a no-op on a video with no decoded frame, which would let
-  // getImageData read a blank canvas and falsely report clean; require a frame.
+  // No decoded frame: drawImage no-ops and getImageData would read clean.
   if (video.readyState < 2) {
     return false
   }
@@ -33,12 +30,9 @@ const DRIFT_TOLERANCE_SECONDS = 0.2
 const CLONE_READY_TIMEOUT_MS = 8000
 
 /**
- * Recovers frame capture for a tainted cross-origin video. A background DNR rule
- * injects `Access-Control-Allow-Origin: *` onto the media URL; a hidden
- * `crossorigin="anonymous"` clone of the same source then loads origin-clean and
- * is captured instead of the live element, so the user's playback is untouched.
- * Only direct http(s) sources are recoverable (not blob/MSE, which is already
- * origin-clean, nor DRM, which is never readable).
+ * Reads a tainted cross-origin video via a hidden crossorigin clone (a
+ * background DNR rule supplies ACAO) instead of the live element, leaving
+ * playback untouched. http(s) only: blob/MSE aren't tainted, DRM never readable.
  */
 export class CrossOriginCapture {
   private clone: HTMLVideoElement | null = null
@@ -81,24 +75,21 @@ export class CrossOriginCapture {
       this.sync()
       return clone
     } catch {
-      // A failed RPC / rule install must not leave capture half-resolved; give
-      // up cleanly so the caller falls through to the tainted-canvas status
-      // instead of capturing the unrecovered (tainted) original forever.
+      // Any failure: give up cleanly so the caller falls back to the taint
+      // status rather than capturing the unrecovered original.
       this.dispose()
       return null
     }
   }
 
-  // Keep the clone aligned with the live element so the captured frame matches
-  // what the user sees; called once per capture cycle.
+  // Align the clone to the live element; called once per capture cycle.
   sync(): void {
     const clone = this.clone
     if (!clone) {
       return
     }
     const target = this.original.currentTime
-    // Match rate first; otherwise a non-1x original drifts continuously and
-    // triggers a corrective seek every cycle.
+    // Match rate, else a non-1x original drifts and seeks every cycle.
     if (clone.playbackRate !== this.original.playbackRate) {
       clone.playbackRate = this.original.playbackRate
     }
@@ -149,8 +140,7 @@ export class CrossOriginCapture {
         void clone.play().catch(() => undefined)
       }
       const onMeta = () => seekToLive()
-      // readyState dips while seeking, so gate on a decoded frame being present
-      // rather than the event firing, to avoid reporting ready mid-seek.
+      // readyState dips during a seek; gate on the decoded frame, not the event.
       const onReady = () => {
         if (clone.readyState >= 2) {
           finish(true)
@@ -162,8 +152,7 @@ export class CrossOriginCapture {
       clone.addEventListener('loadeddata', onReady)
       clone.addEventListener('seeked', onReady)
       clone.addEventListener('error', onError)
-      // A cached/fast clone may already be past these events, which won't fire
-      // again; drive the seek and readiness check synchronously.
+      // Already-loaded clone won't re-fire these events; kick it synchronously.
       if (clone.readyState >= 1) {
         seekToLive()
         onReady()
@@ -180,8 +169,7 @@ export class CrossOriginCapture {
     try {
       await chromeRpcClient.occlusionRemoveCorsRule({ ruleId })
     } catch {
-      // Best-effort cleanup; a stale session rule only re-adds one harmless ACAO
-      // header and is cleared when the browser session ends.
+      // Best-effort; a leaked rule only re-adds one ACAO header for the session.
     }
   }
 }

--- a/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
@@ -1,0 +1,151 @@
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
+
+// A cross-origin video loaded without CORS taints the capture canvas, so the
+// segmenter cannot read its frames. createImageBitmap does not reliably throw on
+// such a video (the taint only surfaces at the later pixel read), so probe with
+// an actual getImageData and treat SecurityError as the taint signal.
+export function isVideoOriginClean(video: HTMLVideoElement): boolean {
+  const canvas = document.createElement('canvas')
+  canvas.width = 2
+  canvas.height = 2
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return true
+  }
+  try {
+    ctx.drawImage(video, 0, 0, 2, 2)
+    ctx.getImageData(0, 0, 1, 1)
+    return true
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'SecurityError') {
+      return false
+    }
+    return true
+  }
+}
+
+const DRIFT_TOLERANCE_SECONDS = 0.2
+const CLONE_READY_TIMEOUT_MS = 8000
+
+/**
+ * Recovers frame capture for a tainted cross-origin video. A background DNR rule
+ * injects `Access-Control-Allow-Origin: *` onto the media URL; a hidden
+ * `crossorigin="anonymous"` clone of the same source then loads origin-clean and
+ * is captured instead of the live element, so the user's playback is untouched.
+ * Only direct http(s) sources are recoverable (not blob/MSE, which is already
+ * origin-clean, nor DRM, which is never readable).
+ */
+export class CrossOriginCapture {
+  private clone: HTMLVideoElement | null = null
+  private ruleId: number | null = null
+  private disposed = false
+
+  constructor(private readonly original: HTMLVideoElement) {}
+
+  async setup(): Promise<HTMLVideoElement | null> {
+    const src = this.original.currentSrc
+    if (!/^https?:/i.test(src)) {
+      return null
+    }
+
+    this.ruleId = (
+      await chromeRpcClient.occlusionAddCorsRule({ url: src })
+    ).data
+    if (this.disposed) {
+      void this.removeRule()
+      return null
+    }
+
+    const clone = document.createElement('video')
+    clone.crossOrigin = 'anonymous'
+    clone.muted = true
+    clone.playsInline = true
+    clone.preload = 'auto'
+    clone.style.cssText =
+      'position:fixed;width:1px;height:1px;top:-9999px;left:-9999px;opacity:0;pointer-events:none;'
+    clone.src = src
+    document.body.appendChild(clone)
+    this.clone = clone
+
+    const ready = await this.waitReady(clone)
+    if (!ready || this.disposed) {
+      this.dispose()
+      return null
+    }
+    this.sync()
+    return clone
+  }
+
+  // Keep the clone aligned with the live element so the captured frame matches
+  // what the user sees; called once per capture cycle.
+  sync(): void {
+    const clone = this.clone
+    if (!clone) {
+      return
+    }
+    const target = this.original.currentTime
+    if (Math.abs(clone.currentTime - target) > DRIFT_TOLERANCE_SECONDS) {
+      clone.currentTime = target
+    }
+    if (this.original.paused) {
+      if (!clone.paused) {
+        clone.pause()
+      }
+    } else if (clone.paused) {
+      void clone.play().catch(() => undefined)
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true
+    const clone = this.clone
+    if (clone) {
+      clone.pause()
+      clone.removeAttribute('src')
+      clone.load()
+      clone.remove()
+      this.clone = null
+    }
+    void this.removeRule()
+  }
+
+  private waitReady(clone: HTMLVideoElement): Promise<boolean> {
+    return new Promise((resolve) => {
+      const finish = (value: boolean) => {
+        clearTimeout(timer)
+        clone.removeEventListener('loadedmetadata', onMeta)
+        clone.removeEventListener('loadeddata', onData)
+        clone.removeEventListener('error', onError)
+        resolve(value)
+      }
+      const onMeta = () => {
+        clone.currentTime = this.original.currentTime
+        void clone.play().catch(() => undefined)
+      }
+      const onData = () => {
+        if (clone.readyState >= 2) {
+          finish(true)
+        }
+      }
+      const onError = () => finish(false)
+      const timer = setTimeout(() => finish(false), CLONE_READY_TIMEOUT_MS)
+      clone.addEventListener('loadedmetadata', onMeta)
+      clone.addEventListener('loadeddata', onData)
+      clone.addEventListener('error', onError)
+    })
+  }
+
+  private async removeRule(): Promise<void> {
+    if (this.ruleId === null) {
+      return
+    }
+    const ruleId = this.ruleId
+    this.ruleId = null
+    try {
+      await chromeRpcClient.occlusionRemoveCorsRule({ ruleId })
+    } catch {
+      // Best-effort cleanup; a stale session rule only re-adds one harmless ACAO
+      // header and is cleared when the browser session ends.
+    }
+  }
+}

--- a/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
@@ -48,32 +48,40 @@ export class CrossOriginCapture {
       return null
     }
 
-    this.ruleId = (
-      await chromeRpcClient.occlusionAddCorsRule({ url: src })
-    ).data
-    if (this.disposed) {
-      void this.removeRule()
-      return null
-    }
+    try {
+      this.ruleId = (
+        await chromeRpcClient.occlusionAddCorsRule({ url: src })
+      ).data
+      if (this.disposed) {
+        this.dispose()
+        return null
+      }
 
-    const clone = document.createElement('video')
-    clone.crossOrigin = 'anonymous'
-    clone.muted = true
-    clone.playsInline = true
-    clone.preload = 'auto'
-    clone.style.cssText =
-      'position:fixed;width:1px;height:1px;top:-9999px;left:-9999px;opacity:0;pointer-events:none;'
-    clone.src = src
-    document.body.appendChild(clone)
-    this.clone = clone
+      const clone = document.createElement('video')
+      clone.crossOrigin = 'anonymous'
+      clone.muted = true
+      clone.playsInline = true
+      clone.preload = 'auto'
+      clone.style.cssText =
+        'position:fixed;width:1px;height:1px;top:-9999px;left:-9999px;opacity:0;pointer-events:none;'
+      clone.src = src
+      document.body.appendChild(clone)
+      this.clone = clone
 
-    const ready = await this.waitReady(clone)
-    if (!ready || this.disposed) {
+      const ready = await this.waitReady(clone)
+      if (!ready || this.disposed) {
+        this.dispose()
+        return null
+      }
+      this.sync()
+      return clone
+    } catch {
+      // A failed RPC / rule install must not leave capture half-resolved; give
+      // up cleanly so the caller falls through to the tainted-canvas status
+      // instead of capturing the unrecovered (tainted) original forever.
       this.dispose()
       return null
     }
-    this.sync()
-    return clone
   }
 
   // Keep the clone aligned with the live element so the captured frame matches

--- a/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.ts
@@ -5,6 +5,11 @@ import { chromeRpcClient } from '@/common/rpcClient/background/client'
 // such a video (the taint only surfaces at the later pixel read), so probe with
 // an actual getImageData and treat SecurityError as the taint signal.
 export function isVideoOriginClean(video: HTMLVideoElement): boolean {
+  // drawImage is a no-op on a video with no decoded frame, which would let
+  // getImageData read a blank canvas and falsely report clean; require a frame.
+  if (video.readyState < 2) {
+    return false
+  }
   const canvas = document.createElement('canvas')
   canvas.width = 2
   canvas.height = 2
@@ -92,6 +97,11 @@ export class CrossOriginCapture {
       return
     }
     const target = this.original.currentTime
+    // Match rate first; otherwise a non-1x original drifts continuously and
+    // triggers a corrective seek every cycle.
+    if (clone.playbackRate !== this.original.playbackRate) {
+      clone.playbackRate = this.original.playbackRate
+    }
     if (Math.abs(clone.currentTime - target) > DRIFT_TOLERANCE_SECONDS) {
       clone.currentTime = target
     }
@@ -119,18 +129,29 @@ export class CrossOriginCapture {
 
   private waitReady(clone: HTMLVideoElement): Promise<boolean> {
     return new Promise((resolve) => {
+      let settled = false
       const finish = (value: boolean) => {
+        if (settled) {
+          return
+        }
+        settled = true
         clearTimeout(timer)
         clone.removeEventListener('loadedmetadata', onMeta)
-        clone.removeEventListener('loadeddata', onData)
+        clone.removeEventListener('loadeddata', onReady)
+        clone.removeEventListener('seeked', onReady)
         clone.removeEventListener('error', onError)
         resolve(value)
       }
-      const onMeta = () => {
-        clone.currentTime = this.original.currentTime
+      const seekToLive = () => {
+        if (clone.currentTime !== this.original.currentTime) {
+          clone.currentTime = this.original.currentTime
+        }
         void clone.play().catch(() => undefined)
       }
-      const onData = () => {
+      const onMeta = () => seekToLive()
+      // readyState dips while seeking, so gate on a decoded frame being present
+      // rather than the event firing, to avoid reporting ready mid-seek.
+      const onReady = () => {
         if (clone.readyState >= 2) {
           finish(true)
         }
@@ -138,8 +159,15 @@ export class CrossOriginCapture {
       const onError = () => finish(false)
       const timer = setTimeout(() => finish(false), CLONE_READY_TIMEOUT_MS)
       clone.addEventListener('loadedmetadata', onMeta)
-      clone.addEventListener('loadeddata', onData)
+      clone.addEventListener('loadeddata', onReady)
+      clone.addEventListener('seeked', onReady)
       clone.addEventListener('error', onError)
+      // A cached/fast clone may already be past these events, which won't fire
+      // again; drive the seek and readiness check synchronously.
+      if (clone.readyState >= 1) {
+        seekToLive()
+        onReady()
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- Occlusion now recovers frame capture on cross-origin videos that taint the capture canvas: a background DNR rule injects `Access-Control-Allow-Origin: *` on the specific media URL, and a hidden `crossorigin="anonymous"` clone of the same source is captured instead of the live element, so the user's playback is untouched. Behind the existing off-by-default occlusion flag.
- Reuses the existing ACAO pattern (`bgm.json`) via a shared session-rule allocator extracted from `setSessionHeader`.
- Re-resolves the capture source when the player swaps `src` on the same element (the clone is bound to the old URL); hardens clone setup so a failed RPC never leaves capture stuck on the tainted original.
- Scope: direct progressive cross-origin `<video src>` only. DRM/EME (never readable) and MSE/blob (already origin-clean) are out of scope.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e e2e/specs/integration/occlusion-cross-origin.spec.ts` — real cross-origin recovery + cross-origin src switch (page on `localhost:8889`, video on `127.0.0.1:8889`; asserts the original is genuinely tainted yet the mask still applies, which only holds if DNR + the clone un-tainted it).
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e e2e/specs/integration/occlusion.spec.ts` — existing occlusion happy path unaffected.
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test src/background/netRequest` — `setMediaCorsRule` + shared allocator (rule shape, no id collisions).

## Notes
- New e2e capability: a Playwright `webServer` serves the harness from a real `localhost` origin so genuine cross-origin network + DNR can be exercised. Route-fulfilled `.invalid` origins can't, since DNR only sees real responses. Reusable for future real-network tests.
- `createImageBitmap(video)` does not reliably throw on a tainted video in current Chromium (the taint surfaces only at the later pixel read), so taint is detected via an explicit `getImageData` probe rather than relying on the capture call throwing.
- The media-CORS DNR rule is intentionally not initiator-restricted (the media is fetched by the host page) and is scoped to the single tainted URL, torn down on stop / src change.
- Known cost: the clone double-downloads the watched portion of the video; acceptable for the narrow progressive-cross-origin case behind an off-by-default flag.