### PR TITLE
(extension) fix search loading skeleton gap and retry state [DA-586]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
@@ -65,4 +65,16 @@ export class SearchPage {
     await expect(card).toBeVisible({ timeout })
     await card.locator(SELECTORS.seasonCardAction).click()
   }
+
+  get resultCountSkeleton(): Locator {
+    return this.page.locator('[data-testid="search-result-count-skeleton"]')
+  }
+
+  get resultRowSkeleton(): Locator {
+    return this.page.locator('[data-testid="season-result-skeleton"]').first()
+  }
+
+  get retryButton(): Locator {
+    return this.page.locator('[data-testid="search-retry"]')
+  }
 }

--- a/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SearchPage.ts
@@ -77,4 +77,11 @@ export class SearchPage {
   get retryButton(): Locator {
     return this.page.locator('[data-testid="search-retry"]')
   }
+
+  // Anchored so a count like 2 doesn't match 12/22; matches both locales.
+  resultCount(count: number): Locator {
+    return this.page.getByText(
+      new RegExp(`^(${count} results|${count} 个结果)$`)
+    )
+  }
 }

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-loading-skeleton.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-loading-skeleton.spec.ts
@@ -1,0 +1,104 @@
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { loadJsonFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Search loading state. While a search is in flight the result-count line
+ * renders a skeleton rather than a blank gap above the row skeletons, and
+ * resolves to the "{n} results" count. When a search errors, clicking Retry
+ * flips back to the loading skeleton instead of staying on the error UI.
+ */
+
+function deferredGate(): { wait: Promise<void>; release: () => void } {
+  let release!: () => void
+  const wait = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return { wait, release }
+}
+
+test('loading shows a result-count skeleton, then the result count', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const gate = deferredGate()
+
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { dandanplay: { enabled: true } },
+    network: [
+      {
+        pattern: /\/ddp\/api\/v2\/search\/anime/,
+        respond: async (route) => {
+          await gate.wait
+          await route.fulfill({ json: loadJsonFixture('ddp-search.json') })
+        },
+      },
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+
+  await expect(popup.search.resultCountSkeleton).toBeVisible()
+  await expect(popup.search.resultRowSkeleton).toBeVisible()
+
+  gate.release()
+
+  await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
+  await expect(popup.search.resultCountSkeleton).toBeHidden()
+  await expect(page.getByText(/2 results|2 个结果/)).toBeVisible()
+})
+
+// The retry path deliberately drives a failed search; the RPC layer logs the
+// HTTP 500 from both the worker and the popup.
+test.describe(() => {
+  test.use({
+    expectedConsoleErrors: [/\[RpcManager\] Error in RPC handler.*HTTP 500/],
+  })
+
+  test('retry on a failed search returns to the loading skeleton', async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    let calls = 0
+    const retryGate = deferredGate()
+
+    const da = await getDaClient(context)
+    await applyProfile(context, da, {
+      providers: { dandanplay: { enabled: true } },
+      network: [
+        {
+          pattern: /\/ddp\/api\/v2\/search\/anime/,
+          respond: async (route) => {
+            calls += 1
+            if (calls === 1) {
+              await route.fulfill({ status: 500, body: 'search failed' })
+              return
+            }
+            await retryGate.wait
+            await route.fulfill({ json: loadJsonFixture('ddp-search.json') })
+          },
+        },
+      ],
+    })
+
+    const popup = await Popup.open(page, extensionId)
+    await popup.search.submit('frieren')
+
+    await expect(popup.search.retryButton).toBeVisible()
+
+    await popup.search.retryButton.click()
+
+    await expect(popup.search.resultRowSkeleton).toBeVisible()
+    await expect(popup.search.retryButton).toBeHidden()
+
+    retryGate.release()
+
+    await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
+  })
+})

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-loading-skeleton.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-loading-skeleton.spec.ts
@@ -50,7 +50,7 @@ test('loading shows a result-count skeleton, then the result count', async ({
 
   await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
   await expect(popup.search.resultCountSkeleton).toBeHidden()
-  await expect(page.getByText(/2 results|2 个结果/)).toBeVisible()
+  await expect(popup.search.resultCount(2)).toBeVisible()
 })
 
 // The retry path deliberately drives a failed search; the RPC layer logs the

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -6,7 +6,7 @@ import type {
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Download, Search } from '@mui/icons-material'
-import { Box, Button, Stack, Typography } from '@mui/material'
+import { Box, Button, Skeleton, Stack, Typography } from '@mui/material'
 import { useQueries } from '@tanstack/react-query'
 import { type ReactNode, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -161,6 +161,24 @@ export function SearchForm({
       ? activeQuery.data.data.length
       : undefined
 
+  const renderResultCount = (): ReactNode => {
+    if (activeQuery?.isFetching) {
+      return (
+        <Skeleton
+          variant="text"
+          width={56}
+          data-testid="search-result-count-skeleton"
+        />
+      )
+    }
+    if (typeof activeCount === 'number') {
+      return t('searchPage.resultsCount', '{{count}} results', {
+        count: activeCount,
+      })
+    }
+    return ' '
+  }
+
   const renderBody = (): ReactNode => {
     if (isUrl) {
       return (
@@ -196,7 +214,7 @@ export function SearchForm({
     if (committedSearchTerm && activeProvider && activeQuery) {
       return (
         <SeasonResultsList
-          isLoading={activeQuery.isPending}
+          isLoading={activeQuery.isFetching}
           data={activeQuery.data?.success ? activeQuery.data.data : null}
           error={
             activeQuery.data?.success === false
@@ -291,11 +309,7 @@ export function SearchForm({
               lineHeight: '16px',
             }}
           >
-            {typeof activeCount === 'number'
-              ? t('searchPage.resultsCount', '{{count}} results', {
-                  count: activeCount,
-                })
-              : ' '}
+            {renderResultCount()}
           </Typography>
         )}
       </Stack>

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -156,11 +156,6 @@ export function SearchForm({
     }
   }
 
-  const activeCount =
-    activeQuery?.data?.success === true
-      ? activeQuery.data.data.length
-      : undefined
-
   const renderResultCount = (): ReactNode => {
     if (activeQuery?.isFetching) {
       return (
@@ -171,9 +166,10 @@ export function SearchForm({
         />
       )
     }
-    if (activeCount !== undefined) {
+    const result = activeQuery?.data
+    if (result?.success) {
       return t('searchPage.resultsCount', '{{count}} results', {
-        count: activeCount,
+        count: result.data.length,
       })
     }
     return ' '

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -171,7 +171,7 @@ export function SearchForm({
         />
       )
     }
-    if (typeof activeCount === 'number') {
+    if (activeCount !== undefined) {
       return t('searchPage.resultsCount', '{{count}} results', {
         count: activeCount,
       })

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SeasonResultRow.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SeasonResultRow.tsx
@@ -117,6 +117,7 @@ export function SeasonResultRow({ season, onClick }: SeasonResultRowProps) {
 export function SeasonResultRowSkeleton() {
   return (
     <Box
+      data-testid="season-result-skeleton"
       sx={{
         width: '100%',
         minWidth: 0,

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SeasonResultsList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SeasonResultsList.tsx
@@ -63,7 +63,7 @@ export function SeasonResultsList({
           message={error}
           size={160}
           beforeContent={
-            <Button onClick={onRetry} variant="text">
+            <Button onClick={onRetry} variant="text" data-testid="search-retry">
               {t('searchPage.retrySearch', 'Retry')}
             </Button>
           }


### PR DESCRIPTION
## Summary
- While a search is in flight, the "x results" count line rendered a blank gap between the source chips and the result list. It now shows a Skeleton placeholder, consistent with the row skeletons below it.
- Clicking "Retry" on a failed search stayed on the error UI. The search query returns a `Result` object instead of throwing, so after an error the React Query status is `success` and `isPending` stays `false`; only `isFetching` flips true on `refetch()`. The result-list loading flag now reads `isFetching`, so retry returns to the skeleton.

## Test plan
- [ ] `pnpm exec playwright test e2e/specs/sources/search-loading-skeleton.spec.ts` (new spec, 2 cases: loading shows the result-count skeleton then the count; retry on a failed search returns to the skeleton)
- [ ] Full suite: `pnpm test:e2e`

## Notes
- The retry test deliberately drives an HTTP 500; the RPC layer logs it, so that one test scopes a justified `expectedConsoleErrors` opt-out to itself.