### PR TITLE
(app) load scraped videos CORS-clean for occlusion frame reads [DA-601]

### DIFF
--- a/app/web/src/app/core/video-player/video.service.ts
+++ b/app/web/src/app/core/video-player/video.service.ts
@@ -199,8 +199,7 @@ export class VideoService {
       airplay: false,
       lang: 'zh-cn',
       theme: '#f472b6',
-      // load CORS-clean so occlusion can read frames from the video; falls back
-      // to no-cors on error (see setupEventListeners) for CDNs that reject it
+      // CORS-clean so occlusion can read frames; falls back to no-cors on error
       moreVideoAttr: { crossOrigin: 'anonymous' },
     })
 
@@ -224,8 +223,7 @@ export class VideoService {
       if (!url) {
         this.updateState({ isVideoReady: false })
       } else {
-        // re-arm CORS for each source so a new one can be read CORS-clean even
-        // after a previous source fell back to no-cors
+        // re-arm CORS per source after a previous no-cors fallback
         this.corsRetryPending = false
         player.video.crossOrigin = 'anonymous'
         void player.switchUrl(url)
@@ -412,9 +410,7 @@ export class VideoService {
       this.updateState({ isFullscreenWeb })
     })
 
-    // a crossorigin video that the CDN refuses to serve CORS fails to load;
-    // drop crossorigin so Artplayer's reconnect reloads it no-cors, keeping
-    // playback alive (occlusion just stays off for this source)
+    // CORS rejected: drop crossorigin so the reconnect reloads no-cors
     player.on('video:error', () => {
       if (player.video.crossOrigin) {
         this.corsRetryPending = true

--- a/app/web/src/app/core/video-player/video.service.ts
+++ b/app/web/src/app/core/video-player/video.service.ts
@@ -134,6 +134,7 @@ export class VideoService {
   private controls: ComponentOption[] = []
   private controlNames = new Set<string>()
   private subtitleRenderer: InstanceType<typeof SubtitlesOctopus> | null = null
+  private corsRetryPending = false
 
   private $player = signal<Artplayer | null>(null)
   private $container = signal<ElementRef<HTMLDivElement> | null>(null)
@@ -198,6 +199,9 @@ export class VideoService {
       airplay: false,
       lang: 'zh-cn',
       theme: '#f472b6',
+      // load CORS-clean so occlusion can read frames from the video; falls back
+      // to no-cors on error (see setupEventListeners) for CDNs that reject it
+      moreVideoAttr: { crossOrigin: 'anonymous' },
     })
 
     this.setupEventListeners(player)
@@ -220,6 +224,10 @@ export class VideoService {
       if (!url) {
         this.updateState({ isVideoReady: false })
       } else {
+        // re-arm CORS for each source so a new one can be read CORS-clean even
+        // after a previous source fell back to no-cors
+        this.corsRetryPending = false
+        player.video.crossOrigin = 'anonymous'
         void player.switchUrl(url)
       }
     }
@@ -404,7 +412,21 @@ export class VideoService {
       this.updateState({ isFullscreenWeb })
     })
 
+    // a crossorigin video that the CDN refuses to serve CORS fails to load;
+    // drop crossorigin so Artplayer's reconnect reloads it no-cors, keeping
+    // playback alive (occlusion just stays off for this source)
+    player.on('video:error', () => {
+      if (player.video.crossOrigin && !this.corsRetryPending) {
+        this.corsRetryPending = true
+        player.video.removeAttribute('crossorigin')
+      }
+    })
+
     player.on('error', (e: unknown) => {
+      if (this.corsRetryPending) {
+        this.corsRetryPending = false
+        return
+      }
       this.messageService.add({
         severity: 'error',
         summary: '视频加载错误',

--- a/app/web/src/app/core/video-player/video.service.ts
+++ b/app/web/src/app/core/video-player/video.service.ts
@@ -416,7 +416,7 @@ export class VideoService {
     // drop crossorigin so Artplayer's reconnect reloads it no-cors, keeping
     // playback alive (occlusion just stays off for this source)
     player.on('video:error', () => {
-      if (player.video.crossOrigin && !this.corsRetryPending) {
+      if (player.video.crossOrigin) {
         this.corsRetryPending = true
         player.video.removeAttribute('crossorigin')
       }

--- a/app/web/src/app/features/kazumi/services/kazumi.service.ts
+++ b/app/web/src/app/features/kazumi/services/kazumi.service.ts
@@ -349,6 +349,7 @@ export class KazumiService {
           await this.setHeadersMutation.mutateAsync({
             url: videoUrl.origin,
             referer: origin,
+            origin,
           })
         }),
         // convert stream to emit an array

--- a/packages/web-scraper/src/messaging/messaging.test.ts
+++ b/packages/web-scraper/src/messaging/messaging.test.ts
@@ -50,6 +50,9 @@ describe('setRequestHeaderRule', () => {
     })
 
     const { action } = getAddedRule()
+    expect(findHeader(action.requestHeaders, 'Referer')?.value).toBe(
+      'https://source.example.com'
+    )
     expect(findHeader(action.requestHeaders, 'Origin')?.value).toBe(
       'https://source.example.com'
     )

--- a/packages/web-scraper/src/messaging/messaging.test.ts
+++ b/packages/web-scraper/src/messaging/messaging.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setRequestHeaderRule } from './messaging.js'
+
+const getSessionRules = vi.fn()
+const updateSessionRules = vi.fn()
+
+const getAddedRule = () => {
+  return updateSessionRules.mock.calls[0][0].addRules[0]
+}
+
+const findHeader = (
+  headers: chrome.declarativeNetRequest.ModifyHeaderInfo[] | undefined,
+  name: string
+) => {
+  return headers?.find((h) => h.header === name)
+}
+
+describe('setRequestHeaderRule', () => {
+  beforeEach(() => {
+    getSessionRules.mockResolvedValue([])
+    vi.stubGlobal('chrome', {
+      declarativeNetRequest: { getSessionRules, updateSessionRules },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('sets Referer without an Origin override when origin is omitted', async () => {
+    await setRequestHeaderRule({
+      url: 'https://cdn.example.com',
+      referer: 'https://source.example.com',
+    })
+
+    const { action } = getAddedRule()
+    expect(findHeader(action.requestHeaders, 'Referer')?.value).toBe(
+      'https://source.example.com'
+    )
+    expect(findHeader(action.requestHeaders, 'Origin')).toBeUndefined()
+    expect(action.responseHeaders).toBeUndefined()
+  })
+
+  it('rewrites Origin and allows it back when origin is provided', async () => {
+    await setRequestHeaderRule({
+      url: 'https://cdn.example.com',
+      referer: 'https://source.example.com',
+      origin: 'https://source.example.com',
+    })
+
+    const { action } = getAddedRule()
+    expect(findHeader(action.requestHeaders, 'Origin')?.value).toBe(
+      'https://source.example.com'
+    )
+    expect(
+      findHeader(action.responseHeaders, 'Access-Control-Allow-Origin')?.value
+    ).toBe('*')
+  })
+})

--- a/packages/web-scraper/src/messaging/messaging.ts
+++ b/packages/web-scraper/src/messaging/messaging.ts
@@ -142,10 +142,8 @@ export type SetHeaderRule = {
   headers?: HTTPHeader[]
   url: string
   referer: string
-  // when set, the request's Origin is rewritten to this value and the response
-  // is given Access-Control-Allow-Origin: *, so a CORS request to a
-  // hotlink-protected CDN that only allowlists the source origin succeeds and
-  // stays origin-clean
+  // rewrites request Origin to this and forces Access-Control-Allow-Origin: *,
+  // so a CDN that only allowlists the source origin serves the CORS request
   origin?: string
 }
 

--- a/packages/web-scraper/src/messaging/messaging.ts
+++ b/packages/web-scraper/src/messaging/messaging.ts
@@ -142,6 +142,11 @@ export type SetHeaderRule = {
   headers?: HTTPHeader[]
   url: string
   referer: string
+  // when set, the request's Origin is rewritten to this value and the response
+  // is given Access-Control-Allow-Origin: *, so a CORS request to a
+  // hotlink-protected CDN that only allowlists the source origin succeeds and
+  // stays origin-clean
+  origin?: string
 }
 
 export const setRequestHeaderRule = async (headerRule: SetHeaderRule) => {
@@ -209,21 +214,40 @@ export const setRequestHeaderRule = async (headerRule: SetHeaderRule) => {
       }
     ) ?? []
 
+  const requestHeaders: chrome.declarativeNetRequest.ModifyHeaderInfo[] = [
+    ...headersToSet,
+    {
+      header: 'Referer',
+      operation: 'set',
+      value: headerRule.referer,
+    },
+  ]
+
+  const action: chrome.declarativeNetRequest.RuleAction = {
+    type: 'modifyHeaders',
+    requestHeaders,
+  }
+
+  if (headerRule.origin) {
+    requestHeaders.push({
+      header: 'Origin',
+      operation: 'set',
+      value: headerRule.origin,
+    })
+    action.responseHeaders = [
+      {
+        header: 'Access-Control-Allow-Origin',
+        operation: 'set',
+        value: '*',
+      },
+    ]
+  }
+
   await chrome.declarativeNetRequest.updateSessionRules({
     addRules: [
       {
         id: lastId + 1,
-        action: {
-          type: 'modifyHeaders',
-          requestHeaders: [
-            ...headersToSet,
-            {
-              header: 'Referer',
-              operation: 'set',
-              value: headerRule.referer,
-            },
-          ],
-        },
+        action,
         condition: {
           urlFilter: `|${headerRule.url}`,
           resourceTypes: resourceTypes,


### PR DESCRIPTION
## Summary
- Set `crossorigin=anonymous` on the web app's Artplayer `<video>` (via `moreVideoAttr`) so the scraped video loads as a CORS request the occlusion feature can read frames from directly, no clone or second fetch.
- Extend the existing source-origin DNR header rule (`setRequestHeaderRule`) with an optional `origin`: when set, it rewrites the request `Origin` to the source origin and forces `Access-Control-Allow-Origin: *` on the response, so a hotlink-protected CDN that only allowlists the source origin still serves the CORS request origin-clean. Threaded from `kazumi.service` using the same `sourceOrigin` already used for `Referer`.
- No-cors fallback: on `video:error` while `crossorigin` is set, drop the attribute so Artplayer's reconnect reloads the video no-cors; playback is never broken (occlusion just stays off for that source). The expected, recoverable CORS error toast is suppressed once; genuine failures still surface.

## Test plan
- [ ] `pnpm --filter @danmaku-anywhere/web-scraper test` (covers the header-policy change: `Origin` + `Access-Control-Allow-Origin` added only when `origin` is provided, `Referer` preserved).
- [ ] On the CF preview: with occlusion enabled, play a real Kazumi/AGE source (agedm.io / toutiao CDN) and confirm the video loads CORS-clean (no 504) and the occlusion mask applies.
- Faithful e2e of the real hotlink CDN is not feasible (live third-party CDN), and this change is in the web app + web-scraper, not the extension Playwright suite, so no extension e2e spec is added. The deterministic header-policy logic is unit-tested; the player CORS/no-cors fallback is verified via the CF preview above.

## Notes
- The `Origin`/`ACAO` rewrite reuses the same broad rule as `Referer` (per design): injecting `Origin: sourceOrigin` toward a CDN that by premise allowlists that origin cannot be more restrictive than omitting it, and `ACAO: *` with `crossorigin=anonymous` exposes only anonymous public content (no credentials).