### PR TITLE
(extension) decouple provider resolution from DanmakuSourceType [DA-591]

### DIFF
--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
@@ -7,14 +7,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ILogger } from '@/common/Logger'
 import { LoggerSymbol } from '@/common/Logger'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
+import { ManifestProviderService } from './ManifestProviderService'
 import type { ManifestRegistry } from './ManifestRegistry'
 
 /**
  * ProviderFactory dispatches on `config.manifestId` and constructs either
  * a ManifestProviderService configured for the source, or the legacy
- * MacCmsProviderService for `legacy:maccms` configs. Custom DanDanPlay
- * servers share the `dandanplay` manifest and thread their
- * baseUrl/auth through configValues; there is no DDP-compat special case.
+ * MacCmsProviderService for `legacy:maccms` configs. Any non-maccms
+ * manifestId (built-in or catalog) resolves to a ManifestProviderService
+ * that stamps `config.impl` as the provider tag. Custom DanDanPlay servers
+ * share the `dandanplay` manifest and thread their baseUrl/auth through
+ * configValues; there is no DDP-compat special case.
  */
 
 const mockRunner = {
@@ -167,18 +170,36 @@ describe('ProviderFactory dispatch', () => {
     expect((service as unknown as { tag?: string }).tag).toBe('maccms-legacy')
   })
 
-  it('throws on an unknown manifestId', async () => {
+  it('resolves a non-built-in catalog manifestId to ManifestProviderService stamping config.impl', async () => {
+    const factory = await buildFactory()
+    const service = factory({
+      id: 'iqiyi-1',
+      manifestId: 'iqiyi',
+      impl: DanmakuSourceType.DanDanPlay,
+      name: 'iQIYI',
+      enabled: true,
+      isBuiltIn: false,
+      configValues: { region: 'cn' },
+    })
+
+    expect(service).toBeInstanceOf(ManifestProviderService)
+    expect(service.forProvider).toBe(DanmakuSourceType.DanDanPlay)
+    await service.search({ keyword: 'x' })
+    expect(mockRunner.runSearch).toHaveBeenCalledWith({ q: 'x', region: 'cn' })
+  })
+
+  it('rejects a non-maccms config that carries the Custom impl', async () => {
     const factory = await buildFactory()
     expect(() =>
       factory({
-        id: 'x',
-        manifestId: 'nonexistent',
-        impl: DanmakuSourceType.DanDanPlay,
-        name: 'X',
+        id: 'bad-1',
+        manifestId: 'iqiyi',
+        impl: DanmakuSourceType.Custom,
+        name: 'Bad',
         enabled: true,
         isBuiltIn: false,
         configValues: {},
       })
-    ).toThrow(/Unknown manifestId/)
+    ).toThrow(/cannot use the Custom impl/)
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.ts
@@ -1,12 +1,12 @@
 import {
+  DanmakuSourceType,
   LEGACY_MACCMS_ID,
-  PROVIDER_TO_BUILTIN_ID,
 } from '@danmaku-anywhere/danmaku-converter'
 import type { ResolutionContext } from 'inversify'
 import type { IDanmakuProvider } from '@/background/services/providers/IDanmakuProvider'
-import { DanmakuSourceType } from '@/common/danmaku/enums'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
+import { invariant } from '@/common/utils/utils'
 import { MacCmsProviderService } from './MacCmsProviderService'
 import { ManifestProviderService } from './ManifestProviderService'
 import { ManifestRegistry } from './ManifestRegistry'
@@ -17,35 +17,26 @@ export type IDanmakuProviderFactory = (
 
 export const DanmakuProviderFactory = Symbol.for('DanmakuProviderFactory')
 
-// Per-manifest dispatch metadata. The map only carries the canonical
-// `DanmakuSourceType` for each builtin; pipeline inputs flow through the
-// generic configValues path on ManifestProviderService.
-const builtinProvider: Record<string, DanmakuSourceType> = {
-  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay]]:
-    DanmakuSourceType.DanDanPlay,
-  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili]]:
-    DanmakuSourceType.Bilibili,
-  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent]]:
-    DanmakuSourceType.Tencent,
-}
-
 function createDanmakuProvider(
   config: ProviderConfig,
   registry: ManifestRegistry,
   logger: ILogger
 ): IDanmakuProvider {
-  // MacCMS still uses the legacy service until a template manifest ships.
+  // MacCMS has no manifest; it resolves through the legacy service.
   if (config.manifestId === LEGACY_MACCMS_ID) {
     return new MacCmsProviderService(config, logger)
   }
-  const provider = builtinProvider[config.manifestId]
-  if (provider === undefined) {
-    throw new Error(`Unknown manifestId: ${config.manifestId}`)
-  }
+  // The Custom impl shares MacCMS's enum value; a manifest source carrying it
+  // would be read as custom danmaku by `isNotCustom` consumers. Identity is the
+  // manifestId, so impl is only the persisted provider tag and must stay real.
+  invariant(
+    config.impl !== DanmakuSourceType.Custom,
+    `Provider config ${config.id} (${config.manifestId}) cannot use the Custom impl`
+  )
   return new ManifestProviderService(
     {
       manifestId: config.manifestId,
-      provider,
+      provider: config.impl,
       providerConfigId: config.id,
       configValues: config.configValues,
     },

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -1,0 +1,246 @@
+import {
+  DanmakuSourceType,
+  type EpisodeMeta,
+  LEGACY_MACCMS_ID,
+  type WithSeason,
+} from '@danmaku-anywhere/danmaku-converter'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DanmakuService } from '@/background/services/persistence/DanmakuService'
+import type { SeasonService } from '@/background/services/persistence/SeasonService'
+import type { ILogger } from '@/common/Logger'
+import type { ProviderConfig } from '@/common/options/providerConfig/schema'
+import type { ProviderConfigService } from '@/common/options/providerConfig/service'
+import type { IDanmakuProvider } from './IDanmakuProvider'
+import type { ManifestRegistry } from './ManifestRegistry'
+import { ProviderService } from './ProviderService'
+
+/**
+ * ProviderService keys legacy custom-danmaku behavior off the config's
+ * manifestId (LEGACY_MACCMS_ID), not the season/episode `provider` tag. This
+ * lets a generic catalog source (any registered manifest) search, fetch
+ * episodes, and fetch danmaku without tripping the MacCMS-only guards, while
+ * MacCMS keeps its bespoke restrictions.
+ */
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  sub: () => silentLogger,
+} as unknown as ILogger
+
+function makeConfig(
+  manifestId: string,
+  impl: DanmakuSourceType
+): ProviderConfig {
+  return {
+    id: `${manifestId}-1`,
+    manifestId,
+    impl,
+    name: manifestId,
+    enabled: true,
+    isBuiltIn: false,
+    configValues: {},
+  }
+}
+
+function makeProvider(
+  overrides: Record<string, unknown> = {}
+): IDanmakuProvider {
+  return {
+    forProvider: DanmakuSourceType.DanDanPlay,
+    search: vi.fn(async () => []),
+    getEpisodes: vi.fn(async () => []),
+    getDanmaku: vi.fn(async () => []),
+    ...overrides,
+  } as unknown as IDanmakuProvider
+}
+
+function build(
+  config: ProviderConfig,
+  provider: IDanmakuProvider,
+  opts: { findExisting?: unknown; existingDanmaku?: unknown[] } = {}
+) {
+  const danmakuService = {
+    filter: vi.fn(async () => opts.existingDanmaku ?? []),
+    upsert: vi.fn(async (e: unknown) => e),
+  } as unknown as DanmakuService
+
+  const season = {
+    id: 1,
+    providerConfigId: config.id,
+    providerIds: { animeId: 42 },
+    provider: config.impl,
+    title: 'Show',
+  }
+
+  const seasonService = {
+    mustGetById: vi.fn(async () => season),
+    findExisting: vi.fn(async () => opts.findExisting),
+  } as unknown as SeasonService
+
+  const providerConfigService = {
+    mustGet: vi.fn(async () => config),
+  } as unknown as ProviderConfigService
+
+  const factory = vi.fn(() => provider)
+
+  const registry = {
+    ready: Promise.resolve(true),
+  } as unknown as ManifestRegistry
+
+  const service = new ProviderService(
+    danmakuService,
+    seasonService,
+    providerConfigService,
+    factory,
+    registry,
+    silentLogger
+  )
+
+  return { service, provider, danmakuService, seasonService }
+}
+
+describe('ProviderService legacy-maccms decoupling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fetchEpisodesBySeason', () => {
+    it('fetches episodes for a generic catalog source without throwing', async () => {
+      const provider = makeProvider({
+        getEpisodes: vi.fn(async () => []),
+      })
+      const { service } = build(
+        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
+        provider
+      )
+
+      await expect(service.fetchEpisodesBySeason(1)).resolves.toEqual([])
+      expect(provider.getEpisodes).toHaveBeenCalledWith({ animeId: 42 })
+    })
+
+    it('throws for a legacy MacCMS config', async () => {
+      const provider = makeProvider()
+      const { service } = build(
+        makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS),
+        provider
+      )
+
+      await expect(service.fetchEpisodesBySeason(1)).rejects.toThrow(
+        'MacCMS does not support fetching episodes'
+      )
+      expect(provider.getEpisodes).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('searchSeason', () => {
+    it('resolves a generic source result against existing seasons (not a custom-season cast)', async () => {
+      const insert = {
+        provider: DanmakuSourceType.DanDanPlay,
+        indexedId: 'x',
+        title: 'A',
+      }
+      const existing = { ...insert, id: 99 }
+      const provider = makeProvider({ search: vi.fn(async () => [insert]) })
+      const { service, seasonService } = build(
+        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
+        provider,
+        { findExisting: existing }
+      )
+
+      const result = await service.searchSeason({
+        providerConfigId: 'iqiyi-1',
+        keyword: 'a',
+      })
+
+      // The generic branch swaps the insert for its persisted row; the MacCMS
+      // branch would return the insert verbatim, never calling findExisting.
+      expect(result).toEqual([existing])
+      expect(seasonService.findExisting).toHaveBeenCalledWith(insert)
+    })
+
+    it('returns MacCMS results verbatim as custom seasons without resolving existing', async () => {
+      const customSeason = {
+        provider: DanmakuSourceType.MacCMS,
+        indexedId: 'c',
+        title: 'C',
+      }
+      const provider = makeProvider({
+        search: vi.fn(async () => [customSeason]),
+      })
+      const { service, seasonService } = build(
+        makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS),
+        provider,
+        { findExisting: { ...customSeason, id: 7 } }
+      )
+
+      const result = await service.searchSeason({
+        providerConfigId: `${LEGACY_MACCMS_ID}-1`,
+        keyword: 'c',
+      })
+
+      expect(result).toEqual([customSeason])
+      expect(seasonService.findExisting).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getDanmaku', () => {
+    const meta = {
+      provider: DanmakuSourceType.DanDanPlay,
+      indexedId: 'ep1',
+      seasonId: 1,
+      providerIds: {},
+      season: { id: 1, providerConfigId: 'iqiyi-1' },
+    } as unknown as WithSeason<EpisodeMeta>
+
+    it('fetches danmaku for a generic source', async () => {
+      const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
+      const { service } = build(
+        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
+        provider
+      )
+
+      await service.getDanmaku({ type: 'by-meta', meta, options: {} })
+
+      expect(provider.getDanmaku).toHaveBeenCalled()
+    })
+
+    it('serves cached danmaku without fetching or resolving the config', async () => {
+      const cached = { id: 5, comments: [] }
+      const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
+      const { service } = build(
+        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
+        provider,
+        { existingDanmaku: [cached] }
+      )
+
+      const result = await service.getDanmaku({
+        type: 'by-meta',
+        meta,
+        options: {},
+      })
+
+      expect(result).toEqual(cached)
+      expect(provider.getDanmaku).not.toHaveBeenCalled()
+    })
+
+    it('throws for a legacy MacCMS config', async () => {
+      const provider = makeProvider()
+      const maccmsMeta = {
+        ...meta,
+        season: { id: 1, providerConfigId: `${LEGACY_MACCMS_ID}-1` },
+      } as unknown as WithSeason<EpisodeMeta>
+      const { service } = build(
+        makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS),
+        provider
+      )
+
+      await expect(
+        service.getDanmaku({ type: 'by-meta', meta: maccmsMeta, options: {} })
+      ).rejects.toThrow('MacCMS episodes are not refetchable')
+      expect(provider.getDanmaku).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -6,6 +6,7 @@ import type {
   SeasonInsert,
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
+import { LEGACY_MACCMS_ID } from '@danmaku-anywhere/danmaku-converter'
 import { inject, injectable } from 'inversify'
 import { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import { SeasonService } from '@/background/services/persistence/SeasonService'
@@ -14,8 +15,6 @@ import type {
   DanmakuFetchByMeta,
   DanmakuFetchRequest,
 } from '@/common/danmaku/dto'
-import { DanmakuSourceType } from '@/common/danmaku/enums'
-import { isProvider } from '@/common/danmaku/utils'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type {
@@ -76,10 +75,7 @@ export class ProviderService {
 
     const seasonInserts = await service.search(params)
     // TODO: fix this once we fold custom seasons into the season insert
-    if (
-      seasonInserts[0] &&
-      isProvider(seasonInserts[0], DanmakuSourceType.MacCMS)
-    ) {
+    if (providerConfig.manifestId === LEGACY_MACCMS_ID) {
       return seasonInserts as CustomSeason[]
     }
     // Surface existing ids so bookmark / cache indicators still resolve.
@@ -105,12 +101,12 @@ export class ProviderService {
     const providerConfig = await this.providerConfigService.mustGet(
       season.providerConfigId
     )
-    const service = this.danmakuProviderFactory(providerConfig)
 
-    if (service.forProvider === DanmakuSourceType.MacCMS) {
+    if (providerConfig.manifestId === LEGACY_MACCMS_ID) {
       throw new Error('MacCMS does not support fetching episodes')
     }
 
+    const service = this.danmakuProviderFactory(providerConfig)
     const episodes = await service.getEpisodes(season.providerIds)
     return episodes.map((episode) => enrichEpisode(episode, season))
   }
@@ -158,14 +154,9 @@ export class ProviderService {
   async getDanmaku(request: DanmakuFetchRequest): Promise<WithSeason<Episode>> {
     await this.manifestRegistry.ready
     const resolved = await this.resolveMeta(request)
-    const { options = {} } = resolved
-    const provider = resolved.meta.provider
+    const { options = {}, meta } = resolved
+    const provider = meta.provider
 
-    if (provider === DanmakuSourceType.MacCMS) {
-      throw new Error('MacCMS episodes are not refetchable')
-    }
-
-    const { meta } = resolved
     const [existingDanmaku] = await this.danmakuService.filter({
       provider,
       indexedId: meta.indexedId,
@@ -186,6 +177,11 @@ export class ProviderService {
     const config = await this.providerConfigService.mustGet(
       meta.season.providerConfigId
     )
+
+    if (config.manifestId === LEGACY_MACCMS_ID) {
+      throw new Error('MacCMS episodes are not refetchable')
+    }
+
     const service = this.danmakuProviderFactory(config)
 
     const comments = await service.getDanmaku(resolved)

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
@@ -20,6 +20,7 @@ import { useDanmakuTreeContext } from '@/common/components/DanmakuSelector/tree/
 import { EpisodeTreeItem } from '@/common/components/DanmakuSelector/tree/items/EpisodeTreeItem'
 import { SeasonTreeItem } from '@/common/components/DanmakuSelector/tree/items/SeasonTreeItem'
 import { DanmakuContextMenu } from '@/common/components/DanmakuSelector/tree/menus/DanmakuContextMenu'
+import { isProvider } from '@/common/danmaku/utils'
 import { useLongPress } from '@/common/hooks/useLongPress'
 import { FolderTreeItem } from './FolderTreeItem'
 import { StubEpisodeTreeItem } from './StubEpisodeTreeItem'
@@ -71,7 +72,7 @@ export const DanmakuTreeItem = forwardRef(function CustomTreeItem(
   const item = itemMap.get(itemId)
   const isSeason = item?.kind === 'season'
   const isCustomSeason = isSeason
-    ? item.data.provider === DanmakuSourceType.MacCMS
+    ? isProvider(item.data, DanmakuSourceType.MacCMS)
     : false
 
   function handleMouseEnter() {


### PR DESCRIPTION
## Summary
- `ProviderFactory` now dispatches purely on `config.manifestId`: `legacy:maccms` -> `MacCmsProviderService`, every other config -> `ManifestProviderService`. Any registered manifest (built-in or catalog) is a valid provider. The `Unknown manifestId` throw and the builtin-only dispatch map are removed. This unblocks **DA-594 (catalog import)**.
- The season/episode `provider` (`DanmakuSourceType`) tag is stamped from `config.impl` (every config already carries `impl`; for built-ins it equals the old canonical value, so existing data is unchanged).
- The three MacCMS-only runtime branches in `ProviderService` (search cast-to-`CustomSeason`, episode-fetch throw, danmaku-refetch throw) are re-keyed from `provider === MacCMS` onto `config.manifestId === LEGACY_MACCMS_ID`. The custom-season tree border uses the shared `isProvider` helper.

## Provider-value decision (the data-contract call)
The `provider` field is a frozen, persisted contract (DA-579) and also a cross-version danmaku import/export contract validated by `z.enum(DanmakuSourceType)`, so **no new enum value was added** (it would break old-version import of new exports). `MacCMS` and `Custom` share the value `'Custom'`, and `isNotCustom()` is a type guard on `provider === MacCMS` used at ~25 sites. Therefore:
- Identity is `providerConfigId -> manifestId`; `provider` is a non-load-bearing tag stamped from `config.impl`.
- A non-maccms config carrying the `Custom` impl is **rejected at the factory** (`invariant`), because it would make a manifest source read as custom danmaku everywhere. This makes the invariant explicit and fail-fast for DA-594.

## Test plan
- [x] `pnpm --filter @mr-quin/danmaku-anywhere test` (455 pass). Provider units cover: non-builtin manifestId resolves to `ManifestProviderService` stamping `config.impl`; generic episode/danmaku fetch does NOT throw the MacCMS error; MacCMS still routes legacy via `LEGACY_MACCMS_ID`; generic search resolves against existing seasons (not a custom cast); cached danmaku served without resolving config; `Custom` impl rejected for a non-maccms config.
- [x] e2e: `e2e/specs/sources/{dandanplay,dandanplay-custom,bilibili,tencent}.spec.ts`, `e2e/specs/migration/migration-smoke.spec.ts`, `e2e/specs/mount/{folder,import-detach}.spec.ts` (custom "Local Danmaku" season still renders as custom). All pass (one custom-ddp setup flake cleared on re-run).
- [x] Browser-verify against staging: seeded a `ProviderConfig` with `manifestId: 'iqiyi'` (no add-source UI yet), drove the real `seasonSearch`/`episodeFetchBySeason`/`episodeFetch` RPCs. Result: search returned 3 seasons, episode fetch returned 700 episodes (no MacCMS throw), danmaku fetch returned 5796 comments. No `Unknown manifestId` in console.

## Notes
- `db.ts` v10 migration (`item.provider === 'Custom'`) is deliberately unchanged: it migrates historical V3 records that predate `manifestId`; changing it would alter migration effect on existing records.
- Deferred to DA-594 (UI still keys off the provider tag, not the manifest): `ProviderLogo` icon, the `TypeSelector`/`danmakuSourceTypeList` type filter, and `useLoadDanmaku` refresh-gating. A generic source inherits the icon/filter/refresh persona of whichever built-in `impl` its config stamps; `impl: DanDanPlay` is the least-broken choice (in the default filter list + gets the refresh affordance). Reworking provider display to be manifest-driven is DA-594 scope.
- Spec: https://app.clickup.com/90131020449/docs/2ky3men1-2133 (see "Sequencing update (DA-591 is the gate)").