### PR TITLE
(extension) seed manifests from the backend catalog [DA-590]

### DIFF
--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -29,6 +29,7 @@ const INDEX = {
   manifests: CATALOG_IDS.map((id) => ({
     id,
     apiVersion: 1,
+    version: '0.3.0',
     file: manifestFile(id),
   })),
 }

--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -21,22 +21,17 @@ function loadManifest(id: string): unknown {
   return JSON.parse(readFileSync(resolved, 'utf-8'))
 }
 
-function buildIndex() {
-  return {
-    packageVersion: '0.3.0',
-    manifests: CATALOG_IDS.map((id) => ({
-      id,
-      name: id,
-      version: '0.3.0',
-      apiVersion: 1,
-      file: manifestFile(id),
-    })),
-  }
-}
-
 const FILES: Record<string, unknown> = Object.fromEntries(
   CATALOG_IDS.map((id) => [manifestFile(id), loadManifest(id)])
 )
+
+const INDEX = {
+  manifests: CATALOG_IDS.map((id) => ({
+    id,
+    apiVersion: 1,
+    file: manifestFile(id),
+  })),
+}
 
 export function mockCatalog(): NetworkMock {
   return {
@@ -45,18 +40,10 @@ export function mockCatalog(): NetworkMock {
       const url = new URL(route.request().url())
       if (url.pathname.endsWith('/manifest/file')) {
         const file = url.searchParams.get('file') ?? ''
-        const manifest = FILES[file]
-        if (!manifest) {
-          await route.fulfill({
-            status: 404,
-            body: `unknown manifest file: ${file}`,
-          })
-          return
-        }
-        await route.fulfill({ json: manifest })
+        await route.fulfill({ json: FILES[file] })
         return
       }
-      await route.fulfill({ json: buildIndex() })
+      await route.fulfill({ json: INDEX })
     },
   }
 }

--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import type { Route } from '@playwright/test'
+import type { NetworkMock } from '../setup/profile'
+
+const nodeRequire = createRequire(import.meta.url)
+
+// The registry seeds runners from the backend catalog on first boot, so every
+// spec needs the built-in three available. Serve the real dango manifests so
+// the seeded runners match production behavior.
+const CATALOG_IDS = ['dandanplay', 'bilibili', 'tencent'] as const
+
+function manifestFile(id: string): string {
+  return `src/manifests/${id}.json`
+}
+
+function loadManifest(id: string): unknown {
+  const resolved = nodeRequire.resolve(
+    `@mr-quin/dango-manifests/manifests/${id}.json`
+  )
+  return JSON.parse(readFileSync(resolved, 'utf-8'))
+}
+
+function buildIndex() {
+  return {
+    packageVersion: '0.3.0',
+    manifests: CATALOG_IDS.map((id) => ({
+      id,
+      name: id,
+      version: '0.3.0',
+      apiVersion: 1,
+      file: manifestFile(id),
+    })),
+  }
+}
+
+const FILES: Record<string, unknown> = Object.fromEntries(
+  CATALOG_IDS.map((id) => [manifestFile(id), loadManifest(id)])
+)
+
+export function mockCatalog(): NetworkMock {
+  return {
+    pattern: /\/manifest(\/file)?(\?|$)/,
+    respond: async (route: Route) => {
+      const url = new URL(route.request().url())
+      if (url.pathname.endsWith('/manifest/file')) {
+        const file = url.searchParams.get('file') ?? ''
+        const manifest = FILES[file]
+        if (!manifest) {
+          await route.fulfill({
+            status: 404,
+            body: `unknown manifest file: ${file}`,
+          })
+          return
+        }
+        await route.fulfill({ json: manifest })
+        return
+      }
+      await route.fulfill({ json: buildIndex() })
+    },
+  }
+}

--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -14,22 +14,25 @@ function manifestFile(id: string): string {
   return `src/manifests/${id}.json`
 }
 
-function loadManifest(id: string): unknown {
+function loadManifest(id: string): { apiVersion: number; version: string } {
   const resolved = nodeRequire.resolve(
     `@mr-quin/dango-manifests/manifests/${id}.json`
   )
   return JSON.parse(readFileSync(resolved, 'utf-8'))
 }
 
+const MANIFESTS = CATALOG_IDS.map((id) => ({ id, manifest: loadManifest(id) }))
+
 const FILES: Record<string, unknown> = Object.fromEntries(
-  CATALOG_IDS.map((id) => [manifestFile(id), loadManifest(id)])
+  MANIFESTS.map(({ id, manifest }) => [manifestFile(id), manifest])
 )
 
+// Derive the index from the served files so apiVersion/version can't drift.
 const INDEX = {
-  manifests: CATALOG_IDS.map((id) => ({
+  manifests: MANIFESTS.map(({ id, manifest }) => ({
     id,
-    apiVersion: 1,
-    version: '0.3.0',
+    apiVersion: manifest.apiVersion,
+    version: manifest.version,
     file: manifestFile(id),
   })),
 }

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -1,6 +1,7 @@
 import { type BrowserContext, test as base, chromium } from '@playwright/test'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { mockCatalog } from '../network/catalog'
 import { attachConsoleWatcher, type ConsoleWatcher } from './console-watcher'
 import {
   type AllowedNetworkPattern,
@@ -51,6 +52,10 @@ export const test = base.extend<{
       context,
       () => allowedNetworkOrigins
     )
+    // Registered after the watcher so it wins (newest handler first), and
+    // before the SW boots so the registry's catalog seed is mocked.
+    const catalog = mockCatalog()
+    await context.route(catalog.pattern, catalog.respond)
     watchersByContext.set(context, {
       console: consoleWatcher,
       network: networkWatcher,

--- a/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
@@ -12,6 +12,7 @@ import packageJson from '../../../package.json' with { type: 'json' }
 import { DANMAKU_DB_NAME } from '../../../src/common/db/db'
 import migrationConfig from '../../migration.config.json' with { type: 'json' }
 import { MigrationLegacyPopup } from '../../poms/legacy/v1.5.0/MigrationLegacyPopup'
+import { mockCatalog } from '../../network/catalog'
 import { attachConsoleWatcher } from '../../setup/console-watcher'
 import { MIGRATION_EXTENSION_ID } from '../../setup/extensionKey'
 import {
@@ -83,6 +84,10 @@ async function runSwap(tmpRoot: string): Promise<BrowserContext> {
   const context = await launchExtension(userDataDir, priorExt)
   const consoleWatcher = attachConsoleWatcher(context)
   await stubReleaseNotes(context)
+  // The prior build predates the manifest store, so the swapped-in current
+  // build boots with an empty store and seeds from the catalog.
+  const catalog = mockCatalog()
+  await context.route(catalog.pattern, catalog.respond)
 
   const popup = await MigrationLegacyPopup.open(context, MIGRATION_EXTENSION_ID)
   await popup.restoreBackup(backupPath)

--- a/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
@@ -11,8 +11,8 @@ import { expect, test } from '@playwright/test'
 import packageJson from '../../../package.json' with { type: 'json' }
 import { DANMAKU_DB_NAME } from '../../../src/common/db/db'
 import migrationConfig from '../../migration.config.json' with { type: 'json' }
-import { MigrationLegacyPopup } from '../../poms/legacy/v1.5.0/MigrationLegacyPopup'
 import { mockCatalog } from '../../network/catalog'
+import { MigrationLegacyPopup } from '../../poms/legacy/v1.5.0/MigrationLegacyPopup'
 import { attachConsoleWatcher } from '../../setup/console-watcher'
 import { MIGRATION_EXTENSION_ID } from '../../setup/extensionKey'
 import {

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -61,7 +61,6 @@
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@mr-quin/dango": "^0.3.0",
-    "@mr-quin/dango-manifests": "^0.3.0",
     "@mui/icons-material": "^9.0.1",
     "@mui/lab": "9.0.0-beta.3",
     "@mui/material": "^9.0.1",
@@ -101,6 +100,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "2.2.1",
+    "@mr-quin/dango-manifests": "^0.3.0",
     "@playwright/test": "^1.59.1",
     "@types/chrome": "^0.0.326",
     "@types/d3": "^7.4.3",

--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -34,7 +34,7 @@ container.get(NetRequestManager).setup()
 container.get(AlarmManager).setup()
 container.get(PortsManager).setup()
 
-void container.get(ManifestRegistry).ready
+container.get(ManifestRegistry).setup()
 
 setLogService(container.get(LogService))
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -231,6 +231,21 @@ describe('ManifestRegistry', () => {
     expect(registry.list()).toEqual([])
   })
 
+  it('seedIfEmpty retries on a later call after a failed seed', async () => {
+    stubFetch(() => ({ status: 503, body: 'down' }))
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.seedIfEmpty()
+    expect(registry.list()).toEqual([])
+
+    stubCatalogFetch(
+      [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],
+      { 'src/manifests/one.json': makeManifest('one') }
+    )
+    await registry.seedIfEmpty()
+    expect(registry.list()).toEqual(['one'])
+  })
+
   it('seedIfEmpty is single-flighted across concurrent calls', async () => {
     const fetchMock = stubCatalogFetch(
       [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -8,12 +8,12 @@ import type {
 } from './ManifestStore'
 
 /**
- * ManifestRegistry is storage-backed: on init it seeds the backend `/manifest`
- * catalog into an empty store and builds a runner per stored manifest.
- * Verifies catalog seeding only on empty stores, apiVersion gating, a fetch
- * failure leaving the store empty without throwing, getRunner resolution,
- * register / unregister mutating both store and runner map, that an invalid
- * stored manifest is skipped rather than fatal, and idempotent init.
+ * ManifestRegistry is storage-backed: init only hydrates runners from the
+ * store (no network), while seedIfEmpty fetches the backend `/manifest`
+ * catalog into an empty store. Verifies hydrate-without-fetch, seedIfEmpty's
+ * catalog seeding / apiVersion gating / fetch-failure-leaves-empty / no-op on
+ * a populated store, getRunner resolution, register / unregister mutating both
+ * store and runner map, and an invalid stored manifest being skipped.
  */
 
 const silentLogger = {
@@ -40,28 +40,44 @@ interface CatalogEntry {
   file: string
 }
 
-function jsonResponse(body: unknown) {
+function makeResponse(status: number, body: unknown) {
   return {
-    status: 200,
+    status,
     headers: { forEach: () => {} },
-    text: async () => JSON.stringify(body),
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   }
+}
+
+function stubFetch(
+  respond: (url: string) => { status: number; body: unknown }
+) {
+  const fetchMock = vi.fn(async (input: unknown) => {
+    const { status, body } = respond(String(input))
+    return makeResponse(status, body)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function fileParam(url: string): string {
+  return new URL(url, 'http://x').searchParams.get('file') ?? ''
 }
 
 function stubCatalogFetch(
   entries: CatalogEntry[],
-  files: Record<string, unknown>
+  files: Record<string, unknown>,
+  fileStatus: Record<string, number> = {}
 ) {
-  const fetchMock = vi.fn(async (input: unknown) => {
-    const url = String(input)
+  return stubFetch((url) => {
     if (url.includes('/manifest/file')) {
-      const file = new URL(url, 'http://x').searchParams.get('file') ?? ''
-      return jsonResponse(files[file])
+      const file = fileParam(url)
+      return { status: fileStatus[file] ?? 200, body: files[file] }
     }
-    return jsonResponse({ packageVersion: '0.0.0', manifests: entries })
+    return {
+      status: 200,
+      body: { packageVersion: '0.0.0', manifests: entries },
+    }
   })
-  vi.stubGlobal('fetch', fetchMock)
-  return fetchMock
 }
 
 afterEach(() => {
@@ -98,7 +114,20 @@ class InMemoryStore implements IManifestStore {
 }
 
 describe('ManifestRegistry', () => {
-  it('seeds the backend catalog into an empty store as preinstalled', async () => {
+  it('hydrates runners from a populated store without fetching', async () => {
+    const fetchMock = stubCatalogFetch([], {})
+    const store = new InMemoryStore({
+      'test:one': { manifest: makeManifest('test:one'), kind: 'preinstalled' },
+      'test:two': { manifest: makeManifest('test:two'), kind: 'user' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(registry.list().sort()).toEqual(['test:one', 'test:two'])
+  })
+
+  it('seedIfEmpty seeds the backend catalog into an empty store as preinstalled', async () => {
     stubCatalogFetch(
       [
         { id: 'one', apiVersion: 1, file: 'src/manifests/one.json' },
@@ -111,7 +140,7 @@ describe('ManifestRegistry', () => {
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await registry.ready
+    await registry.seedIfEmpty()
 
     const record = await store.getAll()
     expect(Object.keys(record).sort()).toEqual(['one', 'two'])
@@ -121,7 +150,7 @@ describe('ManifestRegistry', () => {
     }
   })
 
-  it('skips catalog entries whose apiVersion is unsupported', async () => {
+  it('seedIfEmpty skips catalog entries whose apiVersion is unsupported', async () => {
     const fetchMock = stubCatalogFetch(
       [
         { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
@@ -131,7 +160,7 @@ describe('ManifestRegistry', () => {
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await registry.ready
+    await registry.seedIfEmpty()
 
     expect(registry.list()).toEqual(['good'])
     const fetchedFiles = fetchMock.mock.calls
@@ -140,24 +169,85 @@ describe('ManifestRegistry', () => {
     expect(fetchedFiles.some((url) => url.includes('future'))).toBe(false)
   })
 
-  it('leaves the store empty without throwing when the catalog fetch fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => ({
-        status: 503,
-        headers: { forEach: () => {} },
-        text: async () => 'unavailable',
-      }))
-    )
+  it('seedIfEmpty leaves the store empty without throwing when the index fetch fails', async () => {
+    stubFetch(() => ({ status: 503, body: 'unavailable' }))
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.ready).resolves.toBeUndefined()
+    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
 
     expect(await store.getAll()).toEqual({})
     expect(registry.list()).toEqual([])
   })
 
-  it('does not reseed when the store is already populated', async () => {
+  it('seedIfEmpty leaves the store empty when the index body is malformed', async () => {
+    stubFetch((url) =>
+      url.includes('/manifest/file')
+        ? { status: 200, body: makeManifest('x') }
+        : { status: 200, body: { packageVersion: '0.0.0' } }
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
+
+    expect(await store.getAll()).toEqual({})
+    expect(registry.list()).toEqual([])
+  })
+
+  it('seedIfEmpty skips a catalog file that fails schema validation', async () => {
+    stubCatalogFetch(
+      [
+        { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
+        { id: 'bad', apiVersion: 1, file: 'src/manifests/bad.json' },
+      ],
+      {
+        'src/manifests/good.json': makeManifest('good'),
+        // Valid JSON, invalid manifest (missing name/version/hosts).
+        'src/manifests/bad.json': { apiVersion: 1, id: 'bad' },
+      }
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.seedIfEmpty()
+
+    expect(registry.list()).toEqual(['good'])
+    expect(Object.keys(await store.getAll())).toEqual(['good'])
+  })
+
+  it('seedIfEmpty aborts the whole seed when one catalog file fails to fetch', async () => {
+    stubCatalogFetch(
+      [
+        { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
+        { id: 'broken', apiVersion: 1, file: 'src/manifests/broken.json' },
+      ],
+      { 'src/manifests/good.json': makeManifest('good') },
+      { 'src/manifests/broken.json': 500 }
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
+
+    // All-or-nothing: the valid `good` is not persisted when a sibling fails.
+    expect(await store.getAll()).toEqual({})
+    expect(registry.list()).toEqual([])
+  })
+
+  it('seedIfEmpty is single-flighted across concurrent calls', async () => {
+    const fetchMock = stubCatalogFetch(
+      [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],
+      { 'src/manifests/one.json': makeManifest('one') }
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await Promise.all([registry.seedIfEmpty(), registry.seedIfEmpty()])
+
+    const indexFetches = fetchMock.mock.calls
+      .map(([url]) => String(url))
+      .filter((url) => url.endsWith('/manifest'))
+    expect(indexFetches).toHaveLength(1)
+    expect(registry.list()).toEqual(['one'])
+  })
+
+  it('seedIfEmpty does not fetch or reseed when the store is already populated', async () => {
     const fetchMock = stubCatalogFetch([], {})
     const store = new InMemoryStore({
       'test:one': { manifest: makeManifest('test:one'), kind: 'user' },
@@ -165,6 +255,7 @@ describe('ManifestRegistry', () => {
     const setMany = vi.spyOn(store, 'setMany')
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
+    await registry.seedIfEmpty()
 
     expect(fetchMock).not.toHaveBeenCalled()
     expect(setMany).not.toHaveBeenCalled()
@@ -198,6 +289,21 @@ describe('ManifestRegistry', () => {
       kind: 'user',
     })
     expect(registry.getRunner('test:two')).toBeDefined()
+  })
+
+  it('register rejects an invalid manifest and leaves state unchanged', async () => {
+    const store = new InMemoryStore({
+      'test:one': { manifest: makeManifest('test:one'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    await expect(
+      registry.register({ apiVersion: 1, id: 'bad' }, 'user')
+    ).rejects.toThrow(/invalid manifest/)
+
+    expect(await store.has('bad')).toBe(false)
+    expect(registry.list()).toEqual(['test:one'])
   })
 
   it('unregister removes the manifest from store and runners', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -246,6 +246,21 @@ describe('ManifestRegistry', () => {
     expect(registry.list()).toEqual(['one'])
   })
 
+  it('seedIfEmpty clears its cached attempt when a write throws, allowing retry', async () => {
+    stubCatalogFetch(
+      [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],
+      { 'src/manifests/one.json': makeManifest('one') }
+    )
+    const store = new InMemoryStore()
+    vi.spyOn(store, 'setMany').mockRejectedValueOnce(new Error('write boom'))
+    const registry = new ManifestRegistry(silentLogger, store)
+    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
+    expect(registry.list()).toEqual([])
+
+    await registry.seedIfEmpty()
+    expect(registry.list()).toEqual(['one'])
+  })
+
   it('seedIfEmpty is single-flighted across concurrent calls', async () => {
     const fetchMock = stubCatalogFetch(
       [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ILogger } from '@/common/Logger'
 import { ManifestRegistry } from './ManifestRegistry'
 import type {
@@ -8,11 +8,12 @@ import type {
 } from './ManifestStore'
 
 /**
- * ManifestRegistry is storage-backed: on init it seeds the bundled builtin
- * manifests into an empty store and builds a runner per stored manifest.
- * Verifies seeding only on empty stores, getRunner resolution, register /
- * unregister mutating both store and runner map, that an apiVersion
- * incompatible manifest is skipped rather than fatal, and idempotent init.
+ * ManifestRegistry is storage-backed: on init it seeds the backend `/manifest`
+ * catalog into an empty store and builds a runner per stored manifest.
+ * Verifies catalog seeding only on empty stores, apiVersion gating, a fetch
+ * failure leaving the store empty without throwing, getRunner resolution,
+ * register / unregister mutating both store and runner map, that an invalid
+ * stored manifest is skipped rather than fatal, and idempotent init.
  */
 
 const silentLogger = {
@@ -32,6 +33,40 @@ function makeManifest(id: string, apiVersion = 1): Record<string, unknown> {
     hosts: ['example.com'],
   }
 }
+
+interface CatalogEntry {
+  id: string
+  apiVersion: number
+  file: string
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    status: 200,
+    headers: { forEach: () => {} },
+    text: async () => JSON.stringify(body),
+  }
+}
+
+function stubCatalogFetch(
+  entries: CatalogEntry[],
+  files: Record<string, unknown>
+) {
+  const fetchMock = vi.fn(async (input: unknown) => {
+    const url = String(input)
+    if (url.includes('/manifest/file')) {
+      const file = new URL(url, 'http://x').searchParams.get('file') ?? ''
+      return jsonResponse(files[file])
+    }
+    return jsonResponse({ packageVersion: '0.0.0', manifests: entries })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 class InMemoryStore implements IManifestStore {
   constructor(private record: ManifestRecord = {}) {}
@@ -62,21 +97,67 @@ class InMemoryStore implements IManifestStore {
 }
 
 describe('ManifestRegistry', () => {
-  it('seeds bundled manifests into an empty store as preinstalled', async () => {
+  it('seeds the backend catalog into an empty store as preinstalled', async () => {
+    stubCatalogFetch(
+      [
+        { id: 'one', apiVersion: 1, file: 'src/manifests/one.json' },
+        { id: 'two', apiVersion: 1, file: 'src/manifests/two.json' },
+      ],
+      {
+        'src/manifests/one.json': makeManifest('one'),
+        'src/manifests/two.json': makeManifest('two'),
+      }
+    )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
 
     const record = await store.getAll()
-    const ids = Object.keys(record)
-    expect(ids.length).toBeGreaterThan(0)
-    for (const id of ids) {
+    expect(Object.keys(record).sort()).toEqual(['one', 'two'])
+    for (const id of ['one', 'two']) {
       expect(record[id].kind).toBe('preinstalled')
       expect(registry.getRunner(id)).toBeDefined()
     }
   })
 
+  it('skips catalog entries whose apiVersion is unsupported', async () => {
+    const fetchMock = stubCatalogFetch(
+      [
+        { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
+        { id: 'future', apiVersion: 999, file: 'src/manifests/future.json' },
+      ],
+      { 'src/manifests/good.json': makeManifest('good') }
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    expect(registry.list()).toEqual(['good'])
+    const fetchedFiles = fetchMock.mock.calls
+      .map(([url]) => String(url))
+      .filter((url) => url.includes('/manifest/file'))
+    expect(fetchedFiles.some((url) => url.includes('future'))).toBe(false)
+  })
+
+  it('leaves the store empty without throwing when the catalog fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        status: 503,
+        headers: { forEach: () => {} },
+        text: async () => 'unavailable',
+      }))
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await expect(registry.ready).resolves.toBeUndefined()
+
+    expect(await store.getAll()).toEqual({})
+    expect(registry.list()).toEqual([])
+  })
+
   it('does not reseed when the store is already populated', async () => {
+    const fetchMock = stubCatalogFetch([], {})
     const store = new InMemoryStore({
       'test:one': { manifest: makeManifest('test:one'), kind: 'user' },
     })
@@ -84,6 +165,7 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
 
+    expect(fetchMock).not.toHaveBeenCalled()
     expect(setMany).not.toHaveBeenCalled()
     expect(registry.list()).toEqual(['test:one'])
     expect(registry.getRunner('test:one')).toBeDefined()

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -8,12 +8,11 @@ import type {
 } from './ManifestStore'
 
 /**
- * ManifestRegistry is storage-backed: init only hydrates runners from the
- * store (no network), while seedIfEmpty fetches the backend `/manifest`
- * catalog into an empty store. Verifies hydrate-without-fetch, seedIfEmpty's
- * catalog seeding / apiVersion gating / fetch-failure-leaves-empty / no-op on
- * a populated store, getRunner resolution, register / unregister mutating both
- * store and runner map, and an invalid stored manifest being skipped.
+ * ManifestRegistry hydrates runners from storage on init (no network) and
+ * reconciles against the backend `/manifest` catalog via update(). Covers the
+ * reconcile (seed empty, add missing, replace changed preinstalled by version,
+ * skip unchanged, leave user imports), skipping a bad/failed file, index
+ * failures, and register / unregister / hydrate-skip-invalid.
  */
 
 const silentLogger = {
@@ -24,12 +23,16 @@ const silentLogger = {
   sub: () => silentLogger,
 } as unknown as ILogger
 
-function makeManifest(id: string, apiVersion = 1): Record<string, unknown> {
+function makeManifest(
+  id: string,
+  apiVersion = 1,
+  version = '1.0.0'
+): Record<string, unknown> {
   return {
     apiVersion,
     id,
     name: id,
-    version: '1.0.0',
+    version,
     hosts: ['example.com'],
   }
 }
@@ -37,7 +40,20 @@ function makeManifest(id: string, apiVersion = 1): Record<string, unknown> {
 interface CatalogEntry {
   id: string
   apiVersion: number
+  version: string
   file: string
+}
+
+function manifestPath(id: string): string {
+  return `src/manifests/${id}.json`
+}
+
+function catalogEntry(
+  id: string,
+  version = '1.0.0',
+  apiVersion = 1
+): CatalogEntry {
+  return { id, apiVersion, version, file: manifestPath(id) }
 }
 
 function makeResponse(status: number, body: unknown) {
@@ -61,6 +77,12 @@ function stubFetch(
 
 function fileParam(url: string): string {
   return new URL(url, 'http://x').searchParams.get('file') ?? ''
+}
+
+function fileFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
+  return fetchMock.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.includes('/manifest/file'))
 }
 
 function stubCatalogFetch(
@@ -101,7 +123,7 @@ class InMemoryStore implements IManifestStore {
   }
 
   async set(id: string, entry: ManifestEntry) {
-    this.record[id] = entry
+    await this.setMany({ [id]: entry })
   }
 
   async setMany(entries: ManifestRecord) {
@@ -127,20 +149,14 @@ describe('ManifestRegistry', () => {
     expect(registry.list().sort()).toEqual(['test:one', 'test:two'])
   })
 
-  it('seedIfEmpty seeds the backend catalog into an empty store as preinstalled', async () => {
-    stubCatalogFetch(
-      [
-        { id: 'one', apiVersion: 1, file: 'src/manifests/one.json' },
-        { id: 'two', apiVersion: 1, file: 'src/manifests/two.json' },
-      ],
-      {
-        'src/manifests/one.json': makeManifest('one'),
-        'src/manifests/two.json': makeManifest('two'),
-      }
-    )
+  it('update seeds an empty store as preinstalled', async () => {
+    stubCatalogFetch([catalogEntry('one'), catalogEntry('two')], {
+      [manifestPath('one')]: makeManifest('one'),
+      [manifestPath('two')]: makeManifest('two'),
+    })
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await registry.seedIfEmpty()
+    await registry.update()
 
     const record = await store.getAll()
     expect(Object.keys(record).sort()).toEqual(['one', 'two'])
@@ -150,36 +166,32 @@ describe('ManifestRegistry', () => {
     }
   })
 
-  it('seedIfEmpty skips catalog entries whose apiVersion is unsupported', async () => {
+  it('update skips entries whose apiVersion is unsupported', async () => {
     const fetchMock = stubCatalogFetch(
-      [
-        { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
-        { id: 'future', apiVersion: 999, file: 'src/manifests/future.json' },
-      ],
-      { 'src/manifests/good.json': makeManifest('good') }
+      [catalogEntry('good'), catalogEntry('future', '1.0.0', 999)],
+      { [manifestPath('good')]: makeManifest('good') }
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await registry.seedIfEmpty()
+    await registry.update()
 
     expect(registry.list()).toEqual(['good'])
-    const fetchedFiles = fetchMock.mock.calls
-      .map(([url]) => String(url))
-      .filter((url) => url.includes('/manifest/file'))
-    expect(fetchedFiles.some((url) => url.includes('future'))).toBe(false)
+    expect(fileFetches(fetchMock).some((url) => url.includes('future'))).toBe(
+      false
+    )
   })
 
-  it('seedIfEmpty leaves the store empty without throwing when the index fetch fails', async () => {
+  it('update leaves the store empty when the index fetch fails', async () => {
     stubFetch(() => ({ status: 503, body: 'unavailable' }))
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
+    await expect(registry.update()).resolves.toBeUndefined()
 
     expect(await store.getAll()).toEqual({})
     expect(registry.list()).toEqual([])
   })
 
-  it('seedIfEmpty leaves the store empty when the index body is malformed', async () => {
+  it('update leaves the store empty when the index body is malformed', async () => {
     stubFetch((url) =>
       url.includes('/manifest/file')
         ? { status: 200, body: makeManifest('x') }
@@ -187,110 +199,109 @@ describe('ManifestRegistry', () => {
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
+    await expect(registry.update()).resolves.toBeUndefined()
 
     expect(await store.getAll()).toEqual({})
     expect(registry.list()).toEqual([])
   })
 
-  it('seedIfEmpty skips a catalog file that fails schema validation', async () => {
-    stubCatalogFetch(
-      [
-        { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
-        { id: 'bad', apiVersion: 1, file: 'src/manifests/bad.json' },
-      ],
-      {
-        'src/manifests/good.json': makeManifest('good'),
-        // Valid JSON, invalid manifest (missing name/version/hosts).
-        'src/manifests/bad.json': { apiVersion: 1, id: 'bad' },
-      }
-    )
+  it('update skips a catalog file that fails schema validation', async () => {
+    stubCatalogFetch([catalogEntry('good'), catalogEntry('bad')], {
+      [manifestPath('good')]: makeManifest('good'),
+      [manifestPath('bad')]: { apiVersion: 1, id: 'bad' },
+    })
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await registry.seedIfEmpty()
+    await registry.update()
 
     expect(registry.list()).toEqual(['good'])
     expect(Object.keys(await store.getAll())).toEqual(['good'])
   })
 
-  it('seedIfEmpty aborts the whole seed when one catalog file fails to fetch', async () => {
+  it('update skips a file that fails to fetch and re-fetches it next run', async () => {
     stubCatalogFetch(
-      [
-        { id: 'good', apiVersion: 1, file: 'src/manifests/good.json' },
-        { id: 'broken', apiVersion: 1, file: 'src/manifests/broken.json' },
-      ],
-      { 'src/manifests/good.json': makeManifest('good') },
-      { 'src/manifests/broken.json': 500 }
+      [catalogEntry('good'), catalogEntry('broken')],
+      { [manifestPath('good')]: makeManifest('good') },
+      { [manifestPath('broken')]: 500 }
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
+    await registry.update()
+    expect(Object.keys(await store.getAll())).toEqual(['good'])
 
-    // All-or-nothing: the valid `good` is not persisted when a sibling fails.
-    expect(await store.getAll()).toEqual({})
-    expect(registry.list()).toEqual([])
+    stubCatalogFetch([catalogEntry('good'), catalogEntry('broken')], {
+      [manifestPath('good')]: makeManifest('good'),
+      [manifestPath('broken')]: makeManifest('broken'),
+    })
+    await registry.update()
+    expect(registry.list().sort()).toEqual(['broken', 'good'])
   })
 
-  it('seedIfEmpty retries on a later call after a failed seed', async () => {
-    stubFetch(() => ({ status: 503, body: 'down' }))
-    const store = new InMemoryStore()
-    const registry = new ManifestRegistry(silentLogger, store)
-    await registry.seedIfEmpty()
-    expect(registry.list()).toEqual([])
-
-    stubCatalogFetch(
-      [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],
-      { 'src/manifests/one.json': makeManifest('one') }
-    )
-    await registry.seedIfEmpty()
-    expect(registry.list()).toEqual(['one'])
-  })
-
-  it('seedIfEmpty clears its cached attempt when a write throws, allowing retry', async () => {
-    stubCatalogFetch(
-      [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],
-      { 'src/manifests/one.json': makeManifest('one') }
-    )
-    const store = new InMemoryStore()
-    vi.spyOn(store, 'setMany').mockRejectedValueOnce(new Error('write boom'))
-    const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.seedIfEmpty()).resolves.toBeUndefined()
-    expect(registry.list()).toEqual([])
-
-    await registry.seedIfEmpty()
-    expect(registry.list()).toEqual(['one'])
-  })
-
-  it('seedIfEmpty is single-flighted across concurrent calls', async () => {
-    const fetchMock = stubCatalogFetch(
-      [{ id: 'one', apiVersion: 1, file: 'src/manifests/one.json' }],
-      { 'src/manifests/one.json': makeManifest('one') }
-    )
-    const store = new InMemoryStore()
-    const registry = new ManifestRegistry(silentLogger, store)
-    await Promise.all([registry.seedIfEmpty(), registry.seedIfEmpty()])
-
-    const indexFetches = fetchMock.mock.calls
-      .map(([url]) => String(url))
-      .filter((url) => url.endsWith('/manifest'))
-    expect(indexFetches).toHaveLength(1)
-    expect(registry.list()).toEqual(['one'])
-  })
-
-  it('seedIfEmpty does not fetch or reseed when the store is already populated', async () => {
-    const fetchMock = stubCatalogFetch([], {})
+  it('update does not re-fetch or rewrite an unchanged manifest', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '1.0.0')], {
+      [manifestPath('one')]: makeManifest('one', 1, '1.0.0'),
+    })
     const store = new InMemoryStore({
-      'test:one': { manifest: makeManifest('test:one'), kind: 'user' },
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
     })
     const setMany = vi.spyOn(store, 'setMany')
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
-    await registry.seedIfEmpty()
+    await registry.update()
 
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fileFetches(fetchMock)).toEqual([])
     expect(setMany).not.toHaveBeenCalled()
-    expect(registry.list()).toEqual(['test:one'])
-    expect(registry.getRunner('test:one')).toBeDefined()
+  })
+
+  it('update replaces a preinstalled manifest when its catalog version changed', async () => {
+    stubCatalogFetch([catalogEntry('one', '2.0.0')], {
+      [manifestPath('one')]: makeManifest('one', 1, '2.0.0'),
+    })
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    await registry.update()
+
+    expect((await store.get('one'))?.manifest).toMatchObject({
+      version: '2.0.0',
+    })
+  })
+
+  it('update leaves a user import untouched even when the catalog lists the same id', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {
+      [manifestPath('one')]: makeManifest('one', 1, '2.0.0'),
+    })
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'user' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    await registry.update()
+
+    const stored = await store.get('one')
+    expect(stored?.kind).toBe('user')
+    expect(stored?.manifest).toMatchObject({ version: '1.0.0' })
+    expect(fileFetches(fetchMock)).toEqual([])
+  })
+
+  it('update adds newly-listed manifests to a populated store', async () => {
+    stubCatalogFetch(
+      [catalogEntry('one', '1.0.0'), catalogEntry('two', '1.0.0')],
+      {
+        [manifestPath('one')]: makeManifest('one', 1, '1.0.0'),
+        [manifestPath('two')]: makeManifest('two', 1, '1.0.0'),
+      }
+    )
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    await registry.update()
+
+    expect(registry.list().sort()).toEqual(['one', 'two'])
   })
 
   it('getRunner throws for an unknown manifest id', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -66,6 +66,7 @@ function stubCatalogFetch(
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  vi.restoreAllMocks()
 })
 
 class InMemoryStore implements IManifestStore {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -1,14 +1,11 @@
-import { type Manifest, ManifestRunner, zManifest } from '@mr-quin/dango'
-import builtinBilibili from '@mr-quin/dango-manifests/manifests/bilibili.json' with {
-  type: 'json',
-}
-import builtinDandanplay from '@mr-quin/dango-manifests/manifests/dandanplay.json' with {
-  type: 'json',
-}
-import builtinTencent from '@mr-quin/dango-manifests/manifests/tencent.json' with {
-  type: 'json',
-}
+import {
+  type Manifest,
+  ManifestRunner,
+  SUPPORTED_API_VERSIONS,
+  zManifest,
+} from '@mr-quin/dango'
 import { inject, injectable } from 'inversify'
+import { z } from 'zod'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import { invariant } from '@/common/utils/utils'
 import { extensionFetchLike } from './extensionFetchLike'
@@ -19,11 +16,15 @@ import {
   ManifestStore,
 } from './ManifestStore'
 
-const builtinManifests: unknown[] = [
-  builtinDandanplay,
-  builtinBilibili,
-  builtinTencent,
-]
+const zCatalogIndex = z.object({
+  manifests: z.array(
+    z.object({
+      id: z.string(),
+      apiVersion: z.number(),
+      file: z.string(),
+    })
+  ),
+})
 
 @injectable('Singleton')
 export class ManifestRegistry {
@@ -99,21 +100,55 @@ export class ManifestRegistry {
   }
 
   private async seed(): Promise<void> {
+    let catalog: { raw: unknown; parsed: Manifest }[]
+    try {
+      catalog = await this.fetchCatalog()
+    } catch (e) {
+      // Leave the store empty so the next init / service-worker wake retries.
+      this.log.error('Failed to seed manifests from catalog:', e)
+      return
+    }
     const seeded: Record<string, ManifestEntry> = {}
-    for (const manifest of builtinManifests) {
-      const parsed = zManifest.safeParse(manifest)
+    for (const { raw, parsed } of catalog) {
+      seeded[parsed.id] = { manifest: raw, kind: 'preinstalled' }
+      this.runners.set(parsed.id, this.buildRunner(parsed))
+    }
+    await this.store.setMany(seeded)
+  }
+
+  private async fetchCatalog(): Promise<{ raw: unknown; parsed: Manifest }[]> {
+    const baseUrl = import.meta.env.VITE_PROXY_URL
+    const index = zCatalogIndex.parse(
+      await this.fetchJson(`${baseUrl}/manifest`)
+    )
+    const result: { raw: unknown; parsed: Manifest }[] = []
+    for (const entry of index.manifests) {
+      if (!SUPPORTED_API_VERSIONS.has(entry.apiVersion)) {
+        continue
+      }
+      const raw = await this.fetchJson(
+        `${baseUrl}/manifest/file?file=${encodeURIComponent(entry.file)}`
+      )
+      const parsed = zManifest.safeParse(raw)
       if (!parsed.success) {
         this.log.error(
-          'Failed to load built-in manifest:',
-          (manifest as { id?: string }).id ?? '<unknown>',
+          'Skipping invalid catalog manifest:',
+          entry.id,
           parsed.error.issues
         )
         continue
       }
-      seeded[parsed.data.id] = { manifest, kind: 'preinstalled' }
-      this.runners.set(parsed.data.id, this.buildRunner(parsed.data))
+      result.push({ raw, parsed: parsed.data })
     }
-    await this.store.setMany(seeded)
+    return result
+  }
+
+  private async fetchJson(url: string): Promise<unknown> {
+    const res = await extensionFetchLike(url)
+    if (res.status !== 200) {
+      throw new Error(`catalog fetch failed (${res.status}): ${url}`)
+    }
+    return JSON.parse(await res.text())
   }
 
   private loadEntry(id: string, entry: ManifestEntry): void {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -16,17 +16,30 @@ import {
   ManifestStore,
 } from './ManifestStore'
 
-const zCatalogIndex = z.object({
-  manifests: z.array(
-    z.object({
-      id: z.string(),
-      apiVersion: z.number(),
-      file: z.string(),
-    })
-  ),
+const zCatalogEntry = z.object({
+  id: z.string(),
+  apiVersion: z.number(),
+  version: z.string(),
+  file: z.string(),
 })
 
+const zCatalogIndex = z.object({
+  manifests: z.array(zCatalogEntry),
+})
+
+type CatalogEntry = z.infer<typeof zCatalogEntry>
 type CatalogManifest = { raw: unknown; parsed: Manifest }
+
+function storedVersion(manifest: unknown): unknown {
+  if (
+    manifest !== null &&
+    typeof manifest === 'object' &&
+    'version' in manifest
+  ) {
+    return (manifest as { version: unknown }).version
+  }
+  return undefined
+}
 
 @injectable('Singleton')
 export class ManifestRegistry {
@@ -34,7 +47,6 @@ export class ManifestRegistry {
   private readonly log: ILogger
   private readonly store: IManifestStore
   private initialized = false
-  private seeding?: Promise<void>
   readonly ready: Promise<void>
 
   constructor(
@@ -46,9 +58,8 @@ export class ManifestRegistry {
     this.ready = this.init()
   }
 
-  // Synchronous: callers gate on `ready`, which guarantees the stored set has
-  // hydrated into the map. The install-time catalog seed runs separately, so a
-  // freshly installed profile may briefly resolve no runner until it lands.
+  // Sync: `ready` guarantees the stored set hydrated. The reconcile runs
+  // separately, so a fresh install can briefly resolve no runner yet.
   getRunner(manifestId: string): ManifestRunner {
     invariant(this.initialized, 'ManifestRegistry accessed before ready')
     const runner = this.runners.get(manifestId)
@@ -92,39 +103,54 @@ export class ManifestRegistry {
 
   setup(): void {
     chrome.runtime.onInstalled.addListener(() => {
-      void this.seedIfEmpty()
-    })
-    // Fallback in case the onInstalled seed failed (e.g. offline at install).
-    chrome.runtime.onStartup.addListener(() => {
-      void this.seedIfEmpty()
+      void this.update()
     })
   }
 
-  // Pre-install the catalog set once, on install. A populated store is left
-  // untouched; refreshing it with newer compatible manifests is a separate
-  // path. Single-flighted so onInstalled and onStartup firing together don't
-  // fetch the catalog twice.
-  seedIfEmpty(): Promise<void> {
-    this.seeding ??= this.seedIfEmptyOnce()
-    return this.seeding
-  }
-
-  private async seedIfEmptyOnce(): Promise<void> {
+  // Reconcile the stored set against the catalog: add missing, replace changed
+  // preinstalled, leave user imports alone. Seeding is just the empty-store case.
+  async update(): Promise<void> {
+    const baseUrl = import.meta.env.VITE_PROXY_URL
+    let entries: CatalogEntry[]
     try {
-      await this.ready
-      const record = await this.store.getAll()
-      if (Object.keys(record).length > 0) {
-        return
-      }
-      if (await this.seed()) {
-        return
-      }
+      entries = await this.fetchIndex(baseUrl)
     } catch (e) {
-      this.log.error('Failed to seed manifests from catalog:', e)
+      this.log.error('Failed to fetch manifest catalog:', e)
+      return
     }
-    // Reached only when nothing was seeded; drop the cached attempt so a later
-    // install / startup seed can retry.
-    this.seeding = undefined
+    const stored = await this.store.getAll()
+    const stale = entries.filter((entry) =>
+      this.shouldFetch(entry, stored[entry.id])
+    )
+    const fetched = (
+      await Promise.all(
+        stale.map((entry) => this.fetchManifest(baseUrl, entry.file, entry.id))
+      )
+    ).filter((manifest) => manifest !== null)
+    if (fetched.length === 0) {
+      return
+    }
+    const updates: Record<string, ManifestEntry> = {}
+    for (const { raw, parsed } of fetched) {
+      updates[parsed.id] = { manifest: raw, kind: 'preinstalled' }
+    }
+    await this.store.setMany(updates)
+    for (const { parsed } of fetched) {
+      this.runners.set(parsed.id, this.buildRunner(parsed))
+    }
+  }
+
+  private shouldFetch(
+    entry: CatalogEntry,
+    existing: ManifestEntry | undefined
+  ): boolean {
+    if (!existing) {
+      return true
+    }
+    if (existing.kind === 'user') {
+      return false
+    }
+    return storedVersion(existing.manifest) !== entry.version
   }
 
   private async init(): Promise<void> {
@@ -135,49 +161,31 @@ export class ManifestRegistry {
     this.initialized = true
   }
 
-  private async seed(): Promise<boolean> {
-    let catalog: CatalogManifest[]
-    try {
-      catalog = await this.fetchCatalog()
-    } catch (e) {
-      this.log.error('Failed to seed manifests from catalog:', e)
-      return false
-    }
-    const seeded: Record<string, ManifestEntry> = {}
-    for (const { raw, parsed } of catalog) {
-      seeded[parsed.id] = { manifest: raw, kind: 'preinstalled' }
-    }
-    await this.store.setMany(seeded)
-    for (const { parsed } of catalog) {
-      this.runners.set(parsed.id, this.buildRunner(parsed))
-    }
-    return true
-  }
-
-  private async fetchCatalog(): Promise<CatalogManifest[]> {
-    const baseUrl = import.meta.env.VITE_PROXY_URL
+  private async fetchIndex(baseUrl: string): Promise<CatalogEntry[]> {
     const index = zCatalogIndex.parse(
       await this.fetchJson(`${baseUrl}/manifest`)
     )
-    const supported = index.manifests.filter((entry) =>
+    return index.manifests.filter((entry) =>
       SUPPORTED_API_VERSIONS.has(entry.apiVersion)
     )
-    const fetched = await Promise.all(
-      supported.map((entry) =>
-        this.fetchManifest(baseUrl, entry.file, entry.id)
-      )
-    )
-    return fetched.filter((entry) => entry !== null)
   }
 
+  // Skip (null) on any per-manifest failure so one bad file doesn't block the
+  // rest; the next reconcile retries whatever is still missing.
   private async fetchManifest(
     baseUrl: string,
     file: string,
     id: string
   ): Promise<CatalogManifest | null> {
-    const raw = await this.fetchJson(
-      `${baseUrl}/manifest/file?file=${encodeURIComponent(file)}`
-    )
+    let raw: unknown
+    try {
+      raw = await this.fetchJson(
+        `${baseUrl}/manifest/file?file=${encodeURIComponent(file)}`
+      )
+    } catch (e) {
+      this.log.error('Failed to fetch catalog manifest:', id, e)
+      return null
+    }
     const parsed = zManifest.safeParse(raw)
     if (!parsed.success) {
       this.log.error(

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -115,7 +115,11 @@ export class ManifestRegistry {
     if (Object.keys(record).length > 0) {
       return
     }
-    await this.seed()
+    const seeded = await this.seed()
+    if (!seeded) {
+      // Drop the cached attempt so a later install / startup seed can retry.
+      this.seeding = undefined
+    }
   }
 
   private async init(): Promise<void> {
@@ -126,14 +130,13 @@ export class ManifestRegistry {
     this.initialized = true
   }
 
-  private async seed(): Promise<void> {
+  private async seed(): Promise<boolean> {
     let catalog: CatalogManifest[]
     try {
       catalog = await this.fetchCatalog()
     } catch (e) {
-      // Leave the store empty so the next onStartup / install seed retries.
       this.log.error('Failed to seed manifests from catalog:', e)
-      return
+      return false
     }
     const seeded: Record<string, ManifestEntry> = {}
     for (const { raw, parsed } of catalog) {
@@ -143,6 +146,7 @@ export class ManifestRegistry {
     for (const { parsed } of catalog) {
       this.runners.set(parsed.id, this.buildRunner(parsed))
     }
+    return true
   }
 
   private async fetchCatalog(): Promise<CatalogManifest[]> {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -26,6 +26,8 @@ const zCatalogIndex = z.object({
   ),
 })
 
+type CatalogManifest = { raw: unknown; parsed: Manifest }
+
 @injectable('Singleton')
 export class ManifestRegistry {
   private readonly runners = new Map<string, ManifestRunner>()
@@ -100,7 +102,7 @@ export class ManifestRegistry {
   }
 
   private async seed(): Promise<void> {
-    let catalog: { raw: unknown; parsed: Manifest }[]
+    let catalog: CatalogManifest[]
     try {
       catalog = await this.fetchCatalog()
     } catch (e) {
@@ -116,35 +118,46 @@ export class ManifestRegistry {
     await this.store.setMany(seeded)
   }
 
-  private async fetchCatalog(): Promise<{ raw: unknown; parsed: Manifest }[]> {
+  private async fetchCatalog(): Promise<CatalogManifest[]> {
     const baseUrl = import.meta.env.VITE_PROXY_URL
     const index = zCatalogIndex.parse(
       await this.fetchJson(`${baseUrl}/manifest`)
     )
-    const result: { raw: unknown; parsed: Manifest }[] = []
-    for (const entry of index.manifests) {
-      if (!SUPPORTED_API_VERSIONS.has(entry.apiVersion)) {
-        continue
-      }
-      const raw = await this.fetchJson(
-        `${baseUrl}/manifest/file?file=${encodeURIComponent(entry.file)}`
+    const supported = index.manifests.filter((entry) =>
+      SUPPORTED_API_VERSIONS.has(entry.apiVersion)
+    )
+    const fetched = await Promise.all(
+      supported.map((entry) =>
+        this.fetchManifest(baseUrl, entry.file, entry.id)
       )
-      const parsed = zManifest.safeParse(raw)
-      if (!parsed.success) {
-        this.log.error(
-          'Skipping invalid catalog manifest:',
-          entry.id,
-          parsed.error.issues
-        )
-        continue
-      }
-      result.push({ raw, parsed: parsed.data })
+    )
+    return fetched.filter((entry) => entry !== null)
+  }
+
+  private async fetchManifest(
+    baseUrl: string,
+    file: string,
+    id: string
+  ): Promise<CatalogManifest | null> {
+    const raw = await this.fetchJson(
+      `${baseUrl}/manifest/file?file=${encodeURIComponent(file)}`
+    )
+    const parsed = zManifest.safeParse(raw)
+    if (!parsed.success) {
+      this.log.error(
+        'Skipping invalid catalog manifest:',
+        id,
+        parsed.error.issues
+      )
+      return null
     }
-    return result
+    return { raw, parsed: parsed.data }
   }
 
   private async fetchJson(url: string): Promise<unknown> {
-    const res = await extensionFetchLike(url)
+    const res = await extensionFetchLike(url, {
+      signal: AbortSignal.timeout(5000),
+    })
     if (res.status !== 200) {
       throw new Error(`catalog fetch failed (${res.status}): ${url}`)
     }

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -108,6 +108,7 @@ export class ManifestRegistry {
   // Reconcile the stored set against the catalog: add missing, replace changed
   // preinstalled, leave user imports alone. Seeding is just the empty-store case.
   async update(): Promise<void> {
+    await this.ready
     const baseUrl = import.meta.env.VITE_PROXY_URL
     let entries: CatalogEntry[]
     try {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -34,6 +34,7 @@ export class ManifestRegistry {
   private readonly log: ILogger
   private readonly store: IManifestStore
   private initialized = false
+  private seeding?: Promise<void>
   readonly ready: Promise<void>
 
   constructor(
@@ -45,9 +46,9 @@ export class ManifestRegistry {
     this.ready = this.init()
   }
 
-  // Synchronous: callers gate on `ready` once at the boundary (see
-  // ProviderService), so by the time a runner is resolved the store has
-  // already hydrated into the in-memory map.
+  // Synchronous: callers gate on `ready`, which guarantees the stored set has
+  // hydrated into the map. The install-time catalog seed runs separately, so a
+  // freshly installed profile may briefly resolve no runner until it lands.
   getRunner(manifestId: string): ManifestRunner {
     invariant(this.initialized, 'ManifestRegistry accessed before ready')
     const runner = this.runners.get(manifestId)
@@ -89,14 +90,38 @@ export class ManifestRegistry {
     }
   }
 
+  setup(): void {
+    chrome.runtime.onInstalled.addListener(() => {
+      void this.seedIfEmpty()
+    })
+    // Fallback in case the onInstalled seed failed (e.g. offline at install).
+    chrome.runtime.onStartup.addListener(() => {
+      void this.seedIfEmpty()
+    })
+  }
+
+  // Pre-install the catalog set once, on install. A populated store is left
+  // untouched; refreshing it with newer compatible manifests is a separate
+  // path. Single-flighted so onInstalled and onStartup firing together don't
+  // fetch the catalog twice.
+  seedIfEmpty(): Promise<void> {
+    this.seeding ??= this.seedIfEmptyOnce()
+    return this.seeding
+  }
+
+  private async seedIfEmptyOnce(): Promise<void> {
+    await this.ready
+    const record = await this.store.getAll()
+    if (Object.keys(record).length > 0) {
+      return
+    }
+    await this.seed()
+  }
+
   private async init(): Promise<void> {
     const record = await this.store.getAll()
-    if (Object.keys(record).length === 0) {
-      await this.seed()
-    } else {
-      for (const [id, entry] of Object.entries(record)) {
-        this.loadEntry(id, entry)
-      }
+    for (const [id, entry] of Object.entries(record)) {
+      this.loadEntry(id, entry)
     }
     this.initialized = true
   }
@@ -106,16 +131,18 @@ export class ManifestRegistry {
     try {
       catalog = await this.fetchCatalog()
     } catch (e) {
-      // Leave the store empty so the next init / service-worker wake retries.
+      // Leave the store empty so the next onStartup / install seed retries.
       this.log.error('Failed to seed manifests from catalog:', e)
       return
     }
     const seeded: Record<string, ManifestEntry> = {}
     for (const { raw, parsed } of catalog) {
       seeded[parsed.id] = { manifest: raw, kind: 'preinstalled' }
-      this.runners.set(parsed.id, this.buildRunner(parsed))
     }
     await this.store.setMany(seeded)
+    for (const { parsed } of catalog) {
+      this.runners.set(parsed.id, this.buildRunner(parsed))
+    }
   }
 
   private async fetchCatalog(): Promise<CatalogManifest[]> {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -110,16 +110,21 @@ export class ManifestRegistry {
   }
 
   private async seedIfEmptyOnce(): Promise<void> {
-    await this.ready
-    const record = await this.store.getAll()
-    if (Object.keys(record).length > 0) {
-      return
+    try {
+      await this.ready
+      const record = await this.store.getAll()
+      if (Object.keys(record).length > 0) {
+        return
+      }
+      if (await this.seed()) {
+        return
+      }
+    } catch (e) {
+      this.log.error('Failed to seed manifests from catalog:', e)
     }
-    const seeded = await this.seed()
-    if (!seeded) {
-      // Drop the cached attempt so a later install / startup seed can retry.
-      this.seeding = undefined
-    }
+    // Reached only when nothing was seeded; drop the cached attempt so a later
+    // install / startup seed can retry.
+    this.seeding = undefined
   }
 
   private async init(): Promise<void> {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -101,7 +101,9 @@ export class ManifestRegistry {
 
   setup(): void {
     chrome.runtime.onInstalled.addListener(() => {
-      void this.update()
+      this.update().catch((e) => {
+        this.log.error('Manifest update failed:', e)
+      })
     })
   }
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -58,8 +58,6 @@ export class ManifestRegistry {
     this.ready = this.init()
   }
 
-  // Sync: `ready` guarantees the stored set hydrated. The reconcile runs
-  // separately, so a fresh install can briefly resolve no runner yet.
   getRunner(manifestId: string): ManifestRunner {
     invariant(this.initialized, 'ManifestRegistry accessed before ready')
     const runner = this.runners.get(manifestId)

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.test.ts
@@ -5,9 +5,10 @@ import { ManifestStore } from './ManifestStore'
 
 /**
  * ManifestStore persists a single `manifests` record in chrome.storage.local
- * keyed by manifest id. Verifies getAll defaults to an empty record, and that
- * get/has/set/remove read and mutate the stored record without clobbering
- * sibling entries.
+ * keyed by manifest id. Verifies getAll defaults to an empty record, that
+ * get/has/set/setMany/remove read and mutate the stored record without
+ * clobbering sibling entries, and that the write mutex serializes concurrent
+ * read-modify-write so no write is lost.
  */
 
 function backStorageWith(record: ManifestRecord | undefined) {
@@ -53,6 +54,25 @@ describe('ManifestStore', () => {
     })
   })
 
+  it('setMany merges entries and overwrites only colliding ids', async () => {
+    backStorageWith({
+      'a:1': { manifest: { id: 'a:1' }, kind: 'preinstalled' },
+      'b:2': { manifest: { id: 'b:2' }, kind: 'user' },
+    })
+    const store = new ManifestStore()
+    await store.setMany({
+      'b:2': { manifest: { id: 'b:2', v: 2 }, kind: 'preinstalled' },
+      'c:3': { manifest: { id: 'c:3' }, kind: 'user' },
+    })
+    expect(mockChrome.storage.local.set).toHaveBeenCalledWith({
+      manifests: {
+        'a:1': { manifest: { id: 'a:1' }, kind: 'preinstalled' },
+        'b:2': { manifest: { id: 'b:2', v: 2 }, kind: 'preinstalled' },
+        'c:3': { manifest: { id: 'c:3' }, kind: 'user' },
+      },
+    })
+  })
+
   it('remove drops a single entry and is a no-op when absent', async () => {
     backStorageWith({
       'a:1': { manifest: { id: 'a:1' }, kind: 'preinstalled' },
@@ -67,5 +87,28 @@ describe('ManifestStore', () => {
     mockChrome.storage.local.set.mockClear()
     await store.remove('missing')
     expect(mockChrome.storage.local.set).not.toHaveBeenCalled()
+  })
+
+  it('serializes concurrent writes so none clobber each other', async () => {
+    let backing: ManifestRecord = {
+      'c:3': { manifest: { id: 'c:3' }, kind: 'user' },
+    }
+    mockChrome.storage.local.get.mockImplementation(async () => {
+      await Promise.resolve()
+      return { manifests: { ...backing } }
+    })
+    mockChrome.storage.local.set.mockImplementation(async (items) => {
+      await Promise.resolve()
+      backing = (items as { manifests: ManifestRecord }).manifests
+    })
+    const store = new ManifestStore()
+
+    await Promise.all([
+      store.set('a:1', { manifest: { id: 'a:1' }, kind: 'user' }),
+      store.set('b:2', { manifest: { id: 'b:2' }, kind: 'user' }),
+      store.remove('c:3'),
+    ])
+
+    expect(Object.keys(backing).sort()).toEqual(['a:1', 'b:2'])
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.test.ts
@@ -90,6 +90,8 @@ describe('ManifestStore', () => {
   })
 
   it('serializes concurrent writes so none clobber each other', async () => {
+    // Without serialization the two read-modify-writes both read the same base
+    // and the later set drops the earlier add; the mutex must keep all three.
     let backing: ManifestRecord = {
       'c:3': { manifest: { id: 'c:3' }, kind: 'user' },
     }
@@ -106,9 +108,8 @@ describe('ManifestStore', () => {
     await Promise.all([
       store.set('a:1', { manifest: { id: 'a:1' }, kind: 'user' }),
       store.set('b:2', { manifest: { id: 'b:2' }, kind: 'user' }),
-      store.remove('c:3'),
     ])
 
-    expect(Object.keys(backing).sort()).toEqual(['a:1', 'b:2'])
+    expect(Object.keys(backing).sort()).toEqual(['a:1', 'b:2', 'c:3'])
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.ts
@@ -48,10 +48,7 @@ export class ManifestStore implements IManifestStore {
   }
 
   set(id: string, entry: ManifestEntry): Promise<void> {
-    return this.writeLock.runExclusive(async () => {
-      const record = await this.getAll()
-      await this.storage.set({ ...record, [id]: entry })
-    })
+    return this.setMany({ [id]: entry })
   }
 
   setMany(entries: ManifestRecord): Promise<void> {
@@ -67,10 +64,8 @@ export class ManifestStore implements IManifestStore {
       if (!(id in record)) {
         return
       }
-      const next = Object.fromEntries(
-        Object.entries(record).filter(([key]) => key !== id)
-      )
-      await this.storage.set(next)
+      delete record[id]
+      await this.storage.set(record)
     })
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,9 +308,6 @@ importers:
       '@mr-quin/dango':
         specifier: ^0.3.0
         version: 0.3.0
-      '@mr-quin/dango-manifests':
-        specifier: ^0.3.0
-        version: 0.3.0
       '@mui/icons-material':
         specifier: ^9.0.1
         version: 9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.15)(react@19.2.0)
@@ -423,6 +420,9 @@ importers:
       '@crxjs/vite-plugin':
         specifier: 2.2.1
         version: 2.2.1
+      '@mr-quin/dango-manifests':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.60.0


### PR DESCRIPTION
## Summary
- `ManifestRegistry` now sources the pre-installed set from the backend `/manifest` catalog instead of bundling three npm manifests. One `update()` reconciles the store against the catalog: fetch the index, then add manifests missing from the store, re-fetch + replace `preinstalled` ones whose `version` changed, skip unchanged, and leave `user` imports alone. Seeding an empty store is just the case where every entry is missing, so there's no empty gate.
- Each manifest is validated with `zManifest`, gated on `apiVersion` (`SUPPORTED_API_VERSIONS`), and fetched concurrently, time-boxed with `AbortSignal.timeout`. A failed/invalid file is skipped (not all-or-nothing) since the next reconcile re-fetches whatever is still missing.
- `init()` only hydrates runners from storage (no network). `update()` is triggered on `chrome.runtime.onInstalled` (install + extension update). On a normal startup nothing is fetched. A periodic alarm and a "check for update" button will reuse `update()` (follow-ups, DA-592 / DA-580).
- Dropped the bundled static imports + `builtinManifests`; `@mr-quin/dango-manifests` moved to `devDependencies` (still used by the e2e mock). `@mr-quin/dango` (engine) stays a runtime dep.
- Existing installs are unaffected: unchanged `preinstalled` manifests aren't re-downloaded and `user` imports are never touched. Default provider configs (3 + maccms) stay as-is; the other catalog manifests are registered-but-unconfigured for the import UI later.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` (registry + store units: hydrate-without-fetch; reconcile seed/add-missing/replace-changed-by-version/skip-unchanged/leave-user-imports; skip a bad or failed file then re-fetch next run; index failure leaves the store untouched; store merge + a write-mutex test that fails without the lock)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` (baseline mocks `/manifest` so the install reconcile is deterministic; provider source specs exercise the reconciled runners; migration spec covers the post-swap reconcile)
- Browser-verified the real install reconcile against staging (`api.danmaku-staging.weeblify.app`): all 13 catalog manifests stored as `preinstalled` with versions, no console errors.

## Notes
- Index-fetch failure leaves the store untouched and the next `onInstalled` reconcile retries. Per-file failures are skipped and retried on the next reconcile (graceful degradation: one broken file doesn't block the rest).
- Because the reconcile is decoupled from `ready`, a freshly installed profile has a brief window where `ready` resolved but runners aren't loaded yet; a search in that sub-second window errors transiently until the reconcile lands. Normal startups read from storage, no network.
- Follow-ups (DA-592 / DA-580): a periodic `chrome.alarms` reconcile and a sources-page "check for update" button that call `update()`; plus handling catalog removals and coordinating the in-memory runner map vs storage when the import/edit UI wires up `register`/`refresh`.