### PR TITLE
(chore) portable Warp tab session handoff in da-dev [DA-589]

### DIFF
--- a/.claude/commands/da-cleanup.md
+++ b/.claude/commands/da-cleanup.md
@@ -19,13 +19,16 @@ git worktree list
 
 3. **Check each task's status** in ClickUp via `clickup_get_task`. If the task status is "complete" or "closed", the worktree is eligible for cleanup.
 
-4. **For each completed task**, remove the worktree, the local branch, and the task notes file:
+4. **For each completed task**, remove the worktree, the local branch, the task notes file, and the Warp tab config from step 2 (if present):
 
 ```bash
 git worktree remove <worktree-path>
 git branch -d DA-XXX_<hint>
 rm -f ~/.claude/da-tasks/DA-XXX.md
+rm -f ~/.local/share/warp-terminal/tab_configs/DA-XXX.toml
 ```
+
+The tab config path is platform-specific (macOS `~/.warp/tab_configs/`, Windows `%APPDATA%\warp\Warp\data\tab_configs\`); skip it if you don't use Warp.
 
 Remote branches are auto-deleted by GitHub's "delete branch after merge" setting.
 

--- a/.claude/commands/da-dev.md
+++ b/.claude/commands/da-dev.md
@@ -25,13 +25,50 @@ Pick a `hint` — 2-4 kebab-case words describing the task (e.g. `dev-workflow`,
 node scripts/da-bootstrap.mjs --task DA-XXX --hint <hint> --type <extension|app|proxy|chore|docs>
 ```
 
-That handles `git fetch`, `git worktree add`, env copy, `pnpm install`, `pnpm build:packages`, and writes task notes to `~/.claude/da-tasks/DA-XXX.md` (outside the repo, survives `/da-cleanup`). On success it prints a trailing `READY` block with `worktree=...`, `branch=...`, `task_file=...`, `title=...`. Parse those and launch a new Claude session in the worktree:
+That handles `git fetch`, `git worktree add`, env copy, `pnpm install`, `pnpm build:packages`, and writes task notes to `~/.claude/da-tasks/DA-XXX.md` (outside the repo, survives `/da-cleanup`). On success it prints a trailing `READY` block with `worktree=...`, `branch=...`, `task_file=...`, `title=...`. Parse those and open a new terminal tab in the worktree running:
 
 ```bash
-wt new-tab --title '<title>' -d '<worktree>' -- powershell -NoExit -Command "claude --permission-mode acceptEdits --add-dir . -- 'Read <task_file> and follow the instructions'"
+claude --permission-mode acceptEdits --add-dir . -- "Read <task_file> and follow the instructions"
 ```
 
-(On non-Windows hosts, open a terminal in `<worktree>` and run the `claude ...` portion directly.) The new session reads `<task_file>` and starts from step 3. **Stop the current session here.**
+How you open that tab depends on your terminal:
+
+- **Warp (any OS):** write a tab config, then open it by deeplink. Tab configs live in `~/.local/share/warp-terminal/tab_configs/` (Linux), `~/.warp/tab_configs/` (macOS), or `%APPDATA%\warp\Warp\data\tab_configs\` (Windows). Write `DA-XXX.toml` with two side-by-side panes both in the worktree, claude on the left and a free terminal on the right:
+
+  ```toml
+  name = "<title>"
+  title = "<title>"
+
+  [[panes]]
+  id = "root"
+  split = "horizontal"
+  children = ["left", "right"]
+
+  [[panes]]
+  id = "left"
+  type = "terminal"
+  directory = "<worktree>"
+  commands = ['claude --permission-mode acceptEdits --add-dir . -- "Read <task_file> and follow the instructions"']
+  is_focused = true
+
+  [[panes]]
+  id = "right"
+  type = "terminal"
+  directory = "<worktree>"
+  ```
+
+  Then fire `warp://tab_config/DA-XXX`. On macOS use `open '<uri>'`; on Windows use `start <uri>`. On Linux the Warp launcher drops the deeplink, so hand it to the app over D-Bus:
+
+  ```bash
+  gdbus call --session --dest dev.warp.Warp --object-path /dev/warp/Warp \
+    --method org.freedesktop.Application.Open "['warp://tab_config/DA-XXX']" "{}"
+  ```
+
+- **Windows Terminal (no Warp):** `wt new-tab --title '<title>' -d '<worktree>' -- powershell -NoExit -Command "claude --permission-mode acceptEdits --add-dir . -- 'Read <task_file> and follow the instructions'"`
+
+- **Other terminals:** open a tab in `<worktree>` and run the `claude ...` line yourself.
+
+The new session reads `<task_file>` and starts from step 3. **Stop the current session here.**
 
 For trivial changes (CLAUDE.md / docs / config-only): branch directly without a worktree:
 


### PR DESCRIPTION
## Summary
- Replace the Windows-only `wt new-tab` session-handoff step in `da-dev.md` with terminal-agnostic guidance, so the new Claude session opens in the worktree regardless of host terminal.
- **Warp (any OS):** write a tab config `.toml` and fire `warp://tab_config/<name>`. The config opens a named tab with two side-by-side panes both in the worktree (claude on the left, a free terminal on the right). Verified empirically on the Warp Oz build: `tab_config` opens a tab in the active window and runs each pane's `commands`, whereas `warp://launch/` returns success but does not execute. On Linux the launcher drops the deeplink, so the URI is handed to the app over D-Bus (`org.freedesktop.Application.Open`); macOS uses `open`, Windows `start`.
- **Windows Terminal (non-Warp)** keeps the existing `wt new-tab` fallback; any other terminal falls back to opening a tab manually.
- `/da-cleanup` now removes the matching `tab_configs/DA-XXX.toml` alongside the worktree, branch, and task notes.

## Test plan
- [ ] Read `da-dev.md` step 2 and `da-cleanup.md` step 4; confirm the Warp tab config (2-pane split, named tab), the Windows Terminal fallback, and the manual fallback are present and portable.
- e2e coverage is not applicable: this changes committed agent workflow docs (`.claude/commands/*.md`), not extension/app/proxy runtime code. The Warp mechanism was verified by hand (tab opens in the active window, named, two side-by-side panes, command runs in the left pane).