### PR TITLE
(extension) bump dango to 0.5.0: allow local origins + manifest localization [DA-604]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -12,7 +12,8 @@ import { applyProfile } from '../../setup/profile'
  * and the built-in Bilibili provider, asserting the schema-driven fields show,
  * a save toast appears, and the edited values land in stored configValues.
  * Also asserts the schema's `required` constraint blocks saving an empty
- * auth header until it is filled.
+ * auth header until it is filled. Field titles localize with the UI language,
+ * so they are matched against both the English source and the zh override.
  */
 
 const NAV_URL = /api\.bilibili\.com\/x\/web-interface\/nav/
@@ -41,11 +42,14 @@ test('renders configSchema fields and saves a custom DanDanPlay server', async (
   const popup = await Popup.open(page, extensionId, '/providers')
   await popup.providers.edit('My DDP Server')
 
-  await popup.providers.expectFieldVisible('Base URL')
-  await popup.providers.expectFieldVisible('Chinese conversion')
+  await popup.providers.expectFieldVisible(/Base URL|基础地址/)
+  await popup.providers.expectFieldVisible(/Chinese conversion|中文转换/)
 
-  await popup.providers.fillField('Base URL', 'https://compat.example.invalid')
-  await popup.providers.selectOption('Chinese conversion', '2')
+  await popup.providers.fillField(
+    /Base URL|基础地址/,
+    'https://compat.example.invalid'
+  )
+  await popup.providers.selectOption(/Chinese conversion|中文转换/, '2')
   await popup.providers.save()
 
   await popup.toast.expectSuccess(/Provider updated|弹幕源已更新/)
@@ -69,13 +73,13 @@ test('enforces the schema required constraint on auth headers', async ({
   await popup.providers.addArrayItem()
   await popup.providers.save()
 
-  await expect(popup.providers.field('Header name')).toHaveAttribute(
+  await expect(popup.providers.field(/Header name|请求头名称/)).toHaveAttribute(
     'aria-invalid',
     'true'
   )
 
-  await popup.providers.fillField('Header name', 'X-Token')
-  await popup.providers.fillField('Value', 'secret')
+  await popup.providers.fillField(/Header name|请求头名称/, 'X-Token')
+  await popup.providers.fillField(/Value|值/, 'secret')
   await popup.providers.save()
 
   await popup.toast.expectSuccess(/Provider updated|弹幕源已更新/)
@@ -108,11 +112,11 @@ test('edits the built-in Bilibili provider via the generic form', async ({
   const popup = await Popup.open(page, extensionId, '/providers')
   await popup.providers.edit(/Bilibili|B站/)
 
-  await popup.providers.expectFieldVisible('Danmaku format')
+  await popup.providers.expectFieldVisible(/Danmaku format|弹幕格式/)
   await expect(popup.providers.nameField()).toBeEnabled()
 
   await popup.providers.nameField().fill('Bilibili Custom')
-  await popup.providers.selectOption('Danmaku format', 'protobuf')
+  await popup.providers.selectOption(/Danmaku format|弹幕格式/, 'protobuf')
   await popup.providers.save()
 
   await popup.toast.expectSuccess(/Provider updated|弹幕源已更新/)

--- a/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
@@ -1,0 +1,67 @@
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { Language } from '../../../src/common/localization/language'
+import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
+import { mockCatalog } from '../../network/catalog'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Manifest display strings localize into the active UI language. With the
+ * extension set to Chinese, the catalog lists an uninstalled manifest under its
+ * localized name (iQIYI -> 爱奇艺) and the generic config editor renders a
+ * dandanplay field under its localized title (Base URL -> 基础地址).
+ */
+
+const BILIBILI_NAV = /api\.bilibili\.com\/x\/web-interface\/nav/
+const TENCENT_PROBE =
+  /pbaccess\.video\.qq\.com\/.*page_server_rpc\.PageServer\/GetPageData/
+
+const localDdp: ProviderConfig = {
+  id: 'localized-ddp',
+  manifestId: 'dandanplay',
+  name: 'My DDP',
+  impl: DanmakuSourceType.DanDanPlay,
+  enabled: true,
+  isBuiltIn: false,
+  configValues: {
+    baseUrl: '',
+    auth: { enabled: false, headers: [] },
+  },
+}
+
+test('catalog and config editor render localized manifest strings', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    extensionOptions: { lang: Language.zh },
+    customProviders: [localDdp],
+    network: [
+      mockCatalog(['dandanplay', 'bilibili', 'tencent', 'iqiyi']),
+      {
+        pattern: BILIBILI_NAV,
+        respond: (route) =>
+          route.fulfill({
+            json: { code: 0, message: '0', data: { isLogin: true } },
+          }),
+      },
+      {
+        pattern: TENCENT_PROBE,
+        respond: (route) =>
+          route.fulfill({ json: { ret: 0, msg: '', data: {} } }),
+      },
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+
+  await popup.providers.refreshCatalog()
+  await expect(popup.providers.row('爱奇艺')).toBeVisible()
+
+  await popup.providers.edit('My DDP')
+  await popup.providers.expectFieldVisible('基础地址')
+})

--- a/packages/danmaku-anywhere/e2e/specs/sources/catalog-import.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/catalog-import.spec.ts
@@ -48,15 +48,17 @@ test('catalog: refresh surfaces an uninstalled source and import installs it', a
 
   // iQIYI isn't seeded at boot (the fixture catalog has only the built-ins),
   // so the richer catalog only reaches the registry once Refresh re-fetches.
-  await expect(popup.providers.importButton('iQIYI')).toBeHidden()
+  // The catalog name localizes with the UI language (iQIYI -> 爱奇艺).
+  const iqiyiName = /iQIYI|爱奇艺/
+  await expect(popup.providers.importButton(iqiyiName)).toBeHidden()
   await popup.providers.refreshCatalog()
-  await expect(popup.providers.importButton('iQIYI')).toBeVisible()
+  await expect(popup.providers.importButton(iqiyiName)).toBeVisible()
 
-  await popup.providers.import('iQIYI')
+  await popup.providers.import(iqiyiName)
 
   await popup.toast.expectSuccess(/Provider created|创建/)
-  await expect(popup.providers.importButton('iQIYI')).toBeHidden()
-  await expect(popup.providers.row('iQIYI')).toBeVisible()
+  await expect(popup.providers.importButton(iqiyiName)).toBeHidden()
+  await expect(popup.providers.row(iqiyiName)).toBeVisible()
 
   const configs = await da.providerConfig.list()
   expect(configs.some((config) => config.manifestId === 'iqiyi')).toBe(true)

--- a/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-local-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-local-origin.spec.ts
@@ -1,0 +1,54 @@
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
+import { mockDandanplayCustom } from '../../network/dandanplay'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { test } from '../../setup/fixtures'
+import { loadJsonFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * A DanDanPlay-compatible server on a loopback host. The engine blocks private
+ * and loopback hosts by default, so search and danmaku only resolve because the
+ * host threads the private-host opt-in into every manifest run. Confirms results
+ * render and the comment count shows for a config pointed at http://localhost.
+ */
+
+const LOCAL_BASE_URL = 'http://localhost:7766'
+
+const localConfig: ProviderConfig = {
+  id: 'local-ddp-1',
+  manifestId: 'dandanplay',
+  name: 'LocalDdp',
+  impl: DanmakuSourceType.DanDanPlay,
+  enabled: true,
+  isBuiltIn: false,
+  configValues: {
+    baseUrl: LOCAL_BASE_URL,
+    auth: { enabled: false, headers: [] },
+  },
+}
+
+test('dandanplay: loopback baseUrl resolves with the private-host opt-in', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    customProviders: [localConfig],
+    network: mockDandanplayCustom({
+      baseUrl: LOCAL_BASE_URL,
+      search: loadJsonFixture('ddp-compat-search.json'),
+      bangumi: loadJsonFixture('ddp-compat-bangumi.json'),
+      comments: loadJsonFixture('ddp-compat-comments.json'),
+    }),
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+  await popup.search.openFirstResult('DanDanPlay')
+  const episode =
+    await popup.seasonDetails.fetchDanmakuForFirstEpisode('DanDanPlay')
+  await popup.seasonDetails.expectCommentCount(episode)
+})

--- a/packages/danmaku-anywhere/e2e/specs/sources/updates.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/updates.spec.ts
@@ -68,15 +68,20 @@ test('updates: an uninstalled catalog source updates in place on refresh, not as
 
   const popup = await Popup.open(page, extensionId, '/providers')
 
+  // The catalog name localizes with the UI language (iQIYI -> 爱奇艺).
+  const iqiyiName = /iQIYI|爱奇艺/
+
   // Seeded stale with no runner yet, so it only surfaces once the refresh
   // applies its update in place.
-  await expect(popup.providers.importButton('iQIYI')).toBeHidden()
+  await expect(popup.providers.importButton(iqiyiName)).toBeHidden()
   await expect(page.getByText(/Updates available|有可用更新/)).toBeHidden()
 
   await popup.providers.refreshCatalog()
 
-  await expect(popup.providers.catalogRow('iQIYI')).toContainText(`v${BUMPED}`)
-  await expect(popup.providers.importButton('iQIYI')).toBeVisible()
+  await expect(popup.providers.catalogRow(iqiyiName)).toContainText(
+    `v${BUMPED}`
+  )
+  await expect(popup.providers.importButton(iqiyiName)).toBeVisible()
   await expect(page.getByText(/Updates available|有可用更新/)).toBeHidden()
 
   const stored = (await da.storage.get('local', 'manifests')) as StoredManifests

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -60,7 +60,7 @@
     "@fontsource-variable/noto-sans-tc": "^5.2.10",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
-    "@mr-quin/dango": "^0.3.0",
+    "@mr-quin/dango": "^0.5.0",
     "@mui/icons-material": "^9.0.1",
     "@mui/lab": "9.0.0-beta.3",
     "@mui/material": "^9.0.1",
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "2.2.1",
-    "@mr-quin/dango-manifests": "^0.3.0",
+    "@mr-quin/dango-manifests": "^0.5.0",
     "@playwright/test": "^1.59.1",
     "@types/chrome": "^0.0.326",
     "@types/d3": "^7.4.3",

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -124,14 +124,14 @@ export class RpcManager {
         providerProbeLogin: async ({ manifestId }) => {
           return this.providerService.getLoginStatus(manifestId)
         },
-        providerGetManifestSpec: async ({ manifestId }) => {
-          return this.providerService.getManifestSpec(manifestId)
+        providerGetManifestSpec: async ({ manifestId, locale }) => {
+          return this.providerService.getManifestSpec(manifestId, locale)
         },
-        providerListManifests: async () => {
-          return this.providerService.listManifests()
+        providerListManifests: async (input) => {
+          return this.providerService.listManifests(input?.locale)
         },
-        providerRefreshCatalog: async () => {
-          return this.providerService.refreshCatalog()
+        providerRefreshCatalog: async (input) => {
+          return this.providerService.refreshCatalog(input?.locale)
         },
         providerGetPendingUpdates: async () => {
           return this.manifestRegistry.getPendingUpdates()

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -127,11 +127,11 @@ export class RpcManager {
         providerGetManifestSpec: async ({ manifestId, locale }) => {
           return this.providerService.getManifestSpec(manifestId, locale)
         },
-        providerListManifests: async (input) => {
-          return this.providerService.listManifests(input?.locale)
+        providerListManifests: async ({ locale }) => {
+          return this.providerService.listManifests(locale)
         },
-        providerRefreshCatalog: async (input) => {
-          return this.providerService.refreshCatalog(input?.locale)
+        providerRefreshCatalog: async ({ locale }) => {
+          return this.providerService.refreshCatalog(locale)
         },
         providerGetPendingUpdates: async () => {
           return this.manifestRegistry.getPendingUpdates()

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -127,10 +127,10 @@ export class RpcManager {
         providerGetManifestSpec: async ({ manifestId, locale }) => {
           return this.providerService.getManifestSpec(manifestId, locale)
         },
-        providerListManifests: async ({ locale }) => {
+        providerListManifests: async ({ locale } = {}) => {
           return this.providerService.listManifests(locale)
         },
-        providerRefreshCatalog: async ({ locale }) => {
+        providerRefreshCatalog: async ({ locale } = {}) => {
           return this.providerService.refreshCatalog(locale)
         },
         providerGetPendingUpdates: async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
@@ -18,12 +18,18 @@ import type { ManifestRegistry } from './ManifestRegistry'
  * the caller. Input precedence is exercised via the configValues path.
  */
 
+// Manifest sources may target self-hosted local endpoints, so every runner
+// call opts into private hosts; the manifest `hosts` allowlist still gates
+// requests.
+const RUN_OPTS = { allowPrivateHosts: true }
+
 function makeRunner(returns: Record<string, unknown>): ManifestRunner {
   return {
     runSearch: vi.fn(async () => returns.search ?? []),
     runEpisodes: vi.fn(async () => returns.episodes ?? []),
     runDanmaku: vi.fn(async () => returns.danmaku ?? []),
     runSeason: vi.fn(async () => returns.season ?? null),
+    runParseUrl: vi.fn(async () => returns.parseUrl ?? null),
     hasSeason: vi.fn(() => 'season' in returns),
     configDefaults: vi.fn(
       () => (returns.configDefaults as Record<string, unknown>) ?? {}
@@ -80,7 +86,7 @@ describe('ManifestProviderService.search', () => {
       providerConfigId: 'bilibili',
       schemaVersion: SEASON_SCHEMA_VERSION,
     })
-    expect(runner.runSearch).toHaveBeenCalledWith({ q: 'frieren' })
+    expect(runner.runSearch).toHaveBeenCalledWith({ q: 'frieren' }, RUN_OPTS)
   })
 
   it('merges configValues into the search pipeline inputs', async () => {
@@ -101,11 +107,14 @@ describe('ManifestProviderService.search', () => {
 
     await svc.search({ keyword: 'x' })
 
-    expect(runner.runSearch).toHaveBeenCalledWith({
-      q: 'x',
-      baseUrl: 'https://compat.example',
-      authHeaders: [],
-    })
+    expect(runner.runSearch).toHaveBeenCalledWith(
+      {
+        q: 'x',
+        baseUrl: 'https://compat.example',
+        authHeaders: [],
+      },
+      RUN_OPTS
+    )
   })
 })
 
@@ -152,7 +161,7 @@ describe('ManifestProviderService.getSeason', () => {
       providerConfigId: 'bilibili',
       schemaVersion: SEASON_SCHEMA_VERSION,
     })
-    expect(runner.runSeason).toHaveBeenCalledWith({ seasonId: 41410 })
+    expect(runner.runSeason).toHaveBeenCalledWith({ seasonId: 41410 }, RUN_OPTS)
   })
 
   it('returns null when the season pipeline yields null', async () => {
@@ -201,7 +210,7 @@ describe('ManifestProviderService.getEpisodes', () => {
       schemaVersion: EPISODE_SCHEMA_VERSION,
     })
     expect(typeof result[0].lastChecked).toBe('number')
-    expect(runner.runEpisodes).toHaveBeenCalledWith({ seasonId: 123 })
+    expect(runner.runEpisodes).toHaveBeenCalledWith({ seasonId: 123 }, RUN_OPTS)
   })
 })
 
@@ -240,6 +249,43 @@ describe('ManifestProviderService.getDanmaku', () => {
     const result = await svc.getDanmaku(makeRequest({ episodeId: 42 }))
 
     expect(result).toBe(raw)
-    expect(runner.runDanmaku).toHaveBeenCalledWith({ episodeId: 42 })
+    expect(runner.runDanmaku).toHaveBeenCalledWith({ episodeId: 42 }, RUN_OPTS)
+  })
+})
+
+describe('ManifestProviderService.parseUrl', () => {
+  it('passes the private-host opt-in to the parseUrl pipeline', async () => {
+    const runner = makeRunner({
+      parseUrl: {
+        seasonInsert: {
+          providerIds: { seasonId: 1 },
+          indexedId: '1',
+          title: 'S',
+          type: 'tv',
+        },
+        episodeMeta: {
+          providerIds: { cid: 2 },
+          indexedId: '2',
+          title: 'E',
+        },
+      },
+    })
+    const svc = new ManifestProviderService(
+      {
+        manifestId: 'dandanplay',
+        provider: DanmakuSourceType.DanDanPlay,
+        providerConfigId: 'custom-ddp-1',
+      },
+      makeRegistry(runner),
+      silentLogger
+    )
+
+    await svc.parseUrl('https://local.example/v/1')
+
+    expect(runner.runParseUrl).toHaveBeenCalledWith(
+      'https://local.example/v/1',
+      undefined,
+      RUN_OPTS
+    )
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
@@ -8,7 +8,10 @@ import type { ManifestRunner } from '@mr-quin/dango'
 import { describe, expect, it, vi } from 'vitest'
 import type { DanmakuFetchByMeta } from '@/common/danmaku/dto'
 import type { ILogger } from '@/common/Logger'
-import { ManifestProviderService } from './ManifestProviderService'
+import {
+  MANIFEST_RUN_OPTIONS,
+  ManifestProviderService,
+} from './ManifestProviderService'
 import type { ManifestRegistry } from './ManifestRegistry'
 
 /**
@@ -18,10 +21,7 @@ import type { ManifestRegistry } from './ManifestRegistry'
  * the caller. Input precedence is exercised via the configValues path.
  */
 
-// Manifest sources may target self-hosted local endpoints, so every runner
-// call opts into private hosts; the manifest `hosts` allowlist still gates
-// requests.
-const RUN_OPTS = { allowPrivateHosts: true }
+const RUN_OPTS = MANIFEST_RUN_OPTIONS
 
 function makeRunner(returns: Record<string, unknown>): ManifestRunner {
   return {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
@@ -8,7 +8,7 @@ import {
   stripHtml,
   type WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
-import type { ManifestRunner } from '@mr-quin/dango'
+import type { ManifestRunner, RunOptions } from '@mr-quin/dango'
 import type { DanmakuFetchByMeta } from '@/common/danmaku/dto'
 import type { DanmakuSourceType } from '@/common/danmaku/enums'
 import type { ILogger } from '@/common/Logger'
@@ -71,6 +71,10 @@ export interface ManifestProviderConfig {
   configValues?: Record<string, unknown>
 }
 
+// Permit requests to private/loopback hosts so a config pointed at a
+// self-hosted local server resolves instead of being blocked.
+export const MANIFEST_RUN_OPTIONS: RunOptions = { allowPrivateHosts: true }
+
 export class ManifestProviderService implements IDanmakuProvider {
   readonly forProvider: DanmakuSourceType
 
@@ -97,7 +101,10 @@ export class ManifestProviderService implements IDanmakuProvider {
     this.logger.debug('Search via manifest', this.config.manifestId, params)
     const runner = this.registry.getRunner(this.config.manifestId)
     const inputs = this.resolveInputs(runner, { q: params.keyword })
-    const rows = await runner.runSearch<ManifestSearchRow[]>(inputs)
+    const rows = await runner.runSearch<ManifestSearchRow[]>(
+      inputs,
+      MANIFEST_RUN_OPTIONS
+    )
     return rows.map((row) => ({
       ...row,
       title: stripHtml(row.title),
@@ -120,7 +127,10 @@ export class ManifestProviderService implements IDanmakuProvider {
       return null
     }
     const inputs = this.resolveInputs(runner, seasonRemoteIds)
-    const row = await runner.runSeason<ManifestSearchRow | null>(inputs)
+    const row = await runner.runSeason<ManifestSearchRow | null>(
+      inputs,
+      MANIFEST_RUN_OPTIONS
+    )
     if (row === null) {
       return null
     }
@@ -143,7 +153,10 @@ export class ManifestProviderService implements IDanmakuProvider {
     )
     const runner = this.registry.getRunner(this.config.manifestId)
     const inputs = this.resolveInputs(runner, seasonRemoteIds)
-    const rows = await runner.runEpisodes<ManifestEpisodeRow[]>(inputs)
+    const rows = await runner.runEpisodes<ManifestEpisodeRow[]>(
+      inputs,
+      MANIFEST_RUN_OPTIONS
+    )
     const now = Date.now()
     return rows.map((row) => ({
       ...row,
@@ -168,7 +181,7 @@ export class ManifestProviderService implements IDanmakuProvider {
       ...meta.params,
       ...meta.providerIds,
     })
-    return runner.runDanmaku<CommentEntity[]>(inputs)
+    return runner.runDanmaku<CommentEntity[]>(inputs, MANIFEST_RUN_OPTIONS)
   }
 
   async findEpisode(
@@ -194,7 +207,11 @@ export class ManifestProviderService implements IDanmakuProvider {
   async parseUrl(url: string): Promise<ParseUrlResult | null> {
     this.logger.debug('Parse URL via manifest', this.config.manifestId, url)
     const runner = this.registry.getRunner(this.config.manifestId)
-    const result = await runner.runParseUrl<ManifestParseUrlOutput>(url)
+    const result = await runner.runParseUrl<ManifestParseUrlOutput>(
+      url,
+      undefined,
+      MANIFEST_RUN_OPTIONS
+    )
     if (result === null) {
       return null
     }

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -193,6 +193,47 @@ describe('ManifestRegistry', () => {
     ])
   })
 
+  it('listManifests resolves name and configSchema into the requested locale', async () => {
+    const manifest = {
+      ...makeManifest('one', 1, '1.0.0'),
+      name: 'Source',
+      configSchema: {
+        type: 'object',
+        properties: { baseUrl: { type: 'string', title: 'Base URL' } },
+      },
+      locales: {
+        'zh-CN': {
+          name: '来源',
+          'configSchema.properties.baseUrl.title': '基础地址',
+        },
+      },
+    }
+    const store = new InMemoryStore({
+      one: { manifest, kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    const [info] = registry.listManifests('zh-CN')
+    expect(info.name).toBe('来源')
+    expect(info.configSchema?.properties?.baseUrl.title).toBe('基础地址')
+  })
+
+  it('listManifests falls back to source strings when no locale is given', async () => {
+    const manifest = {
+      ...makeManifest('one', 1, '1.0.0'),
+      name: 'Source',
+      locales: { 'zh-CN': { name: '来源' } },
+    }
+    const store = new InMemoryStore({
+      one: { manifest, kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    expect(registry.listManifests()[0].name).toBe('Source')
+  })
+
   it('update does not stamp lastCheckedAt; recordChecked does', async () => {
     stubCatalogFetch([catalogEntry('one')], {
       [manifestPath('one')]: makeManifest('one'),

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -1,4 +1,5 @@
 import {
+  getDisplayStrings,
   type Manifest,
   ManifestRunner,
   SUPPORTED_API_VERSIONS,
@@ -77,14 +78,17 @@ export class ManifestRegistry {
     return [...this.runners.keys()]
   }
 
-  listManifests(): ProviderManifestInfo[] {
+  listManifests(locale?: string): ProviderManifestInfo[] {
     invariant(this.initialized, 'ManifestRegistry accessed before ready')
-    return [...this.runners.values()].map(({ manifest }) => ({
-      id: manifest.id,
-      name: manifest.name,
-      version: manifest.version,
-      configSchema: manifest.configSchema,
-    }))
+    return [...this.runners.values()].map(({ manifest }) => {
+      const display = getDisplayStrings(manifest, locale)
+      return {
+        id: manifest.id,
+        name: display.name,
+        version: manifest.version,
+        configSchema: display.configSchema,
+      }
+    })
   }
 
   getLastCheckedAt(): Promise<number | null> {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
@@ -20,6 +20,8 @@ import type { ManifestRegistry } from './ManifestRegistry'
  * configValues; there is no DDP-compat special case.
  */
 
+const RUN_OPTS = { allowPrivateHosts: true }
+
 const mockRunner = {
   runSearch: vi.fn(async () => []),
   runEpisodes: vi.fn(async () => []),
@@ -96,7 +98,7 @@ describe('ProviderFactory dispatch', () => {
 
     expect(service.forProvider).toBe(DanmakuSourceType.DanDanPlay)
     await service.search({ keyword: 'x' })
-    expect(mockRunner.runSearch).toHaveBeenCalledWith({ q: 'x' })
+    expect(mockRunner.runSearch).toHaveBeenCalledWith({ q: 'x' }, RUN_OPTS)
   })
 
   it('routes Bilibili and threads danmakuFormat from configValues', async () => {
@@ -113,10 +115,13 @@ describe('ProviderFactory dispatch', () => {
 
     expect(service.forProvider).toBe(DanmakuSourceType.Bilibili)
     await service.search({ keyword: 'frieren' })
-    expect(mockRunner.runSearch).toHaveBeenCalledWith({
-      q: 'frieren',
-      danmakuFormat: 'protobuf',
-    })
+    expect(mockRunner.runSearch).toHaveBeenCalledWith(
+      {
+        q: 'frieren',
+        danmakuFormat: 'protobuf',
+      },
+      RUN_OPTS
+    )
   })
 
   it('routes Tencent without extraInputs', async () => {
@@ -133,7 +138,7 @@ describe('ProviderFactory dispatch', () => {
 
     expect(service.forProvider).toBe(DanmakuSourceType.Tencent)
     await service.search({ keyword: 'x' })
-    expect(mockRunner.runSearch).toHaveBeenCalledWith({ q: 'x' })
+    expect(mockRunner.runSearch).toHaveBeenCalledWith({ q: 'x' }, RUN_OPTS)
   })
 
   it('routes a custom DanDanPlay server through the dandanplay manifest with configValues threaded through', async () => {
@@ -147,11 +152,14 @@ describe('ProviderFactory dispatch', () => {
 
     expect(service.forProvider).toBe(DanmakuSourceType.DanDanPlay)
     await service.search({ keyword: 'x' })
-    expect(mockRunner.runSearch).toHaveBeenCalledWith({
-      q: 'x',
-      baseUrl: 'https://my-ddp.example',
-      auth: { enabled: true, headers: [{ key: 'X-A', value: '1' }] },
-    })
+    expect(mockRunner.runSearch).toHaveBeenCalledWith(
+      {
+        q: 'x',
+        baseUrl: 'https://my-ddp.example',
+        auth: { enabled: true, headers: [{ key: 'X-A', value: '1' }] },
+      },
+      RUN_OPTS
+    )
   })
 
   it('routes legacy MacCMS to MacCmsProviderService (not ManifestProviderService)', async () => {
@@ -185,7 +193,10 @@ describe('ProviderFactory dispatch', () => {
     expect(service).toBeInstanceOf(ManifestProviderService)
     expect(service.forProvider).toBe(DanmakuSourceType.DanDanPlay)
     await service.search({ keyword: 'x' })
-    expect(mockRunner.runSearch).toHaveBeenCalledWith({ q: 'x', region: 'cn' })
+    expect(mockRunner.runSearch).toHaveBeenCalledWith(
+      { q: 'x', region: 'cn' },
+      RUN_OPTS
+    )
   })
 
   it('rejects a non-maccms config that carries the Custom impl', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
@@ -7,7 +7,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ILogger } from '@/common/Logger'
 import { LoggerSymbol } from '@/common/Logger'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
-import { ManifestProviderService } from './ManifestProviderService'
+import {
+  MANIFEST_RUN_OPTIONS,
+  ManifestProviderService,
+} from './ManifestProviderService'
 import type { ManifestRegistry } from './ManifestRegistry'
 
 /**
@@ -20,7 +23,7 @@ import type { ManifestRegistry } from './ManifestRegistry'
  * configValues; there is no DDP-compat special case.
  */
 
-const RUN_OPTS = { allowPrivateHosts: true }
+const RUN_OPTS = MANIFEST_RUN_OPTIONS
 
 const mockRunner = {
   runSearch: vi.fn(async () => []),

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -11,6 +11,7 @@ import type { ILogger } from '@/common/Logger'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import type { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type { IDanmakuProvider } from './IDanmakuProvider'
+import { MANIFEST_RUN_OPTIONS } from './ManifestProviderService'
 import type { ManifestRegistry } from './ManifestRegistry'
 import { ProviderService } from './ProviderService'
 
@@ -120,9 +121,7 @@ describe('ProviderService.probeLogin', () => {
 
     await service.probeLogin('dandanplay')
 
-    expect(runLoginProbe).toHaveBeenCalledWith(undefined, {
-      allowPrivateHosts: true,
-    })
+    expect(runLoginProbe).toHaveBeenCalledWith(undefined, MANIFEST_RUN_OPTIONS)
   })
 })
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -102,6 +102,87 @@ function build(
   return { service, provider, danmakuService, seasonService }
 }
 
+describe('ProviderService.probeLogin', () => {
+  it('runs the login probe with the private-host opt-in', async () => {
+    const runLoginProbe = vi.fn(async () => true)
+    const registry = {
+      ready: Promise.resolve(true),
+      getRunner: vi.fn(() => ({ runLoginProbe })),
+    } as unknown as ManifestRegistry
+    const service = new ProviderService(
+      {} as unknown as DanmakuService,
+      {} as unknown as SeasonService,
+      {} as unknown as ProviderConfigService,
+      vi.fn(() => makeProvider()),
+      registry,
+      silentLogger
+    )
+
+    await service.probeLogin('dandanplay')
+
+    expect(runLoginProbe).toHaveBeenCalledWith(undefined, {
+      allowPrivateHosts: true,
+    })
+  })
+})
+
+describe('ProviderService.getManifestSpec', () => {
+  function buildWithManifest(manifest: Record<string, unknown>) {
+    const registry = {
+      ready: Promise.resolve(true),
+      getRunner: vi.fn(() => ({ manifest })),
+    } as unknown as ManifestRegistry
+    return new ProviderService(
+      {} as unknown as DanmakuService,
+      {} as unknown as SeasonService,
+      {} as unknown as ProviderConfigService,
+      vi.fn(() => makeProvider()),
+      registry,
+      silentLogger
+    )
+  }
+
+  it('resolves name, configSchema, and cookieSet title into the locale', async () => {
+    const service = buildWithManifest({
+      id: 'dandanplay',
+      name: 'DanDanPlay',
+      cookieSet: { url: 'https://ddp.example/login', title: 'Sign in' },
+      configSchema: {
+        type: 'object',
+        properties: { baseUrl: { type: 'string', title: 'Base URL' } },
+      },
+      locales: {
+        'zh-CN': {
+          name: '弹弹play',
+          'cookieSet.title': '登录',
+          'configSchema.properties.baseUrl.title': '基础地址',
+        },
+      },
+    })
+
+    const spec = await service.getManifestSpec('dandanplay', 'zh-CN')
+
+    expect(spec.name).toBe('弹弹play')
+    expect(spec.cookieSet).toEqual({
+      url: 'https://ddp.example/login',
+      title: '登录',
+    })
+    expect(spec.configSchema?.properties?.baseUrl.title).toBe('基础地址')
+  })
+
+  it('falls back to source strings when no locale is given', async () => {
+    const service = buildWithManifest({
+      id: 'dandanplay',
+      name: 'DanDanPlay',
+      locales: { 'zh-CN': { name: '弹弹play' } },
+    })
+
+    const spec = await service.getManifestSpec('dandanplay')
+
+    expect(spec.name).toBe('DanDanPlay')
+  })
+})
+
 describe('ProviderService legacy-maccms decoupling', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -7,6 +7,7 @@ import type {
   WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { LEGACY_MACCMS_ID } from '@danmaku-anywhere/danmaku-converter'
+import { getDisplayStrings } from '@mr-quin/dango'
 import { inject, injectable } from 'inversify'
 import { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import { SeasonService } from '@/background/services/persistence/SeasonService'
@@ -24,6 +25,7 @@ import type {
 } from '@/common/rpcClient/background/types'
 import { invariant, isServiceWorker } from '@/common/utils/utils'
 import type { OmitSeasonId } from './IDanmakuProvider'
+import { MANIFEST_RUN_OPTIONS } from './ManifestProviderService'
 import { ManifestRegistry } from './ManifestRegistry'
 import {
   DanmakuProviderFactory,
@@ -230,7 +232,9 @@ export class ProviderService {
 
   async probeLogin<T = unknown>(manifestId: string): Promise<T | null> {
     await this.manifestRegistry.ready
-    return this.manifestRegistry.getRunner(manifestId).runLoginProbe<T>()
+    return this.manifestRegistry
+      .getRunner(manifestId)
+      .runLoginProbe<T>(undefined, MANIFEST_RUN_OPTIONS)
   }
 
   // Resolves whether a manifest-driven source needs a login/cookie action so
@@ -261,10 +265,10 @@ export class ProviderService {
   // Lists every registered manifest plus the last catalog-check timestamp so
   // the popup can render the catalog section (registered manifests the user
   // has no config for) without bundling the manifest set itself.
-  async listManifests(): Promise<ProviderManifestList> {
+  async listManifests(locale?: string): Promise<ProviderManifestList> {
     await this.manifestRegistry.ready
     return {
-      manifests: this.manifestRegistry.listManifests(),
+      manifests: this.manifestRegistry.listManifests(locale),
       lastCheckedAt: await this.manifestRegistry.getLastCheckedAt(),
     }
   }
@@ -279,9 +283,9 @@ export class ProviderService {
     })
   }
 
-  async refreshCatalog(): Promise<ProviderManifestList> {
+  async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
     await this.syncCatalog()
-    return this.listManifests()
+    return this.listManifests(locale)
   }
 
   // Bring the catalog current: updates for uninstalled sources (no config or
@@ -313,16 +317,22 @@ export class ProviderService {
 
   // Surfaces the host-relevant subset of a manifest so the popup can render
   // generic affordances (warning icon, cookieSet link, config form) without
-  // bundling source-specific switches.
-  async getManifestSpec(manifestId: string): Promise<ProviderManifestSpec> {
+  // bundling source-specific switches. Display strings resolve into `locale`.
+  async getManifestSpec(
+    manifestId: string,
+    locale?: string
+  ): Promise<ProviderManifestSpec> {
     await this.manifestRegistry.ready
     try {
       const { manifest } = this.manifestRegistry.getRunner(manifestId)
+      const display = getDisplayStrings(manifest, locale)
       return {
-        name: manifest.name,
+        name: display.name,
         hasLoginProbe: manifest.loginProbe !== undefined,
-        cookieSet: manifest.cookieSet,
-        configSchema: manifest.configSchema,
+        cookieSet: manifest.cookieSet
+          ? { url: manifest.cookieSet.url, title: display.cookieSet?.title }
+          : undefined,
+        configSchema: display.configSchema,
       }
     } catch {
       // Unknown id (legacy:maccms) or a catalog miss: report a minimal spec so

--- a/packages/danmaku-anywhere/src/common/localization/language.test.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { toManifestLocale } from './language'
+
+describe('toManifestLocale', () => {
+  it('maps the bare zh code to zh-CN', () => {
+    expect(toManifestLocale('zh')).toBe('zh-CN')
+  })
+
+  it('maps any zh variant to zh-CN', () => {
+    expect(toManifestLocale('zh-TW')).toBe('zh-CN')
+    expect(toManifestLocale('zh-HK')).toBe('zh-CN')
+  })
+
+  it('passes other language codes through unchanged', () => {
+    expect(toManifestLocale('en')).toBe('en')
+  })
+
+  it('falls back to the default locale when language is unset', () => {
+    expect(toManifestLocale(undefined)).toBe('en')
+    expect(toManifestLocale('')).toBe('en')
+  })
+})

--- a/packages/danmaku-anywhere/src/common/localization/language.test.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.test.ts
@@ -6,9 +6,10 @@ describe('toManifestLocale', () => {
     expect(toManifestLocale('zh')).toBe('zh-CN')
   })
 
-  it('maps any zh variant to zh-CN', () => {
+  it('maps any zh variant to zh-CN, case-insensitively', () => {
     expect(toManifestLocale('zh-TW')).toBe('zh-CN')
     expect(toManifestLocale('zh-HK')).toBe('zh-CN')
+    expect(toManifestLocale('ZH-CN')).toBe('zh-CN')
   })
 
   it('passes other language codes through unchanged', () => {

--- a/packages/danmaku-anywhere/src/common/localization/language.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.ts
@@ -8,7 +8,7 @@ export function toManifestLocale(language?: string): string {
   if (!language) {
     return Language.en
   }
-  if (language.startsWith('zh')) {
+  if (language.toLowerCase().startsWith('zh')) {
     return 'zh-CN'
   }
   return language

--- a/packages/danmaku-anywhere/src/common/localization/language.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.ts
@@ -3,8 +3,7 @@ export enum Language {
   zh = 'zh',
 }
 
-// Map the app's bare language code to the BCP-47 tag (e.g. `zh-CN`) that
-// localized manifest strings are keyed by.
+// Map the app's bare language code to a BCP-47 locale tag (e.g. `zh` -> `zh-CN`).
 export function toManifestLocale(language?: string): string {
   if (!language) {
     return Language.en

--- a/packages/danmaku-anywhere/src/common/localization/language.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.ts
@@ -9,7 +9,7 @@ export function toManifestLocale(language?: string): string {
   if (!language) {
     return Language.en
   }
-  if (language === Language.zh) {
+  if (language.startsWith('zh')) {
     return 'zh-CN'
   }
   return language

--- a/packages/danmaku-anywhere/src/common/localization/language.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.ts
@@ -5,7 +5,10 @@ export enum Language {
 
 // Map the app's bare language code to the BCP-47 tag (e.g. `zh-CN`) that
 // localized manifest strings are keyed by.
-export function toManifestLocale(language: string): string {
+export function toManifestLocale(language?: string): string {
+  if (!language) {
+    return Language.en
+  }
   if (language === Language.zh) {
     return 'zh-CN'
   }

--- a/packages/danmaku-anywhere/src/common/localization/language.ts
+++ b/packages/danmaku-anywhere/src/common/localization/language.ts
@@ -3,6 +3,15 @@ export enum Language {
   zh = 'zh',
 }
 
+// Map the app's bare language code to the BCP-47 tag (e.g. `zh-CN`) that
+// localized manifest strings are keyed by.
+export function toManifestLocale(language: string): string {
+  if (language === Language.zh) {
+    return 'zh-CN'
+  }
+  return language
+}
+
 export const LanguageList = [
   {
     value: Language.en,

--- a/packages/danmaku-anywhere/src/common/queries/queryKeys.ts
+++ b/packages/danmaku-anywhere/src/common/queries/queryKeys.ts
@@ -66,8 +66,12 @@ export const sourceQueryKeys = {
     [{ scope: 'source', kind: 'loginStatus', manifestId }] as const,
   manifestSpec: (manifestId: string, locale: string) =>
     [{ scope: 'source', kind: 'manifestSpec', manifestId, locale }] as const,
-  manifestList: (locale: string) =>
-    [{ scope: 'source', kind: 'manifestList', locale }] as const,
+  // Omit locale for a family-prefix key that matches every locale's list
+  // (used to invalidate all cached lists at once).
+  manifestList: (locale?: string) =>
+    locale === undefined
+      ? ([{ scope: 'source', kind: 'manifestList' }] as const)
+      : ([{ scope: 'source', kind: 'manifestList', locale }] as const),
   pendingUpdates: () => [{ scope: 'source', kind: 'pendingUpdates' }] as const,
 }
 

--- a/packages/danmaku-anywhere/src/common/queries/queryKeys.ts
+++ b/packages/danmaku-anywhere/src/common/queries/queryKeys.ts
@@ -64,9 +64,10 @@ export const customEpisodeQueryKeys = {
 export const sourceQueryKeys = {
   loginStatus: (manifestId: string) =>
     [{ scope: 'source', kind: 'loginStatus', manifestId }] as const,
-  manifestSpec: (manifestId: string) =>
-    [{ scope: 'source', kind: 'manifestSpec', manifestId }] as const,
-  manifestList: () => [{ scope: 'source', kind: 'manifestList' }] as const,
+  manifestSpec: (manifestId: string, locale: string) =>
+    [{ scope: 'source', kind: 'manifestSpec', manifestId, locale }] as const,
+  manifestList: (locale: string) =>
+    [{ scope: 'source', kind: 'manifestList', locale }] as const,
   pendingUpdates: () => [{ scope: 'source', kind: 'pendingUpdates' }] as const,
 }
 

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -177,14 +177,8 @@ export type BackgroundMethods = {
     { manifestId: string; locale?: string },
     ProviderManifestSpec
   >
-  providerListManifests: RPCDef<
-    { locale?: string } | void,
-    ProviderManifestList
-  >
-  providerRefreshCatalog: RPCDef<
-    { locale?: string } | void,
-    ProviderManifestList
-  >
+  providerListManifests: RPCDef<{ locale?: string }, ProviderManifestList>
+  providerRefreshCatalog: RPCDef<{ locale?: string }, ProviderManifestList>
   providerGetPendingUpdates: RPCDef<void, ManifestUpdate[]>
   providerApplyUpdates: RPCDef<{ manifestIds: string[] }, void>
   fetchImage: RPCDef<{ src: string }, string | null>

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -173,9 +173,18 @@ export type BackgroundMethods = {
   danmakuPurgeCache: RPCDef<number, number>
   bilibiliSetCookies: RPCDef<void, void>
   providerProbeLogin: RPCDef<{ manifestId: string }, ProviderLoginStatus>
-  providerGetManifestSpec: RPCDef<{ manifestId: string }, ProviderManifestSpec>
-  providerListManifests: RPCDef<void, ProviderManifestList>
-  providerRefreshCatalog: RPCDef<void, ProviderManifestList>
+  providerGetManifestSpec: RPCDef<
+    { manifestId: string; locale?: string },
+    ProviderManifestSpec
+  >
+  providerListManifests: RPCDef<
+    { locale?: string } | void,
+    ProviderManifestList
+  >
+  providerRefreshCatalog: RPCDef<
+    { locale?: string } | void,
+    ProviderManifestList
+  >
   providerGetPendingUpdates: RPCDef<void, ManifestUpdate[]>
   providerApplyUpdates: RPCDef<{ manifestIds: string[] }, void>
   fetchImage: RPCDef<{ src: string }, string | null>

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestList.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestList.ts
@@ -1,22 +1,28 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toManifestLocale } from '@/common/localization/language'
 import { sourceQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 
 export const useManifestList = () => {
+  const { i18n } = useTranslation()
+  const locale = toManifestLocale(i18n.language)
   return useQuery({
-    queryFn: () => chromeRpcClient.providerListManifests(),
+    queryFn: () => chromeRpcClient.providerListManifests({ locale }),
     select: (res) => res.data,
-    queryKey: sourceQueryKeys.manifestList(),
+    queryKey: sourceQueryKeys.manifestList(locale),
     refetchOnWindowFocus: false,
   })
 }
 
 export const useRefreshCatalog = () => {
   const queryClient = useQueryClient()
+  const { i18n } = useTranslation()
+  const locale = toManifestLocale(i18n.language)
   return useMutation({
-    mutationFn: () => chromeRpcClient.providerRefreshCatalog(),
+    mutationFn: () => chromeRpcClient.providerRefreshCatalog({ locale }),
     onSuccess: (res) => {
-      queryClient.setQueryData(sourceQueryKeys.manifestList(), res)
+      queryClient.setQueryData(sourceQueryKeys.manifestList(locale), res)
       // A refresh re-checks the catalog, which can change the pending set.
       void queryClient.invalidateQueries({
         queryKey: sourceQueryKeys.pendingUpdates(),

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestList.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestList.ts
@@ -1,12 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useTranslation } from 'react-i18next'
-import { toManifestLocale } from '@/common/localization/language'
 import { sourceQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { useManifestLocale } from './useManifestLocale'
 
 export const useManifestList = () => {
-  const { i18n } = useTranslation()
-  const locale = toManifestLocale(i18n.language)
+  const locale = useManifestLocale()
   return useQuery({
     queryFn: () => chromeRpcClient.providerListManifests({ locale }),
     select: (res) => res.data,
@@ -17,8 +15,7 @@ export const useManifestList = () => {
 
 export const useRefreshCatalog = () => {
   const queryClient = useQueryClient()
-  const { i18n } = useTranslation()
-  const locale = toManifestLocale(i18n.language)
+  const locale = useManifestLocale()
   return useMutation({
     mutationFn: () => chromeRpcClient.providerRefreshCatalog({ locale }),
     onSuccess: (res) => {

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestLocale.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestLocale.ts
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import { toManifestLocale } from '@/common/localization/language'
 
-// Resolves the active UI language to the locale tag manifest display strings
-// are keyed by, so the query key and the RPC arg never diverge.
+// Resolve the active UI language to a locale tag once, so the query key and
+// the RPC arg stay in sync.
 export const useManifestLocale = (): string => {
   const { i18n } = useTranslation()
   return toManifestLocale(i18n.language)

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestLocale.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestLocale.ts
@@ -1,0 +1,9 @@
+import { useTranslation } from 'react-i18next'
+import { toManifestLocale } from '@/common/localization/language'
+
+// Resolves the active UI language to the locale tag manifest display strings
+// are keyed by, so the query key and the RPC arg never diverge.
+export const useManifestLocale = (): string => {
+  const { i18n } = useTranslation()
+  return toManifestLocale(i18n.language)
+}

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestSpec.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestSpec.ts
@@ -1,12 +1,17 @@
 import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toManifestLocale } from '@/common/localization/language'
 import { sourceQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 
 export const useManifestSpec = (manifestId: string) => {
+  const { i18n } = useTranslation()
+  const locale = toManifestLocale(i18n.language)
   return useQuery({
-    queryFn: () => chromeRpcClient.providerGetManifestSpec({ manifestId }),
+    queryFn: () =>
+      chromeRpcClient.providerGetManifestSpec({ manifestId, locale }),
     select: (res) => res.data,
-    queryKey: sourceQueryKeys.manifestSpec(manifestId),
+    queryKey: sourceQueryKeys.manifestSpec(manifestId, locale),
     retry: false,
     refetchOnWindowFocus: false,
     refetchOnMount: false,

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestSpec.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/useManifestSpec.ts
@@ -1,12 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
-import { useTranslation } from 'react-i18next'
-import { toManifestLocale } from '@/common/localization/language'
 import { sourceQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { useManifestLocale } from './useManifestLocale'
 
 export const useManifestSpec = (manifestId: string) => {
-  const { i18n } = useTranslation()
-  const locale = toManifestLocale(i18n.language)
+  const locale = useManifestLocale()
   return useQuery({
     queryFn: () =>
       chromeRpcClient.providerGetManifestSpec({ manifestId, locale }),

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { sourceQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { useManifestLocale } from './useManifestLocale'
 
 export const usePendingUpdates = () => {
   return useQuery({
@@ -13,6 +14,7 @@ export const usePendingUpdates = () => {
 
 export const useApplyUpdates = () => {
   const queryClient = useQueryClient()
+  const locale = useManifestLocale()
   return useMutation({
     mutationFn: (manifestIds: string[]) =>
       chromeRpcClient.providerApplyUpdates({ manifestIds }),
@@ -23,7 +25,7 @@ export const useApplyUpdates = () => {
         queryKey: sourceQueryKeys.pendingUpdates(),
       })
       void queryClient.invalidateQueries({
-        queryKey: sourceQueryKeys.manifestList(),
+        queryKey: sourceQueryKeys.manifestList(locale),
       })
     },
   })

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { sourceQueryKeys } from '@/common/queries/queryKeys'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
-import { useManifestLocale } from './useManifestLocale'
 
 export const usePendingUpdates = () => {
   return useQuery({
@@ -14,18 +13,18 @@ export const usePendingUpdates = () => {
 
 export const useApplyUpdates = () => {
   const queryClient = useQueryClient()
-  const locale = useManifestLocale()
   return useMutation({
     mutationFn: (manifestIds: string[]) =>
       chromeRpcClient.providerApplyUpdates({ manifestIds }),
     onSuccess: () => {
       // Applying changes stored versions, so both the pending list and the
-      // manifest list (used for the version subtitles) need to refetch.
+      // manifest list (used for the version subtitles) need to refetch. The
+      // version is locale-independent, so invalidate every locale's list.
       void queryClient.invalidateQueries({
         queryKey: sourceQueryKeys.pendingUpdates(),
       })
       void queryClient.invalidateQueries({
-        queryKey: sourceQueryKeys.manifestList(locale),
+        queryKey: sourceQueryKeys.manifestList(),
       })
     },
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,8 +306,8 @@ importers:
         specifier: 0.10.18
         version: 0.10.18
       '@mr-quin/dango':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@mui/icons-material':
         specifier: ^9.0.1
         version: 9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.15)(react@19.2.0)
@@ -421,8 +421,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@mr-quin/dango-manifests':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.60.0
@@ -2831,11 +2831,11 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@mr-quin/dango-manifests@0.3.0':
-    resolution: {integrity: sha512-ZU4vWzaYKr4NsZ6rBYxDVJM5EaFwYQVAXMotlswkwOaoStarJGoa9UNfhr+SXLDRw6inLt/eummasg3WE7pnqw==}
+  '@mr-quin/dango-manifests@0.5.0':
+    resolution: {integrity: sha512-9jJvPBhFkxTyB163bZYe8+NqxqD2uH3z23M9Yr8T4pn/P+1PRgWLNaHmctvIP60adNCABjnqS2t3+GOJlVj8+g==}
 
-  '@mr-quin/dango@0.3.0':
-    resolution: {integrity: sha512-8AWHbqt3f9PoVeHUtd7L0QQto3wxO8zVobDkZNoXV47ciI7u1fsiumXsfbj+AATc8YAMKJOjr7rX+gTMoaOVpg==}
+  '@mr-quin/dango@0.5.0':
+    resolution: {integrity: sha512-zrR5zmDYl/gaJTX7ugaNejrG8jhytngUpHQupSePR4yCwQM2ySlWEWvQIrQyCWrBlH1628OzWm0aYc2a8IgzaQ==}
     engines: {node: '>=20'}
 
   '@mr-quin/danmu@0.20.0-rc.4':
@@ -10412,9 +10412,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mr-quin/dango-manifests@0.3.0': {}
+  '@mr-quin/dango-manifests@0.5.0': {}
 
-  '@mr-quin/dango@0.3.0':
+  '@mr-quin/dango@0.5.0':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
       fast-xml-parser: 4.5.6


### PR DESCRIPTION
## Summary
- Bump `@mr-quin/dango` and `@mr-quin/dango-manifests` to 0.5.0 (additive: new `locales` schema field, `getDisplayStrings`, `allowPrivateHosts` run option; apiVersion unchanged).
- Allow local origins: thread the engine's `allowPrivateHosts` opt-in into every manifest pipeline run so a config pointed at a self-hosted loopback/private endpoint resolves instead of being blocked by the anti-SSRF guard.
- Localization: resolve manifest display strings (name, `configSchema` titles/descriptions, `cookieSet` title) into the active UI locale via `getDisplayStrings`. The popup passes its locale through the manifest RPCs (`providerListManifests` / `providerGetManifestSpec` / `providerRefreshCatalog`), keyed in react-query so a language switch refetches. The default UI language is Chinese, so the catalog and config editor now render localized manifest strings by default.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` (unit: `ManifestProviderService`, `ProviderService`, `ManifestRegistry`, `ProviderFactory` cover the `allowPrivateHosts` threading on all six run methods and the name/configSchema/cookieSet localization + source-string fallback; `toManifestLocale` covers the zh-variant and unset paths)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- e2e/specs/providers/localization.spec.ts` (catalog shows localized name, config editor shows localized field title)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- e2e/specs/sources/dandanplay-local-origin.spec.ts` (a config on `http://localhost` resolves; verified this spec fails when the opt-in is removed, so it is not theatre)
- [ ] Existing `config-form` / `catalog-import` specs updated to locale-stable matchers (manifest strings are now translated).

## Notes
- The catalog is served from the dango repo's `main` branch (via the proxy), which already ships the 0.5.0 manifests, so no backend change is needed.
- `allowPrivateHosts` is currently enabled globally as a single constant rather than gated per config. This is a deliberate, temporary relaxation of the anti-SSRF private-host block; the manifest `hosts` allowlist still applies. A follow-up task tracks clamping it down to a per-config, user-authorized toggle.
- Preloaded/built-in provider *instance* names (e.g. the installed Bilibili/Tencent rows) still show their seeded names rather than the localized manifest name. Fixing that cleanly means reworking provider seeding to auto-import after the manifest catalog loads; it is tracked as a separate follow-up under the manifest-driven provider epic.