### PR TITLE
(extension) occlusion: decompose Occlusion.service into FrameSource + MaskCompositor [DA-603]

### DIFF
--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -66,7 +66,7 @@ import type {
   MountConfigAiConfig,
 } from '@/common/options/mountConfig/schema'
 import type { SeasonMapSnapshot } from '@/common/seasonMap/SeasonMap'
-import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.service'
+import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 import type { RPCDef } from '../../rpc/types'
 
 type IconSetDto =

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
@@ -21,7 +21,7 @@ import { selectBestFrame } from '@/content/controller/danmaku/frame/selectBestFr
 import { useMigrateDanmaku } from '@/content/controller/danmaku/frame/useMigrateDanmaku'
 import { usePreloadNextEpisode } from '@/content/controller/danmaku/frame/usePreloadNextEpisode'
 import { useStore } from '@/content/controller/store/store'
-import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.service'
+import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 
 const logger = Logger.sub('[FrameManager]')
 const frameRegistry = uiContainer.get(FrameRegistry)

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -19,10 +19,8 @@ import { DanmakuComponent } from '@/content/player/components/DanmakuComponent'
 import { DanmakuLayoutService } from '@/content/player/danmakuLayout/DanmakuLayout.service'
 import { RectObserver } from '@/content/player/danmakuManager/RectObserver'
 import { DanmakuDebugOverlayService } from '@/content/player/debugOverlay/DanmakuDebugOverlay.service'
-import {
-  OcclusionService,
-  type OcclusionStatus,
-} from '@/content/player/occlusion/Occlusion.service'
+import { OcclusionService } from '@/content/player/occlusion/Occlusion.service'
+import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 import { VideoNodeObserverService } from '@/content/player/videoObserver/VideoNodeObserver.service'
 
 const OCCLUSION_QUALITY_PRESETS: Record<

--- a/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.test.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MaskCompositor } from './MaskCompositor'
+import type { SegmentationResult } from './types'
+
+class FakeCtx {
+  filter = 'none'
+  filterAtDraw: string | null = null
+  clearRect = vi.fn()
+  drawImage = vi.fn(() => {
+    this.filterAtDraw = this.filter
+  })
+  putImageData = vi.fn()
+  createImageData = (w: number, h: number) => ({
+    data: new Uint8ClampedArray(w * h * 4),
+  })
+}
+
+class FakeCanvas {
+  width = 0
+  height = 0
+  readonly ctx = new FakeCtx()
+  getContext = () => this.ctx
+  toDataURL = vi.fn(() => 'data:image/png;base64,AAAA')
+}
+
+let canvases: FakeCanvas[]
+
+beforeEach(() => {
+  canvases = []
+  vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+    if (tag === 'canvas') {
+      const canvas = new FakeCanvas()
+      canvases.push(canvas)
+      return canvas as unknown as HTMLCanvasElement
+    }
+    throw new Error(`unexpected createElement(${tag})`)
+  }) as typeof document.createElement)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function makeResult(): SegmentationResult {
+  return {
+    category: new Uint8Array([0, 1, 1, 0]),
+    maskSize: { width: 2, height: 2 },
+  }
+}
+
+function makeVideo(
+  overrides: Partial<HTMLVideoElement> = {}
+): HTMLVideoElement {
+  return {
+    clientWidth: 100,
+    clientHeight: 100,
+    videoWidth: 100,
+    videoHeight: 100,
+    ...overrides,
+  } as HTMLVideoElement
+}
+
+describe('MaskCompositor', () => {
+  it('composes a mask into a PNG data URL', () => {
+    const compositor = new MaskCompositor(() => undefined)
+
+    const result = compositor.compose(makeResult(), makeVideo(), {
+      outputMaxSide: 64,
+      edgeSoftness: 0,
+    })
+
+    expect(result?.url).toBe('data:image/png;base64,AAAA')
+    expect(result?.mask.width).toBeGreaterThan(0)
+    const [maskCanvas, rawMaskCanvas] = canvases
+    expect(rawMaskCanvas.ctx.putImageData).toHaveBeenCalled()
+    expect(maskCanvas.ctx.drawImage).toHaveBeenCalled()
+  })
+
+  it('skips and logs when the video box has zero size', () => {
+    const log = vi.fn()
+    const compositor = new MaskCompositor(log)
+
+    const result = compositor.compose(
+      makeResult(),
+      makeVideo({ clientWidth: 0, clientHeight: 0 }),
+      { outputMaxSide: 64, edgeSoftness: 0 }
+    )
+
+    expect(result).toBeNull()
+    expect(log).toHaveBeenCalledWith('video box has zero size; skipping')
+  })
+
+  it('applies a blur filter when edge softness is set', () => {
+    const compositor = new MaskCompositor(() => undefined)
+
+    compositor.compose(makeResult(), makeVideo(), {
+      outputMaxSide: 64,
+      edgeSoftness: 4,
+    })
+
+    const maskCanvas = canvases[0]
+    expect(maskCanvas.ctx.filterAtDraw).toBe('blur(4px)')
+    // filter is reset to 'none' after the blurred draw.
+    expect(maskCanvas.ctx.filter).toBe('none')
+  })
+})

--- a/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.test.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.test.ts
@@ -70,7 +70,9 @@ describe('MaskCompositor', () => {
     })
 
     expect(result?.url).toBe('data:image/png;base64,AAAA')
-    expect(result?.mask.width).toBeGreaterThan(0)
+    // box 100x100 capped at outputMaxSide 64 => outputScale 0.64 => 64x64.
+    expect(result?.mask.width).toBe(64)
+    expect(result?.mask.height).toBe(64)
     const [maskCanvas, rawMaskCanvas] = canvases
     expect(rawMaskCanvas.ctx.putImageData).toHaveBeenCalled()
     expect(maskCanvas.ctx.drawImage).toHaveBeenCalled()

--- a/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.ts
@@ -1,4 +1,4 @@
-import { buildAlphaMask } from './maskGeometry'
+import { buildAlphaMask, type Mask } from './maskGeometry'
 import type { SegmentationResult } from './types'
 
 // The bundled selfie_segmenter's category mask marks the PERSON as category 0
@@ -12,12 +12,6 @@ function isPerson(value: number): boolean {
 export interface CompositeOptions {
   outputMaxSide: number
   edgeSoftness: number
-}
-
-export interface Mask {
-  data: Uint8ClampedArray
-  width: number
-  height: number
 }
 
 export interface CompositeResult {

--- a/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/MaskCompositor.ts
@@ -1,0 +1,99 @@
+import { buildAlphaMask } from './maskGeometry'
+import type { SegmentationResult } from './types'
+
+// The bundled selfie_segmenter's category mask marks the PERSON as category 0
+// and the background as non-zero (verified empirically against the shipped
+// model; inverted from some MediaPipe docs). Danmaku hide where the person is,
+// so person pixels become transparent (alpha 0) in the mask.
+function isPerson(value: number): boolean {
+  return value === 0
+}
+
+export interface CompositeOptions {
+  outputMaxSide: number
+  edgeSoftness: number
+}
+
+export interface Mask {
+  data: Uint8ClampedArray
+  width: number
+  height: number
+}
+
+export interface CompositeResult {
+  url: string
+  mask: Mask
+}
+
+/**
+ * Turns a segmentation result into an alpha-mask PNG data URL sized to the
+ * video's on-screen box: builds the mask (letterboxed via maskGeometry), softens
+ * its edges with a blur pass, and serializes it. Owns the reused canvases so the
+ * per-frame loop allocates nothing steady-state.
+ */
+export class MaskCompositor {
+  private readonly maskCanvas = document.createElement('canvas')
+  private readonly rawMaskCanvas = document.createElement('canvas')
+  private readonly maskCtx = this.maskCanvas.getContext('2d')
+  private readonly rawMaskCtx = this.rawMaskCanvas.getContext('2d')
+  private imageData?: ImageData
+
+  constructor(private readonly log: (message: string) => void) {}
+
+  compose(
+    result: SegmentationResult,
+    video: HTMLVideoElement,
+    options: CompositeOptions
+  ): CompositeResult | null {
+    const maskCtx = this.maskCtx
+    const rawMaskCtx = this.rawMaskCtx
+    if (!maskCtx || !rawMaskCtx) {
+      return null
+    }
+
+    const box = { width: video.clientWidth, height: video.clientHeight }
+    if (box.width === 0 || box.height === 0) {
+      this.log('video box has zero size; skipping')
+      return null
+    }
+    const content = {
+      width: video.videoWidth || box.width,
+      height: video.videoHeight || box.height,
+    }
+    const outputScale = Math.min(
+      1,
+      options.outputMaxSide / Math.max(box.width, box.height)
+    )
+
+    const mask = buildAlphaMask({
+      category: result.category,
+      maskSize: result.maskSize,
+      content,
+      box,
+      outputScale,
+      isPerson,
+    })
+
+    if (
+      this.maskCanvas.width !== mask.width ||
+      this.maskCanvas.height !== mask.height ||
+      !this.imageData
+    ) {
+      this.maskCanvas.width = mask.width
+      this.maskCanvas.height = mask.height
+      this.rawMaskCanvas.width = mask.width
+      this.rawMaskCanvas.height = mask.height
+      this.imageData = rawMaskCtx.createImageData(mask.width, mask.height)
+    }
+    this.imageData.data.set(mask.data)
+    rawMaskCtx.putImageData(this.imageData, 0, 0)
+
+    maskCtx.clearRect(0, 0, mask.width, mask.height)
+    maskCtx.filter =
+      options.edgeSoftness > 0 ? `blur(${options.edgeSoftness}px)` : 'none'
+    maskCtx.drawImage(this.rawMaskCanvas, 0, 0)
+    maskCtx.filter = 'none'
+
+    return { url: this.maskCanvas.toDataURL('image/png'), mask }
+  }
+}

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.test.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.test.ts
@@ -5,6 +5,7 @@ import { MockMaskProvider } from './MockMaskProvider'
 import type { IMaskProviderFactory } from './maskProviderFactory'
 import { OcclusionService } from './Occlusion.service'
 import type { OcclusionConfig, OcclusionStatus } from './Occlusion.types'
+import type { MaskProvider } from './types'
 
 const peopleModel = modelEntrySchema.parse({
   id: 'people',
@@ -12,6 +13,15 @@ const peopleModel = modelEntrySchema.parse({
   runtime: 'mediapipe',
   delivery: 'bundled',
   inputSize: 256,
+  requiresWebGpu: false,
+})
+
+const animeModel = modelEntrySchema.parse({
+  id: 'anime',
+  label: { en: 'Anime', zh: '动漫' },
+  runtime: 'mediapipe',
+  delivery: 'bundled',
+  inputSize: 512,
   requiresWebGpu: false,
 })
 
@@ -75,6 +85,30 @@ describe('OcclusionService stats', () => {
     expect(service.getStats().debugOverlay).toBe(true)
     service.setDebug(false)
     expect(service.getStats().debugOverlay).toBe(false)
+  })
+})
+
+describe('OcclusionService provider lifecycle', () => {
+  it('rebuilds the provider only when the model descriptor changes', () => {
+    const disposes: Array<() => void> = []
+    const spyFactory: IMaskProviderFactory = () => {
+      const dispose = vi.fn()
+      disposes.push(dispose)
+      return {
+        init: vi.fn().mockResolvedValue(undefined),
+        segment: vi.fn().mockResolvedValue(null),
+        dispose,
+      } as unknown as MaskProvider
+    }
+    const service = new OcclusionService(spyFactory, makeLogger())
+
+    service.configure(makeConfig({ descriptor: peopleModel }))
+    service.configure(makeConfig({ descriptor: peopleModel }))
+    expect(disposes).toHaveLength(1)
+
+    service.configure(makeConfig({ descriptor: animeModel }))
+    expect(disposes).toHaveLength(2)
+    expect(disposes[0]).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.test.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.test.ts
@@ -3,11 +3,8 @@ import type { ILogger } from '@/common/Logger'
 import { modelEntrySchema } from '@/common/models/schema'
 import { MockMaskProvider } from './MockMaskProvider'
 import type { IMaskProviderFactory } from './maskProviderFactory'
-import {
-  type OcclusionConfig,
-  OcclusionService,
-  type OcclusionStatus,
-} from './Occlusion.service'
+import { OcclusionService } from './Occlusion.service'
+import type { OcclusionConfig, OcclusionStatus } from './Occlusion.types'
 
 const peopleModel = modelEntrySchema.parse({
   id: 'people',

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
@@ -1,66 +1,24 @@
 import { inject, injectable } from 'inversify'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import type { ModelEntry } from '@/common/models/schema'
-import { CrossOriginCapture, isVideoOriginClean } from './crossOriginCapture'
-import { buildAlphaMask } from './maskGeometry'
+import { FrameSource } from './frameSource'
+import { MaskCompositor } from './MaskCompositor'
 import {
   type IMaskProviderFactory,
   MaskProviderFactory,
 } from './maskProviderFactory'
+import type {
+  OcclusionConfig,
+  OcclusionStats,
+  OcclusionStatus,
+  OcclusionStatusReason,
+} from './Occlusion.types'
+import { OcclusionDebugView } from './OcclusionDebugView'
 import type { MaskProvider } from './types'
-
-// Distinct reasons because the user-facing remedy differs (taint vs webgpu vs
-// init); the rest are surfaced the same way.
-export type OcclusionStatusReason =
-  | 'downloading'
-  | 'init'
-  | 'taint'
-  | 'webgpu'
-  | 'segment'
-  | 'unavailable'
-
-export interface OcclusionStatus {
-  reason: OcclusionStatusReason
-  message: string
-}
-
-export interface OcclusionStats {
-  running: boolean
-  fps: number | null
-  lastError: string | null
-  debugOverlay: boolean
-}
-
-export interface OcclusionConfig {
-  descriptor: ModelEntry
-  captureSize: number
-  // Capture at the video's aspect ratio (long side = captureSize) instead of a
-  // square. The anime model is distortion-sensitive; the people segmenter is
-  // robust and uses the cheaper square capture.
-  capturePreserveAspect: boolean
-  minIntervalMs: number
-  outputMaxSide: number
-  threshold: number
-  edgeSoftness: number
-  debug: boolean
-  applyMask: (url?: string) => void
-  // Classified failure gates a higher layer (settings/toast) surfaces; also
-  // tracked as lastError in stats.
-  onStatus?: (status: OcclusionStatus) => void
-}
 
 const DEFAULT_CAPTURE_SIZE = 256
 const DEFAULT_MIN_INTERVAL_MS = 80
 const DEFAULT_OUTPUT_MAX_SIDE = 320
-const DEBUG_Z_INDEX = '2147483646'
-
-// The bundled selfie_segmenter's category mask marks the PERSON as category 0
-// and the background as non-zero (verified empirically against the shipped
-// model; inverted from some MediaPipe docs). Danmaku hide where the person is,
-// so person pixels become transparent (alpha 0) in the mask.
-function isPerson(value: number): boolean {
-  return value === 0
-}
 
 function modelKey(descriptor: ModelEntry): string {
   // Every load-bearing field (inputSize, preprocessing, capture, source) must
@@ -71,8 +29,9 @@ function modelKey(descriptor: ModelEntry): string {
 /**
  * Drives a per-frame person-mask loop for one video and applies the resulting
  * alpha mask (as a data URL) to the danmaku overlay so comments render behind
- * people. Capture and mask application live here (co-located with the video and
- * overlay); inference is delegated to a MaskProvider created per model.
+ * people. A FrameSource resolves the readable element, a MaskProvider runs
+ * inference, and a MaskCompositor turns the result into the applied mask; this
+ * service is the lifecycle and per-frame coordinator.
  */
 @injectable('Singleton')
 export class OcclusionService {
@@ -80,11 +39,9 @@ export class OcclusionService {
   private running = false
   private busy = false
   private lastSegmentTs = 0
-  private readonly maskCanvas = document.createElement('canvas')
-  private readonly rawMaskCanvas = document.createElement('canvas')
-  private readonly maskCtx: CanvasRenderingContext2D | null
-  private readonly rawMaskCtx: CanvasRenderingContext2D | null
   private readonly logger: ILogger
+  private readonly frameSource: FrameSource
+  private readonly compositor: MaskCompositor
   private provider?: MaskProvider
   // Identity of the model behind the live provider. Includes the download source
   // so a manifest refresh that re-points the same id rebuilds the provider.
@@ -101,27 +58,20 @@ export class OcclusionService {
   private debug = false
   private debugView?: OcclusionDebugView
   private appliedOnce = false
-  private imageData?: ImageData
   private callbackId: number | null = null
   private fps: number | null = null
   private lastError: string | null = null
   private lastStatusReason?: OcclusionStatusReason
   private lastAppliedTs = 0
-  // Element to read frames from: the live video, or a clone when it's tainted.
-  private captureEl: HTMLVideoElement | null = null
-  private crossOriginCapture: CrossOriginCapture | null = null
-  private captureResolved = false
-  // src the capture was resolved against; a change forces a re-resolve.
-  private resolvedSrc: string | null = null
 
   constructor(
     @inject(MaskProviderFactory)
     private readonly createProvider: IMaskProviderFactory,
     @inject(LoggerSymbol) logger: ILogger
   ) {
-    this.maskCtx = this.maskCanvas.getContext('2d')
-    this.rawMaskCtx = this.rawMaskCanvas.getContext('2d')
     this.logger = logger.sub('[OcclusionService]')
+    this.frameSource = new FrameSource((message) => this.log(message))
+    this.compositor = new MaskCompositor((message) => this.log(message))
   }
 
   configure(config: OcclusionConfig): void {
@@ -219,11 +169,7 @@ export class OcclusionService {
     this.appliedOnce = false
     this.fps = null
     this.lastAppliedTs = 0
-    this.crossOriginCapture?.dispose()
-    this.crossOriginCapture = null
-    this.captureEl = null
-    this.captureResolved = false
-    this.resolvedSrc = null
+    this.frameSource.reset()
     this.applyMask(undefined)
     this.debugView?.remove()
     this.debugView = undefined
@@ -322,35 +268,91 @@ export class OcclusionService {
   }
 
   private async segmentAndApply(video: HTMLVideoElement): Promise<void> {
-    const maskCtx = this.maskCtx
-    const rawMaskCtx = this.rawMaskCtx
     const provider = this.provider
-    if (!maskCtx || !rawMaskCtx || !provider) {
+    if (!provider) {
       return
     }
+    const isStale = () => !this.running || this.video !== video
 
-    // start() no-ops on an unchanged element, so catch same-element src swaps
-    // here (the clone is bound to the old URL).
-    if (this.captureResolved && this.resolvedSrc !== video.currentSrc) {
-      this.crossOriginCapture?.dispose()
-      this.crossOriginCapture = null
-      this.captureEl = null
-      this.captureResolved = false
-    }
-
-    if (!this.captureResolved) {
-      await this.resolveCaptureSource(video)
-      if (!this.running || this.video !== video) {
-        return
-      }
-    }
-    const source = this.captureEl
-    if (!source) {
+    const source = await this.frameSource.read(video, isStale)
+    if (source === 'taint') {
+      this.disableForTaint()
       return
     }
-    this.crossOriginCapture?.sync()
+    if (!source || isStale()) {
+      return
+    }
 
     const t0 = performance.now()
+    const frame = await this.captureFrame(source, video)
+    if (frame === 'taint') {
+      this.disableForTaint()
+      return
+    }
+    if (!frame) {
+      return
+    }
+    if (isStale()) {
+      frame.close()
+      return
+    }
+
+    const result = await provider.segment(frame, { threshold: this.threshold })
+    if (!result) {
+      this.status(
+        'segment',
+        'segment returned no result (provider failed or timed out)'
+      )
+      return
+    }
+    if (isStale()) {
+      return
+    }
+
+    const composed = this.compositor.compose(result, video, {
+      outputMaxSide: this.outputMaxSide,
+      edgeSoftness: this.edgeSoftness,
+    })
+    if (!composed || isStale()) {
+      return
+    }
+
+    this.applyMask(composed.url)
+    this.lastError = null
+    this.lastStatusReason = undefined
+    const appliedAt = performance.now()
+    if (this.lastAppliedTs > 0) {
+      const dt = appliedAt - this.lastAppliedTs
+      const instantFps = dt > 0 ? 1000 / dt : 0
+      this.fps =
+        this.fps === null ? instantFps : this.fps * 0.7 + instantFps * 0.3
+    }
+    this.lastAppliedTs = appliedAt
+    if (!this.appliedOnce) {
+      this.appliedOnce = true
+      const { width, height } = composed.mask
+      this.log(
+        `first mask applied (${width}x${height}) in ${Math.round(appliedAt - t0)}ms`
+      )
+    }
+
+    if (this.debug) {
+      this.renderDebug(
+        video,
+        composed.mask,
+        result.maskSize,
+        performance.now() - t0
+      )
+    }
+  }
+
+  // createImageBitmap resizes on the GPU during decode, avoiding a main-thread
+  // canvas draw. Returns 'taint' when the source is unreadable (some engines
+  // throw here even though the upfront probe usually catches it first).
+  private async captureFrame(
+    source: HTMLVideoElement,
+    video: HTMLVideoElement
+  ): Promise<ImageBitmap | 'taint' | null> {
     let resizeWidth = this.captureSize
     let resizeHeight = this.captureSize
     if (
@@ -365,135 +367,19 @@ export class OcclusionService {
         resizeWidth = Math.max(1, Math.round(this.captureSize * aspect))
       }
     }
-    let frame: ImageBitmap
     try {
-      // Resize on the GPU during decode; avoids a main-thread canvas draw.
-      frame = await createImageBitmap(source, {
+      return await createImageBitmap(source, {
         resizeWidth,
         resizeHeight,
         resizeQuality: 'medium',
       })
     } catch (e) {
-      // Fallback: some engines do throw here; the upfront probe usually catches
-      // it first.
       if (e instanceof DOMException && e.name === 'SecurityError') {
-        this.disableForTaint()
-        return
+        return 'taint'
       }
       this.log(`capture failed: ${e instanceof Error ? e.message : e}`)
-      return
+      return null
     }
-
-    if (!this.running || this.video !== video) {
-      frame.close()
-      return
-    }
-    const result = await provider.segment(frame, {
-      threshold: this.threshold,
-    })
-    if (!result) {
-      this.status(
-        'segment',
-        'segment returned no result (provider failed or timed out)'
-      )
-      return
-    }
-    if (!this.running || this.video !== video) {
-      return
-    }
-
-    const box = { width: video.clientWidth, height: video.clientHeight }
-    if (box.width === 0 || box.height === 0) {
-      this.log('video box has zero size; skipping')
-      return
-    }
-    const content = {
-      width: video.videoWidth || box.width,
-      height: video.videoHeight || box.height,
-    }
-    const outputScale = Math.min(
-      1,
-      this.outputMaxSide / Math.max(box.width, box.height)
-    )
-
-    const mask = buildAlphaMask({
-      category: result.category,
-      maskSize: result.maskSize,
-      content,
-      box,
-      outputScale,
-      isPerson,
-    })
-
-    if (
-      this.maskCanvas.width !== mask.width ||
-      this.maskCanvas.height !== mask.height ||
-      !this.imageData
-    ) {
-      this.maskCanvas.width = mask.width
-      this.maskCanvas.height = mask.height
-      this.rawMaskCanvas.width = mask.width
-      this.rawMaskCanvas.height = mask.height
-      this.imageData = rawMaskCtx.createImageData(mask.width, mask.height)
-    }
-    this.imageData.data.set(mask.data)
-    rawMaskCtx.putImageData(this.imageData, 0, 0)
-
-    maskCtx.clearRect(0, 0, mask.width, mask.height)
-    maskCtx.filter =
-      this.edgeSoftness > 0 ? `blur(${this.edgeSoftness}px)` : 'none'
-    maskCtx.drawImage(this.rawMaskCanvas, 0, 0)
-    maskCtx.filter = 'none'
-
-    if (!this.running || this.video !== video) {
-      return
-    }
-    this.applyMask(this.maskCanvas.toDataURL('image/png'))
-    this.lastError = null
-    this.lastStatusReason = undefined
-    const appliedAt = performance.now()
-    if (this.lastAppliedTs > 0) {
-      const dt = appliedAt - this.lastAppliedTs
-      const instantFps = dt > 0 ? 1000 / dt : 0
-      this.fps =
-        this.fps === null ? instantFps : this.fps * 0.7 + instantFps * 0.3
-    }
-    this.lastAppliedTs = appliedAt
-    if (!this.appliedOnce) {
-      this.appliedOnce = true
-      this.log(
-        `first mask applied (${mask.width}x${mask.height}) in ${Math.round(appliedAt - t0)}ms`
-      )
-    }
-
-    if (this.debug) {
-      this.renderDebug(video, mask, result.maskSize, performance.now() - t0)
-    }
-  }
-
-  // Resolve the capture element once per video: live if clean, else a clone for
-  // http(s) sources, else give up. Runs under onFrame's readyState >= 2 gate.
-  private async resolveCaptureSource(video: HTMLVideoElement): Promise<void> {
-    this.captureResolved = true
-    this.resolvedSrc = video.currentSrc
-    if (isVideoOriginClean(video)) {
-      this.captureEl = video
-      return
-    }
-    const recovery = new CrossOriginCapture(video)
-    const clone = await recovery.setup()
-    if (!this.running || this.video !== video) {
-      recovery.dispose()
-      return
-    }
-    if (clone && isVideoOriginClean(clone)) {
-      this.crossOriginCapture = recovery
-      this.captureEl = clone
-      this.log('cross-origin video recovered via CORS-bypassed clone')
-      return
-    }
-    recovery.dispose()
-    this.disableForTaint()
   }
 
   private disableForTaint(): void {
@@ -528,77 +414,5 @@ export class OcclusionService {
       cycleMs,
       personFraction,
     })
-  }
-}
-
-interface DebugUpdate {
-  rect: DOMRect
-  mask: { data: Uint8ClampedArray; width: number; height: number }
-  sourceSize: { width: number; height: number }
-  cycleMs: number
-  personFraction: number
-}
-
-/**
- * Visible debug overlay (debug mode only): tints the detected person region over
- * the video and prints timing / coverage so the segmentation can be seen and
- * profiled. Owns its own DOM in the host page; removed on stop / debug-off.
- */
-class OcclusionDebugView {
-  private readonly root = document.createElement('div')
-  private readonly canvas = document.createElement('canvas')
-  private readonly label = document.createElement('div')
-  private readonly ctx: CanvasRenderingContext2D | null
-
-  constructor() {
-    this.root.style.cssText = `position:fixed;z-index:${DEBUG_Z_INDEX};pointer-events:none;outline:1px solid rgba(0,255,128,0.6);`
-    this.canvas.style.cssText = 'width:100%;height:100%;display:block;'
-    this.label.style.cssText =
-      'position:absolute;top:0;left:0;padding:2px 6px;font:11px monospace;color:#0f8;background:rgba(0,0,0,0.6);white-space:pre;'
-    this.root.appendChild(this.canvas)
-    this.root.appendChild(this.label)
-    document.body.appendChild(this.root)
-    this.ctx = this.canvas.getContext('2d')
-  }
-
-  update(u: DebugUpdate): void {
-    this.root.style.left = `${u.rect.left}px`
-    this.root.style.top = `${u.rect.top}px`
-    this.root.style.width = `${u.rect.width}px`
-    this.root.style.height = `${u.rect.height}px`
-
-    const ctx = this.ctx
-    if (ctx) {
-      if (
-        this.canvas.width !== u.mask.width ||
-        this.canvas.height !== u.mask.height
-      ) {
-        this.canvas.width = u.mask.width
-        this.canvas.height = u.mask.height
-      }
-      const tint = ctx.createImageData(u.mask.width, u.mask.height)
-      for (let i = 0; i < u.mask.data.length; i += 4) {
-        // mask alpha 0 => person; tint it green, leave background clear.
-        const personHere = u.mask.data[i + 3] === 0
-        tint.data[i] = 0
-        tint.data[i + 1] = 255
-        tint.data[i + 2] = 128
-        tint.data[i + 3] = personHere ? 110 : 0
-      }
-      ctx.putImageData(tint, 0, 0)
-    }
-
-    const fps = u.cycleMs > 0 ? 1000 / u.cycleMs : 0
-    const coverage = `${Math.round(u.personFraction * 100)}%`
-    const detected = u.personFraction < 0.005 ? ' (no person detected)' : ''
-    this.label.textContent = `occlusion ${u.cycleMs.toFixed(0)}ms ~${fps.toFixed(0)}fps\nsrc ${u.sourceSize.width}x${u.sourceSize.height} person ${coverage}${detected}`
-  }
-
-  showDisabled(message: string): void {
-    this.label.textContent = message
-  }
-
-  remove(): void {
-    this.root.remove()
   }
 }

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.service.ts
@@ -3,6 +3,7 @@ import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import type { ModelEntry } from '@/common/models/schema'
 import { FrameSource } from './frameSource'
 import { MaskCompositor } from './MaskCompositor'
+import type { Mask } from './maskGeometry'
 import {
   type IMaskProviderFactory,
   MaskProviderFactory,
@@ -392,7 +393,7 @@ export class OcclusionService {
 
   private renderDebug(
     video: HTMLVideoElement,
-    mask: { data: Uint8ClampedArray; width: number; height: number },
+    mask: Mask,
     sourceSize: { width: number; height: number },
     cycleMs: number
   ): void {

--- a/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.types.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/Occlusion.types.ts
@@ -1,0 +1,41 @@
+import type { ModelEntry } from '@/common/models/schema'
+
+// Distinct reasons because the user-facing remedy differs (taint vs webgpu vs
+// init); the rest are surfaced the same way.
+export type OcclusionStatusReason =
+  | 'downloading'
+  | 'init'
+  | 'taint'
+  | 'webgpu'
+  | 'segment'
+  | 'unavailable'
+
+export interface OcclusionStatus {
+  reason: OcclusionStatusReason
+  message: string
+}
+
+export interface OcclusionStats {
+  running: boolean
+  fps: number | null
+  lastError: string | null
+  debugOverlay: boolean
+}
+
+export interface OcclusionConfig {
+  descriptor: ModelEntry
+  captureSize: number
+  // Capture at the video's aspect ratio (long side = captureSize) instead of a
+  // square. The anime model is distortion-sensitive; the people segmenter is
+  // robust and uses the cheaper square capture.
+  capturePreserveAspect: boolean
+  minIntervalMs: number
+  outputMaxSide: number
+  threshold: number
+  edgeSoftness: number
+  debug: boolean
+  applyMask: (url?: string) => void
+  // Classified failure gates a higher layer (settings/toast) surfaces; also
+  // tracked as lastError in stats.
+  onStatus?: (status: OcclusionStatus) => void
+}

--- a/packages/danmaku-anywhere/src/content/player/occlusion/OcclusionDebugView.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/OcclusionDebugView.ts
@@ -20,6 +20,7 @@ export class OcclusionDebugView {
   private readonly canvas = document.createElement('canvas')
   private readonly label = document.createElement('div')
   private readonly ctx: CanvasRenderingContext2D | null
+  private imageData?: ImageData
 
   constructor() {
     this.root.style.cssText = `position:fixed;z-index:${DEBUG_Z_INDEX};pointer-events:none;outline:1px solid rgba(0,255,128,0.6);`
@@ -42,12 +43,14 @@ export class OcclusionDebugView {
     if (ctx) {
       if (
         this.canvas.width !== u.mask.width ||
-        this.canvas.height !== u.mask.height
+        this.canvas.height !== u.mask.height ||
+        !this.imageData
       ) {
         this.canvas.width = u.mask.width
         this.canvas.height = u.mask.height
+        this.imageData = ctx.createImageData(u.mask.width, u.mask.height)
       }
-      const tint = ctx.createImageData(u.mask.width, u.mask.height)
+      const tint = this.imageData
       for (let i = 0; i < u.mask.data.length; i += 4) {
         // mask alpha 0 => person; tint it green, leave background clear.
         const personHere = u.mask.data[i + 3] === 0

--- a/packages/danmaku-anywhere/src/content/player/occlusion/OcclusionDebugView.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/OcclusionDebugView.ts
@@ -1,0 +1,73 @@
+const DEBUG_Z_INDEX = '2147483646'
+
+export interface DebugUpdate {
+  rect: DOMRect
+  mask: { data: Uint8ClampedArray; width: number; height: number }
+  sourceSize: { width: number; height: number }
+  cycleMs: number
+  personFraction: number
+}
+
+/**
+ * Visible debug overlay (debug mode only): tints the detected person region over
+ * the video and prints timing / coverage so the segmentation can be seen and
+ * profiled. Owns its own DOM in the host page; removed on stop / debug-off.
+ */
+export class OcclusionDebugView {
+  private readonly root = document.createElement('div')
+  private readonly canvas = document.createElement('canvas')
+  private readonly label = document.createElement('div')
+  private readonly ctx: CanvasRenderingContext2D | null
+
+  constructor() {
+    this.root.style.cssText = `position:fixed;z-index:${DEBUG_Z_INDEX};pointer-events:none;outline:1px solid rgba(0,255,128,0.6);`
+    this.canvas.style.cssText = 'width:100%;height:100%;display:block;'
+    this.label.style.cssText =
+      'position:absolute;top:0;left:0;padding:2px 6px;font:11px monospace;color:#0f8;background:rgba(0,0,0,0.6);white-space:pre;'
+    this.root.appendChild(this.canvas)
+    this.root.appendChild(this.label)
+    document.body.appendChild(this.root)
+    this.ctx = this.canvas.getContext('2d')
+  }
+
+  update(u: DebugUpdate): void {
+    this.root.style.left = `${u.rect.left}px`
+    this.root.style.top = `${u.rect.top}px`
+    this.root.style.width = `${u.rect.width}px`
+    this.root.style.height = `${u.rect.height}px`
+
+    const ctx = this.ctx
+    if (ctx) {
+      if (
+        this.canvas.width !== u.mask.width ||
+        this.canvas.height !== u.mask.height
+      ) {
+        this.canvas.width = u.mask.width
+        this.canvas.height = u.mask.height
+      }
+      const tint = ctx.createImageData(u.mask.width, u.mask.height)
+      for (let i = 0; i < u.mask.data.length; i += 4) {
+        // mask alpha 0 => person; tint it green, leave background clear.
+        const personHere = u.mask.data[i + 3] === 0
+        tint.data[i] = 0
+        tint.data[i + 1] = 255
+        tint.data[i + 2] = 128
+        tint.data[i + 3] = personHere ? 110 : 0
+      }
+      ctx.putImageData(tint, 0, 0)
+    }
+
+    const fps = u.cycleMs > 0 ? 1000 / u.cycleMs : 0
+    const coverage = `${Math.round(u.personFraction * 100)}%`
+    const detected = u.personFraction < 0.005 ? ' (no person detected)' : ''
+    this.label.textContent = `occlusion ${u.cycleMs.toFixed(0)}ms ~${fps.toFixed(0)}fps\nsrc ${u.sourceSize.width}x${u.sourceSize.height} person ${coverage}${detected}`
+  }
+
+  showDisabled(message: string): void {
+    this.label.textContent = message
+  }
+
+  remove(): void {
+    this.root.remove()
+  }
+}

--- a/packages/danmaku-anywhere/src/content/player/occlusion/OcclusionDebugView.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/OcclusionDebugView.ts
@@ -1,8 +1,10 @@
+import type { Mask } from './maskGeometry'
+
 const DEBUG_Z_INDEX = '2147483646'
 
 export interface DebugUpdate {
   rect: DOMRect
-  mask: { data: Uint8ClampedArray; width: number; height: number }
+  mask: Mask
   sourceSize: { width: number; height: number }
   cycleMs: number
   personFraction: number

--- a/packages/danmaku-anywhere/src/content/player/occlusion/frameSource.test.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/frameSource.test.ts
@@ -20,7 +20,12 @@ vi.mock('@/common/rpcClient/background/client', () => ({
   },
 }))
 
-import { CrossOriginCapture, isVideoOriginClean } from './crossOriginCapture'
+import {
+  type CloneCapture,
+  CrossOriginCapture,
+  FrameSource,
+  isVideoOriginClean,
+} from './frameSource'
 
 type Listener = () => void
 
@@ -313,5 +318,137 @@ describe('CrossOriginCapture.dispose', () => {
 
     expect(clone.remove).toHaveBeenCalledTimes(1)
     expect(removeCorsRule).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('FrameSource', () => {
+  const notStale = () => false
+
+  function fakeClone(): { capture: CloneCapture; cloneEl: HTMLVideoElement } {
+    const cloneEl = asVideo(makeOriginal())
+    const capture: CloneCapture = {
+      setup: vi.fn().mockResolvedValue(cloneEl),
+      sync: vi.fn(),
+      dispose: vi.fn(),
+    }
+    return { capture, cloneEl }
+  }
+
+  function makeSource(deps: {
+    isOriginClean: (v: HTMLVideoElement) => boolean
+    createCapture: () => CloneCapture
+  }): FrameSource {
+    return new FrameSource(() => undefined, {
+      isOriginClean: deps.isOriginClean,
+      createCapture: deps.createCapture,
+    })
+  }
+
+  it('returns the live element when the origin is clean, without a clone', async () => {
+    const video = asVideo(makeOriginal())
+    const createCapture = vi.fn()
+    const source = makeSource({ isOriginClean: () => true, createCapture })
+
+    expect(await source.read(video, notStale)).toBe(video)
+    expect(createCapture).not.toHaveBeenCalled()
+  })
+
+  it('recovers a tainted video via a clean clone', async () => {
+    const video = asVideo(makeOriginal())
+    const { capture, cloneEl } = fakeClone()
+    const source = makeSource({
+      isOriginClean: (v) => v === cloneEl,
+      createCapture: () => capture,
+    })
+
+    expect(await source.read(video, notStale)).toBe(cloneEl)
+    expect(capture.sync).toHaveBeenCalled()
+  })
+
+  it('reports taint and disposes the clone when recovery is not readable', async () => {
+    const video = asVideo(makeOriginal())
+    const { capture } = fakeClone()
+    const source = makeSource({
+      isOriginClean: () => false,
+      createCapture: () => capture,
+    })
+
+    expect(await source.read(video, notStale)).toBe('taint')
+    expect(capture.dispose).toHaveBeenCalled()
+  })
+
+  it('reports taint when clone setup yields nothing', async () => {
+    const video = asVideo(makeOriginal())
+    const capture: CloneCapture = {
+      setup: vi.fn().mockResolvedValue(null),
+      sync: vi.fn(),
+      dispose: vi.fn(),
+    }
+    const source = makeSource({
+      isOriginClean: () => false,
+      createCapture: () => capture,
+    })
+
+    expect(await source.read(video, notStale)).toBe('taint')
+  })
+
+  it('caches the resolved element and syncs the clone on each read', async () => {
+    const video = asVideo(makeOriginal())
+    const { capture, cloneEl } = fakeClone()
+    const createCapture = vi.fn(() => capture)
+    const source = makeSource({
+      isOriginClean: (v) => v === cloneEl,
+      createCapture,
+    })
+
+    await source.read(video, notStale)
+    await source.read(video, notStale)
+
+    expect(createCapture).toHaveBeenCalledTimes(1)
+    expect(capture.sync).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-resolves and disposes the old clone when the src changes', async () => {
+    const original = makeOriginal({ currentSrc: 'http://a/v.webm' })
+    const video = asVideo(original)
+    const first = fakeClone()
+    const second = fakeClone()
+    const captures = [first.capture, second.capture]
+    const clones = [first.cloneEl, second.cloneEl]
+    const source = makeSource({
+      isOriginClean: (v) => clones.includes(v),
+      createCapture: () => captures.shift() as CloneCapture,
+    })
+
+    await source.read(video, notStale)
+    original.currentSrc = 'http://b/v.webm'
+    expect(await source.read(video, notStale)).toBe(second.cloneEl)
+    expect(first.capture.dispose).toHaveBeenCalled()
+  })
+
+  it('aborts and disposes the clone when the read goes stale mid-setup', async () => {
+    const video = asVideo(makeOriginal())
+    const { capture } = fakeClone()
+    const source = makeSource({
+      isOriginClean: () => false,
+      createCapture: () => capture,
+    })
+
+    expect(await source.read(video, () => true)).toBeNull()
+    expect(capture.dispose).toHaveBeenCalled()
+  })
+
+  it('disposes the live clone on reset', async () => {
+    const video = asVideo(makeOriginal())
+    const { capture, cloneEl } = fakeClone()
+    const source = makeSource({
+      isOriginClean: (v) => v === cloneEl,
+      createCapture: () => capture,
+    })
+
+    await source.read(video, notStale)
+    source.reset()
+
+    expect(capture.dispose).toHaveBeenCalled()
   })
 })

--- a/packages/danmaku-anywhere/src/content/player/occlusion/frameSource.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/frameSource.ts
@@ -173,3 +173,100 @@ export class CrossOriginCapture {
     }
   }
 }
+
+export interface CloneCapture {
+  setup(): Promise<HTMLVideoElement | null>
+  sync(): void
+  dispose(): void
+}
+
+export interface FrameSourceDeps {
+  isOriginClean: (video: HTMLVideoElement) => boolean
+  createCapture: (video: HTMLVideoElement) => CloneCapture
+}
+
+const defaultDeps: FrameSourceDeps = {
+  isOriginClean: isVideoOriginClean,
+  createCapture: (video) => new CrossOriginCapture(video),
+}
+
+// 'taint' = the video is unreadable and recovery failed; the caller should
+// disable. null = nothing to capture yet (still resolving or the loop moved on).
+export type ReadResult = HTMLVideoElement | 'taint' | null
+
+/**
+ * Answers "what element do I read frames from, and is it readable?" for one
+ * video. Probes the live element; on a cross-origin taint it falls back to a
+ * CORS-bypassed clone. The result is cached until the video's src changes or the
+ * source is reset. The probe and clone are injectable so the resolution logic is
+ * testable without a DOM.
+ */
+export class FrameSource {
+  private capture: CloneCapture | null = null
+  private captureEl: HTMLVideoElement | null = null
+  private resolved = false
+  // src the capture was resolved against; a change forces a re-resolve.
+  private resolvedSrc: string | null = null
+
+  constructor(
+    private readonly log: (message: string) => void,
+    private readonly deps: FrameSourceDeps = defaultDeps
+  ) {}
+
+  // isStale lets the caller abort a resolve whose async clone setup outlived the
+  // capture loop (stopped or switched video), so a late clone isn't leaked.
+  async read(
+    video: HTMLVideoElement,
+    isStale: () => boolean
+  ): Promise<ReadResult> {
+    if (this.resolved && this.resolvedSrc !== video.currentSrc) {
+      this.reset()
+    }
+    if (!this.resolved) {
+      const outcome = await this.resolve(video, isStale)
+      if (outcome !== 'ok') {
+        return outcome === 'taint' ? 'taint' : null
+      }
+    }
+    const source = this.captureEl
+    if (!source) {
+      return null
+    }
+    this.capture?.sync()
+    return source
+  }
+
+  reset(): void {
+    this.capture?.dispose()
+    this.capture = null
+    this.captureEl = null
+    this.resolved = false
+    this.resolvedSrc = null
+  }
+
+  private async resolve(
+    video: HTMLVideoElement,
+    isStale: () => boolean
+  ): Promise<'ok' | 'taint' | 'aborted'> {
+    this.resolved = true
+    this.resolvedSrc = video.currentSrc
+    if (this.deps.isOriginClean(video)) {
+      this.captureEl = video
+      return 'ok'
+    }
+    const recovery = this.deps.createCapture(video)
+    const clone = await recovery.setup()
+    if (isStale()) {
+      recovery.dispose()
+      return 'aborted'
+    }
+    if (clone && this.deps.isOriginClean(clone)) {
+      this.capture = recovery
+      this.captureEl = clone
+      this.log('cross-origin video recovered via CORS-bypassed clone')
+      return 'ok'
+    }
+    recovery.dispose()
+    return 'taint'
+  }
+}

--- a/packages/danmaku-anywhere/src/content/player/occlusion/maskGeometry.ts
+++ b/packages/danmaku-anywhere/src/content/player/occlusion/maskGeometry.ts
@@ -2,6 +2,8 @@ export type Size = { width: number; height: number }
 
 export type Rect = { x: number; y: number; width: number; height: number }
 
+export type Mask = { data: Uint8ClampedArray; width: number; height: number }
+
 export function computeContainRect(content: Size, box: Size): Rect {
   const contentAspect = content.width / content.height
   const boxAspect = box.width / box.height
@@ -36,7 +38,7 @@ export function buildAlphaMask(opts: {
   // The decoded frame's native size, used for object-fit:contain letterboxing.
   // Falls back to maskSize when the segmenter saw the full (un-letterboxed) frame.
   content?: Size
-}): { data: Uint8ClampedArray; width: number; height: number } {
+}): Mask {
   const { category, maskSize, box, isPerson } = opts
   const outputScale = opts.outputScale ?? 1
 


### PR DESCRIPTION
## Summary
- Behavior-preserving decomposition of the ~600-line `Occlusion.service.ts` into a thin lifecycle + per-frame coordinator plus cohesive, testable units.
- **FrameSource** (`frameSource.ts`) owns "what element do I read frames from, and is it readable?": the origin-clean probe, the cross-origin clone recovery, and src-change invalidation. The probe and clone factory sit behind an injectable seam (`FrameSourceDeps`) so the resolution logic is unit-testable without a DOM. `crossOriginCapture.ts` is folded in here.
- **MaskCompositor** (`MaskCompositor.ts`) owns the geometry + canvas + blur + serialize half: turns a segmentation result into the applied PNG data URL, reusing `maskGeometry`.
- **OcclusionDebugView** and the status/config types move to their own files (`OcclusionDebugView.ts`, `Occlusion.types.ts`); a single `Mask` type is shared from `maskGeometry`.
- `segmentAndApply` is now a readable pipeline: `frameSource.read -> captureFrame -> provider.segment -> compositor.compose -> apply/stats`.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere lint`
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` (new: `FrameSource` suite + `MaskCompositor.test.ts` + a provider-lifecycle test in `Occlusion.service.test.ts`; the prior `crossOriginCapture` tests carry over to `frameSource.test.ts`)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` covering `e2e/specs/integration/occlusion.spec.ts`, `occlusion-cross-origin.spec.ts`, `occlusion-cache-scope.spec.ts`, `occlusion-models.spec.ts` (all 9 pass locally)

## Notes
- No functional change. Capture-source resolution, taint handling, the rVFC loop, fps/stats, status classification, and debug overlay all preserve their original semantics and guard ordering (verified line-by-line against the deleted code).
- `createImageBitmap` frame preparation deliberately stays in the service (`captureFrame`): the FrameSource seam returns the readable element, not a bitmap.
- A whole-feature review surfaced pre-existing issues outside this refactor's scope (DNR CORS-rule authorization/leak hardening, and a few e2e-only test gaps); these are noted for follow-up tasks rather than addressed here to keep the refactor behavior-preserving.