### PR TITLE
(extension) occlusion: close test-coverage gaps from cross-origin capture [DA-602]

### DIFF
--- a/packages/danmaku-anywhere/e2e/harness/serve.mjs
+++ b/packages/danmaku-anywhere/e2e/harness/serve.mjs
@@ -89,14 +89,13 @@ const CORS_FAIL_PREFIX = '/cors-fail/'
 
 function handle(req, res) {
   let urlPath = req.url
-  const corsFail = urlPath.startsWith(CORS_FAIL_PREFIX)
-  if (corsFail) {
-    urlPath = `/${urlPath.slice(CORS_FAIL_PREFIX.length)}`
+  if (urlPath.startsWith(CORS_FAIL_PREFIX)) {
     if (req.headers.origin) {
       res.writeHead(403)
       res.end('Forbidden')
       return
     }
+    urlPath = `/${urlPath.slice(CORS_FAIL_PREFIX.length)}`
   }
   const filePath = resolvePath(urlPath)
   if (!filePath) {

--- a/packages/danmaku-anywhere/e2e/harness/serve.mjs
+++ b/packages/danmaku-anywhere/e2e/harness/serve.mjs
@@ -82,8 +82,23 @@ function sendRange(req, res, filePath, size, type) {
   createReadStream(filePath, { start, end }).pipe(res)
 }
 
+// Media served under this prefix rejects the crossorigin clone's CORS request
+// (it carries an Origin header) so the occlusion DNR ACAO rule can't rescue it,
+// while the plain <video> request (no Origin) still plays and taints.
+const CORS_FAIL_PREFIX = '/cors-fail/'
+
 function handle(req, res) {
-  const filePath = resolvePath(req.url)
+  let urlPath = req.url
+  const corsFail = urlPath.startsWith(CORS_FAIL_PREFIX)
+  if (corsFail) {
+    urlPath = `/${urlPath.slice(CORS_FAIL_PREFIX.length)}`
+    if (req.headers.origin) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+  }
+  const filePath = resolvePath(urlPath)
   if (!filePath) {
     res.writeHead(403)
     res.end('Forbidden')

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
@@ -1,6 +1,7 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { defaultDanmakuOptions } from '../../../src/common/options/danmakuOptions/constant'
 import { IntegrationPage } from '../../pom/IntegrationPage'
+import { Toast } from '../../pom/Toast'
 import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import {
@@ -10,11 +11,12 @@ import {
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Occlusion cross-origin recovery over real network (route-fulfilled .invalid
+ * Occlusion cross-origin behavior over real network (route-fulfilled .invalid
  * origins can't exercise DNR). Page on localhost:8889, video on 127.0.0.1:8889,
- * so the canvas genuinely taints; asserts the original is tainted yet a mask
- * still applies (only possible if the DNR rule + crossorigin clone un-tainted
- * it). Also covers swapping to another cross-origin src.
+ * so the canvas genuinely taints. Asserts the recovery path (tainted original +
+ * DNR clone yields a mask), the src-swap re-recovery, and the graceful-failure
+ * path (a clone the DNR rule cannot rescue surfaces the taint status, leaves
+ * playback intact, and applies no mask).
  */
 
 const PAGE_ORIGIN = 'http://localhost:8889'
@@ -22,6 +24,9 @@ const MEDIA_ORIGIN = 'http://127.0.0.1:8889'
 const PAGE_URL = `${PAGE_ORIGIN}/sites/cross-origin-video.html`
 const VIDEO_1 = `${MEDIA_ORIGIN}/media/sample-motion.webm`
 const VIDEO_2 = `${MEDIA_ORIGIN}/media/person-akiyo.webm`
+// Served so the crossorigin clone's CORS request is rejected (DNR can't rescue
+// it) while the plain <video> still plays and taints.
+const VIDEO_UNRECOVERABLE = `${MEDIA_ORIGIN}/cors-fail/media/sample-motion.webm`
 const MOUNT_PATTERN = `${PAGE_ORIGIN}/*`
 
 const EPISODE_TITLE = 'DA Harness Native Video'
@@ -69,6 +74,20 @@ function videoTaintState(page: import('@playwright/test').Page) {
     } catch (e) {
       return e instanceof DOMException ? e.name : 'error'
     }
+  })
+}
+
+function videoIsPlaying(page: import('@playwright/test').Page) {
+  return page.evaluate(async () => {
+    const v = document.querySelector<HTMLVideoElement>(
+      'video[data-testid="da-video"]'
+    )
+    if (!v) {
+      return false
+    }
+    const before = v.currentTime
+    await new Promise((r) => setTimeout(r, 400))
+    return !v.paused && v.currentTime > before
   })
 }
 
@@ -159,4 +178,38 @@ test('occlusion re-recovers when the player swaps to another cross-origin src', 
   await expect
     .poll(() => maskImageOf(integrationPage.danmuContainer()))
     .toMatch(/^url\(/)
+})
+
+test.describe('unrecoverable cross-origin source', () => {
+  // The clone's CORS fetch is rejected by design; that 403 is the trigger.
+  test.use({ expectedConsoleErrors: [/403.*cors-fail\/media/] })
+
+  test('occlusion degrades safely when the tainted source cannot be recovered', async ({
+    context,
+    page,
+  }) => {
+    const da = await seedOcclusionMount(context)
+    const integrationPage = new IntegrationPage(page)
+    const toast = new Toast(page)
+
+    await page.bringToFront()
+    await page.goto(PAGE_URL)
+    await setVideoSrc(page, VIDEO_UNRECOVERABLE)
+
+    await expect.poll(() => videoTaintState(page)).toBe('SecurityError')
+
+    const mirror = await da.mount.waitForMount(undefined, 15_000)
+    expect(mirror.isMounted).toBe(true)
+    await expect(integrationPage.commentElements().first()).toBeVisible({
+      timeout: 15_000,
+    })
+
+    await toast.expectError(/cross-origin or DRM|跨域或 DRM/, {
+      timeout: 15_000,
+    })
+    expect(await videoIsPlaying(page)).toBe(true)
+    await expect(maskImageOf(integrationPage.danmuContainer())).resolves.toBe(
+      'none'
+    )
+  })
 })

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cross-origin.spec.ts
@@ -77,17 +77,12 @@ function videoTaintState(page: import('@playwright/test').Page) {
   })
 }
 
-function videoIsPlaying(page: import('@playwright/test').Page) {
-  return page.evaluate(async () => {
+function videoCurrentTime(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
     const v = document.querySelector<HTMLVideoElement>(
       'video[data-testid="da-video"]'
     )
-    if (!v) {
-      return false
-    }
-    const before = v.currentTime
-    await new Promise((r) => setTimeout(r, 400))
-    return !v.paused && v.currentTime > before
+    return v?.currentTime ?? 0
   })
 }
 
@@ -181,8 +176,8 @@ test('occlusion re-recovers when the player swaps to another cross-origin src', 
 })
 
 test.describe('unrecoverable cross-origin source', () => {
-  // The clone's CORS fetch is rejected by design; that 403 is the trigger.
-  test.use({ expectedConsoleErrors: [/403.*cors-fail\/media/] })
+  // The clone's CORS fetch to this source is rejected by design.
+  test.use({ expectedConsoleErrors: [/cors-fail\/media/] })
 
   test('occlusion degrades safely when the tainted source cannot be recovered', async ({
     context,
@@ -207,7 +202,10 @@ test.describe('unrecoverable cross-origin source', () => {
     await toast.expectError(/cross-origin or DRM|跨域或 DRM/, {
       timeout: 15_000,
     })
-    expect(await videoIsPlaying(page)).toBe(true)
+    const playheadBefore = await videoCurrentTime(page)
+    await expect
+      .poll(() => videoCurrentTime(page))
+      .toBeGreaterThan(playheadBefore)
     await expect(maskImageOf(integrationPage.danmuContainer())).resolves.toBe(
       'none'
     )

--- a/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.test.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/crossOriginCapture.test.ts
@@ -1,0 +1,317 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from 'vitest'
+
+const { addCorsRule, removeCorsRule } = vi.hoisted(() => ({
+  addCorsRule: vi.fn(),
+  removeCorsRule: vi.fn(),
+}))
+
+vi.mock('@/common/rpcClient/background/client', () => ({
+  chromeRpcClient: {
+    occlusionAddCorsRule: addCorsRule,
+    occlusionRemoveCorsRule: removeCorsRule,
+  },
+}))
+
+import { CrossOriginCapture, isVideoOriginClean } from './crossOriginCapture'
+
+type Listener = () => void
+
+class FakeVideo {
+  readyState = 0
+  currentTime = 0
+  currentSrc = ''
+  src = ''
+  playbackRate = 1
+  paused = true
+  crossOrigin: string | null = null
+  muted = false
+  playsInline = false
+  preload = ''
+  style: { cssText: string } = { cssText: '' }
+  play: Mock = vi.fn(() => {
+    this.paused = false
+    return Promise.resolve()
+  })
+  pause: Mock = vi.fn(() => {
+    this.paused = true
+  })
+  load = vi.fn()
+  remove = vi.fn()
+  removeAttribute = vi.fn()
+  private readonly listeners = new Map<string, Set<Listener>>()
+
+  addEventListener(type: string, fn: Listener): void {
+    const set = this.listeners.get(type) ?? new Set<Listener>()
+    set.add(fn)
+    this.listeners.set(type, set)
+  }
+
+  removeEventListener(type: string, fn: Listener): void {
+    this.listeners.get(type)?.delete(fn)
+  }
+
+  dispatch(type: string): void {
+    for (const fn of this.listeners.get(type) ?? []) {
+      fn()
+    }
+  }
+}
+
+function asVideo(fake: FakeVideo): HTMLVideoElement {
+  return fake as unknown as HTMLVideoElement
+}
+
+let createdVideos: FakeVideo[]
+let cloneInit: Partial<FakeVideo>
+let canvasMode: 'clean' | 'security' | 'other'
+let canvasCount: number
+
+function makeFakeCanvas(): unknown {
+  return {
+    width: 0,
+    height: 0,
+    getContext: () => ({
+      drawImage: () => undefined,
+      getImageData: () => {
+        if (canvasMode === 'security') {
+          throw new DOMException('tainted', 'SecurityError')
+        }
+        if (canvasMode === 'other') {
+          throw new DOMException('boom', 'InvalidStateError')
+        }
+        return { data: new Uint8ClampedArray(4) }
+      },
+    }),
+  }
+}
+
+beforeEach(() => {
+  createdVideos = []
+  cloneInit = {}
+  canvasMode = 'clean'
+  canvasCount = 0
+  addCorsRule.mockReset().mockResolvedValue({ data: 7 })
+  removeCorsRule.mockReset().mockResolvedValue(undefined)
+  vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+    if (tag === 'video') {
+      const video = Object.assign(new FakeVideo(), cloneInit)
+      createdVideos.push(video)
+      return asVideo(video)
+    }
+    if (tag === 'canvas') {
+      canvasCount++
+      return makeFakeCanvas()
+    }
+    throw new Error(`unexpected createElement(${tag})`)
+  }) as typeof document.createElement)
+  vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+function makeOriginal(overrides: Partial<FakeVideo> = {}): FakeVideo {
+  return Object.assign(new FakeVideo(), {
+    currentSrc: 'http://example.com/v.webm',
+    ...overrides,
+  })
+}
+
+describe('isVideoOriginClean', () => {
+  it('returns false without probing a canvas when no frame is decoded', () => {
+    const result = isVideoOriginClean(asVideo(makeOriginal({ readyState: 1 })))
+    expect(result).toBe(false)
+    expect(canvasCount).toBe(0)
+  })
+
+  it('returns false when reading pixels throws SecurityError', () => {
+    canvasMode = 'security'
+    const result = isVideoOriginClean(asVideo(makeOriginal({ readyState: 2 })))
+    expect(result).toBe(false)
+  })
+
+  it('returns true when pixels read back clean', () => {
+    canvasMode = 'clean'
+    const result = isVideoOriginClean(asVideo(makeOriginal({ readyState: 2 })))
+    expect(result).toBe(true)
+  })
+
+  it('treats a non-SecurityError read failure as clean', () => {
+    canvasMode = 'other'
+    const result = isVideoOriginClean(asVideo(makeOriginal({ readyState: 2 })))
+    expect(result).toBe(true)
+  })
+})
+
+describe('CrossOriginCapture.setup', () => {
+  it('returns null for a non-http(s) source without touching DNR', async () => {
+    const original = makeOriginal({ currentSrc: 'blob:abc' })
+    const capture = new CrossOriginCapture(asVideo(original))
+
+    expect(await capture.setup()).toBeNull()
+    expect(addCorsRule).not.toHaveBeenCalled()
+    expect(createdVideos).toHaveLength(0)
+  })
+
+  it('returns null gracefully when the DNR rule RPC fails', async () => {
+    addCorsRule.mockRejectedValueOnce(new Error('rpc down'))
+    const capture = new CrossOriginCapture(asVideo(makeOriginal()))
+
+    expect(await capture.setup()).toBeNull()
+    expect(removeCorsRule).not.toHaveBeenCalled()
+  })
+
+  it('resolves the clone and aligns it to the live element once ready', async () => {
+    const original = makeOriginal({ currentTime: 12, readyState: 2 })
+    cloneInit = { readyState: 2 }
+    const capture = new CrossOriginCapture(asVideo(original))
+
+    const clone = await capture.setup()
+
+    expect(clone).toBe(asVideo(createdVideos[0]))
+    expect(addCorsRule).toHaveBeenCalledWith({ url: original.currentSrc })
+    expect(createdVideos[0].src).toBe(original.currentSrc)
+    expect(createdVideos[0].crossOrigin).toBe('anonymous')
+    expect(createdVideos[0].currentTime).toBe(12)
+    expect(createdVideos[0].play).toHaveBeenCalled()
+  })
+
+  it('resolves only after a decoded frame, not mid-seek', async () => {
+    cloneInit = { readyState: 0 }
+    const capture = new CrossOriginCapture(asVideo(makeOriginal()))
+
+    const setupPromise = capture.setup()
+    let settled = false
+    void setupPromise.then(() => {
+      settled = true
+    })
+    await flush()
+    const clone = createdVideos[0]
+
+    clone.readyState = 1
+    clone.dispatch('loadeddata')
+    await flush()
+    expect(settled).toBe(false)
+
+    clone.readyState = 2
+    clone.dispatch('seeked')
+    expect(await setupPromise).toBe(asVideo(clone))
+  })
+
+  it('returns null and removes the rule when the clone errors', async () => {
+    cloneInit = { readyState: 0 }
+    const capture = new CrossOriginCapture(asVideo(makeOriginal()))
+
+    const setupPromise = capture.setup()
+    await flush()
+    const clone = createdVideos[0]
+    clone.dispatch('error')
+
+    expect(await setupPromise).toBeNull()
+    expect(clone.remove).toHaveBeenCalled()
+    expect(removeCorsRule).toHaveBeenCalledWith({ ruleId: 7 })
+  })
+
+  it('returns null when the clone never becomes ready before the timeout', async () => {
+    vi.useFakeTimers()
+    cloneInit = { readyState: 0 }
+    const capture = new CrossOriginCapture(asVideo(makeOriginal()))
+
+    const setupPromise = capture.setup()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(8000)
+
+    expect(await setupPromise).toBeNull()
+    expect(removeCorsRule).toHaveBeenCalledWith({ ruleId: 7 })
+  })
+
+  it('aborts and removes the rule when disposed before the clone is created', async () => {
+    const capture = new CrossOriginCapture(asVideo(makeOriginal()))
+
+    const setupPromise = capture.setup()
+    capture.dispose()
+
+    expect(await setupPromise).toBeNull()
+    expect(createdVideos).toHaveLength(0)
+    expect(removeCorsRule).toHaveBeenCalledWith({ ruleId: 7 })
+  })
+})
+
+describe('CrossOriginCapture.sync', () => {
+  async function setupReady(
+    original: FakeVideo
+  ): Promise<{ capture: CrossOriginCapture; clone: FakeVideo }> {
+    cloneInit = { readyState: 2 }
+    const capture = new CrossOriginCapture(asVideo(original))
+    await capture.setup()
+    return { capture, clone: createdVideos[0] }
+  }
+
+  it('matches the clone playback rate to the original', async () => {
+    const original = makeOriginal({ readyState: 2, playbackRate: 2 })
+    const { capture, clone } = await setupReady(original)
+    clone.playbackRate = 1
+
+    capture.sync()
+
+    expect(clone.playbackRate).toBe(2)
+  })
+
+  it('seeks the clone only when drift exceeds tolerance', async () => {
+    const original = makeOriginal({ readyState: 2 })
+    const { capture, clone } = await setupReady(original)
+
+    original.currentTime = 10
+    clone.currentTime = 9.95
+    capture.sync()
+    expect(clone.currentTime).toBe(9.95)
+
+    clone.currentTime = 5
+    capture.sync()
+    expect(clone.currentTime).toBe(10)
+  })
+
+  it('mirrors pause and play state from the original', async () => {
+    const original = makeOriginal({ readyState: 2 })
+    const { capture, clone } = await setupReady(original)
+
+    original.paused = true
+    clone.paused = false
+    capture.sync()
+    expect(clone.pause).toHaveBeenCalled()
+
+    original.paused = false
+    clone.paused = true
+    clone.play.mockClear()
+    capture.sync()
+    expect(clone.play).toHaveBeenCalled()
+  })
+})
+
+describe('CrossOriginCapture.dispose', () => {
+  it('tears the clone down once and is idempotent', async () => {
+    const original = makeOriginal({ readyState: 2 })
+    cloneInit = { readyState: 2 }
+    const capture = new CrossOriginCapture(asVideo(original))
+    await capture.setup()
+    const clone = createdVideos[0]
+
+    capture.dispose()
+    capture.dispose()
+
+    expect(clone.remove).toHaveBeenCalledTimes(1)
+    expect(removeCorsRule).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for `crossOriginCapture.ts` (previously zero coverage, the most-churned code in the occlusion feature). Mocks `document.createElement('video')`/`canvas` and stubs `chromeRpcClient` to exercise: the `isVideoOriginClean` origin probe (readyState guard, SecurityError vs other), clone `waitReady` (already-loaded sync kick, readyState-gated resolve, error, timeout), `sync` (playbackRate match, drift-triggered seek, pause/play mirroring), `dispose` idempotency, and the setup RPC-failure graceful path.
- Add a failure-path e2e to `occlusion-cross-origin.spec.ts`: a cross-origin source the DNR rule cannot rescue surfaces the taint status (error toast), keeps playback intact (playhead advances), and applies no mask. This is the first test of the "fails gracefully without breaking playback" guarantee.
- Extend the harness (`e2e/harness/serve.mjs`) with a `/cors-fail/` route that 403s the crossorigin clone's CORS request (it carries an `Origin` header) while the plain `<video>` (no `Origin`) still plays and taints, so the DNR ACAO rule genuinely cannot recover it.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` (covers `src/content/player/occlusion/crossOriginCapture.test.ts`)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e e2e/specs/integration/occlusion-cross-origin.spec.ts` (the new "occlusion degrades safely when the tainted source cannot be recovered" case plus the existing recovery cases)
- [ ] `pnpm lint`

## Notes
- The crossOriginCapture unit tests are intended to migrate/extend into the FrameSource tests once the sibling refactor lands.