### PR TITLE
(extension) add bottom padding and larger gap to list pages [DA-596]

### DIFF
--- a/packages/danmaku-anywhere/src/common/components/DraggableList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DraggableList.tsx
@@ -56,7 +56,7 @@ const StyledListItem = styled(ListItem)(({ theme }) => {
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
     backgroundColor: theme.palette.background.paper,
-    marginBottom: theme.spacing(0.5),
+    marginBottom: theme.spacing(1),
     '&:last-of-type': {
       marginBottom: 0,
     },
@@ -341,7 +341,7 @@ export function DraggableList<T extends DraggableItem>({
         strategy={verticalListSortingStrategy}
       >
         <ScrollBox sx={{ overflow: 'auto' }}>
-          <List dense disablePadding>
+          <List dense disablePadding sx={{ pb: 1.5 }}>
             {orderedItems.map((item) => (
               <SortableItem
                 key={item.id}

--- a/packages/danmaku-anywhere/src/common/components/DraggableList.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DraggableList.tsx
@@ -56,10 +56,6 @@ const StyledListItem = styled(ListItem)(({ theme }) => {
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
     backgroundColor: theme.palette.background.paper,
-    marginBottom: theme.spacing(1),
-    '&:last-of-type': {
-      marginBottom: 0,
-    },
     '.MuiListItemButton-root': {
       paddingRight: theme.spacing(12), // make room for action buttons
     },
@@ -341,7 +337,11 @@ export function DraggableList<T extends DraggableItem>({
         strategy={verticalListSortingStrategy}
       >
         <ScrollBox sx={{ overflow: 'auto' }}>
-          <List dense disablePadding sx={{ pb: 1.5 }}>
+          <List
+            dense
+            disablePadding
+            sx={{ display: 'flex', flexDirection: 'column', gap: 1, pb: 1.5 }}
+          >
             {orderedItems.map((item) => (
               <SortableItem
                 key={item.id}


### PR DESCRIPTION
## Summary
- Bump the gap between items in the shared `DraggableList` from 4px to 8px so list rows have a bit more breathing room.
- Add 12px bottom padding to the scrollable list area so the last item isn't flush against the bottom edge.

These render the danmaku source list plus the mount config, AI provider, and title-mapping lists, which all share `DraggableList`.

## Test plan
- [ ] Open the popup, visit 弹幕源 (Danmaku Sources), 装填配置 (Mount Configs), AI源, and 标题映射 (Title Mapping) and confirm the larger inter-item gap and bottom padding.
- No e2e coverage: pure presentational spacing change with no behavioral surface; asserting pixel spacing would be brittle.

## Notes
- Scope is intentionally the shared `DraggableList`. The few bespoke lists not built on it (integration policy, cloud backup, rules) are unchanged.