### PR TITLE
(chore) share context7 MCP + cloudflare plugin in project config [DA-585]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "cloudflare@claude-plugins-official": true
+  },
+  "enabledMcpjsonServers": ["chrome-devtools-ext", "context7"]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,6 +9,10 @@
         "--categoryExtensions=true",
         "--executablePath=${CHROME_DEVTOOLS_EXECUTABLE:-}"
       ]
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add the `context7` remote MCP server to the shared `.mcp.json`. `CLAUDE.md` and `da-dev.md` already instruct agents to use context7 for docs lookups, but it was never in the shared config (only `chrome-devtools-ext` was).
- Commit `.claude/settings.json` enabling the `cloudflare@claude-plugins-official` plugin (the backend is Cloudflare Workers/Hono), and pre-approving `chrome-devtools-ext` + `context7` via `enabledMcpjsonServers` so contributors aren't prompted to approve them.

## Why these (usage-driven)
- **context7** and **chrome-devtools-ext** are used by every contributor following the documented workflow (docs lookups; `browser-verify` for extension work), so they're pre-approved for all.
- **cloudflare plugin** matches `backend/proxy/` (CF Workers). `claude-plugins-official` is a built-in marketplace, so no marketplace declaration is needed.
- **ClickUp MCP** is intentionally left out: the `da-dev` workflow treats it as opt-in and it uses interactive OAuth, so it stays in each developer's personal config.

## Notes
- `enabledPlugins` keeps the plugin enabled but does not auto-install it. Teammates run `/plugin install cloudflare@claude-plugins-official` once; it then stays enabled from this committed setting.
- Config is portable: the context7 URL is public, the plugin is from the official marketplace, and `chrome-devtools-ext` still resolves its binary via the `CHROME_DEVTOOLS_EXECUTABLE` env var. No secrets or machine-specific paths are committed.
- Personal MCP enablement remains in the gitignored `.claude/settings.local.json`.

## Test plan
- [ ] Config-only (two JSON files); both parse and neither is gitignored. No build/test impact.
- [ ] After merge + pull, a contributor who trusts the workspace gets `chrome-devtools-ext` and `context7` without an approval prompt.