### PR TITLE
(extension) seed providers from the manifest after catalog load [DA-607]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/da-client.ts
+++ b/packages/danmaku-anywhere/e2e/setup/da-client.ts
@@ -37,6 +37,10 @@ export class DaClient {
       ] as const),
     reset: (): Promise<void> =>
       this.sw.evaluate(() => self.__da.providerConfig.reset()),
+    hasSeeded: (): Promise<boolean> =>
+      this.sw.evaluate(() => self.__da.providerConfig.hasSeeded()),
+    markSeeded: (): Promise<void> =>
+      this.sw.evaluate(() => self.__da.providerConfig.markSeeded()),
   }
 
   storage = {

--- a/packages/danmaku-anywhere/e2e/setup/profile.ts
+++ b/packages/danmaku-anywhere/e2e/setup/profile.ts
@@ -45,17 +45,15 @@ export interface TestProfile {
   network?: NetworkMock[]
 }
 
-const SEEDED_FLAG_KEY = 'providerConfigSeeded'
-
 // The extension seeds its preloaded providers on first boot, after the catalog
-// loads, and sets this flag as the last step. Wait for it before rebuilding
-// storage so the seed write can't land on top of the profile's configs. The
-// flag is a definitive completion signal, so wait reliably (the ceiling only
-// guards against a genuinely stuck seed under heavy parallel load).
+// loads, and marks itself seeded as the last step. Wait for that before
+// rebuilding storage so the seed write can't land on top of the profile's
+// configs. The flag is a definitive completion signal, so wait reliably (the
+// ceiling only guards against a genuinely stuck seed under heavy parallel load).
 async function waitForSeeded(da: DaClient): Promise<void> {
   const deadline = Date.now() + 20000
   while (Date.now() < deadline) {
-    if ((await da.storage.get('sync', SEEDED_FLAG_KEY)) === true) {
+    if (await da.providerConfig.hasSeeded()) {
       return
     }
     await new Promise((resolve) => setTimeout(resolve, 50))
@@ -136,7 +134,7 @@ export async function applyProfile(
 
   // The profile is the source of truth, so mark seeding done; a catalog refresh
   // during the test must not re-seed over it.
-  await da.storage.setRaw('sync', SEEDED_FLAG_KEY, true)
+  await da.providerConfig.markSeeded()
 
   if (profile.extensionOptions) {
     await da.extensionOptions.update(profile.extensionOptions)

--- a/packages/danmaku-anywhere/e2e/setup/profile.ts
+++ b/packages/danmaku-anywhere/e2e/setup/profile.ts
@@ -42,9 +42,25 @@ export interface TestProfile {
   extensionOptions?: Partial<ExtensionOptions>
   // Raw chrome.storage seeds applied before typed writes.
   rawStorage?: RawStorageSeed[]
-  // If true, runs storage migrations after rawStorage is applied.
-  runUpgrade?: boolean
   network?: NetworkMock[]
+}
+
+const SEEDED_FLAG_KEY = 'providerConfigSeeded'
+
+// The extension seeds its preloaded providers on first boot, after the catalog
+// loads, and sets this flag as the last step. Wait for it before rebuilding
+// storage so the seed write can't land on top of the profile's configs. The
+// flag is a definitive completion signal, so wait reliably (the ceiling only
+// guards against a genuinely stuck seed under heavy parallel load).
+async function waitForSeeded(da: DaClient): Promise<void> {
+  const deadline = Date.now() + 20000
+  while (Date.now() < deadline) {
+    if ((await da.storage.get('sync', SEEDED_FLAG_KEY)) === true) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error('applyProfile: timed out waiting for the first-boot seed')
 }
 
 function buildBuiltInProviderConfigs(
@@ -97,14 +113,16 @@ export async function applyProfile(
   da: DaClient,
   profile: TestProfile
 ): Promise<void> {
+  await waitForSeeded(da)
   await da.storage.clear()
+
+  // clear() wiped the options stores; rerun the upgrade so the typed writes
+  // below have versioned options to read. Raw seeds are applied afterwards so
+  // they stay authoritative rather than being re-migrated.
+  await da.runtime.runUpgrade()
 
   for (const seed of profile.rawStorage ?? []) {
     await da.storage.setRaw(seed.area, seed.key, seed.value)
-  }
-
-  if (profile.runUpgrade) {
-    await da.runtime.runUpgrade()
   }
 
   if (
@@ -115,6 +133,10 @@ export async function applyProfile(
     const customs = profile.customProviders ?? []
     await da.providerConfig.set([...builtIns, ...customs])
   }
+
+  // The profile is the source of truth, so mark seeding done; a catalog refresh
+  // during the test must not re-seed over it.
+  await da.storage.setRaw('sync', SEEDED_FLAG_KEY, true)
 
   if (profile.extensionOptions) {
     await da.extensionOptions.update(profile.extensionOptions)

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -7,9 +7,12 @@ import { expect, test } from '../../setup/fixtures'
 
 /**
  * Fresh-install smoke. Asserts the SW registers, onInstalled seeds default
- * extensionOptions + the three built-in provider configs, no console errors.
+ * extensionOptions, and the three preloaded provider configs are seeded after
+ * the manifest catalog loads with names derived from the manifest (so they
+ * localize): the default UI language is Chinese, so the seeded names are the
+ * manifests' zh strings, not hardcoded English. No console errors.
  *
- * A runtime.reload() variant was dropped — under --load-extension, the
+ * A runtime.reload() variant was dropped: under --load-extension, the
  * extension does not respawn after reload, so the case isn't exercisable.
  */
 
@@ -18,6 +21,13 @@ const BUILTIN_PROVIDER_IDS = [
   PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
   PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
 ] as const
+
+// The manifests' zh-CN display names; the default UI language is Chinese.
+const LOCALIZED_NAMES_BY_ID: Record<string, string> = {
+  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay]]: '弹弹play',
+  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili]]: 'B站',
+  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent]]: '腾讯视频',
+}
 
 test('fresh install: default options seeded, no console errors', async ({
   context,
@@ -33,7 +43,17 @@ test('fresh install: default options seeded, no console errors', async ({
   expect(options.hotkeys).toBeTruthy()
   expect(options.theme).toBeTruthy()
 
+  // Seeding happens after the catalog loads (a network round-trip), so poll
+  // until the preloaded set lands rather than reading once.
+  await expect
+    .poll(async () => {
+      const providers = await da.providerConfig.list()
+      return providers.map((p) => p.id).sort()
+    })
+    .toEqual([...BUILTIN_PROVIDER_IDS].sort())
+
   const providers = await da.providerConfig.list()
-  const ids = providers.map((p) => p.id).sort()
-  expect(ids).toEqual([...BUILTIN_PROVIDER_IDS].sort())
+  for (const provider of providers) {
+    expect(provider.name).toBe(LOCALIZED_NAMES_BY_ID[provider.id])
+  }
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import type { SeasonService } from '@/background/services/persistence/SeasonService'
 import type { ILogger } from '@/common/Logger'
+import type { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import type { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type { IDanmakuProvider } from './IDanmakuProvider'
@@ -30,6 +31,10 @@ const silentLogger = {
   error: () => {},
   sub: () => silentLogger,
 } as unknown as ILogger
+
+const silentExtensionOptions = {
+  get: async () => ({ lang: 'zh' }),
+} as unknown as ExtensionOptionsService
 
 function makeConfig(
   manifestId: string,
@@ -97,7 +102,8 @@ function build(
     providerConfigService,
     factory,
     registry,
-    silentLogger
+    silentLogger,
+    silentExtensionOptions
   )
 
   return { service, provider, danmakuService, seasonService }
@@ -116,7 +122,8 @@ describe('ProviderService.probeLogin', () => {
       {} as unknown as ProviderConfigService,
       vi.fn(() => makeProvider()),
       registry,
-      silentLogger
+      silentLogger,
+      silentExtensionOptions
     )
 
     await service.probeLogin('dandanplay')
@@ -137,7 +144,8 @@ describe('ProviderService.getManifestSpec', () => {
       {} as unknown as ProviderConfigService,
       vi.fn(() => makeProvider()),
       registry,
-      silentLogger
+      silentLogger,
+      silentExtensionOptions
     )
   }
 
@@ -352,6 +360,7 @@ describe('ProviderService.refreshCatalog', () => {
           makeConfig(manifestId, DanmakuSourceType.DanDanPlay)
         )
       ),
+      hasSeeded: vi.fn(async () => true),
     } as unknown as ProviderConfigService
 
     const service = new ProviderService(
@@ -360,7 +369,8 @@ describe('ProviderService.refreshCatalog', () => {
       providerConfigService,
       vi.fn(),
       registry,
-      silentLogger
+      silentLogger,
+      silentExtensionOptions
     )
 
     return { service, applyUpdates, recordChecked }
@@ -422,7 +432,8 @@ describe('ProviderService.refreshCatalog', () => {
       {} as unknown as ProviderConfigService,
       vi.fn(),
       registry,
-      silentLogger
+      silentLogger,
+      silentExtensionOptions
     )
 
     await service.refreshCatalog()
@@ -447,11 +458,180 @@ describe('ProviderService.setup', () => {
       {} as unknown as ProviderConfigService,
       vi.fn(),
       registry,
-      silentLogger
+      silentLogger,
+      silentExtensionOptions
     )
 
     service.setup()
 
     expect(chrome.runtime.onInstalled.addListener).toHaveBeenCalled()
+  })
+})
+
+describe('ProviderService.seedDefaultProviders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const DEFAULT_MANIFESTS = [
+    { id: 'dandanplay', name: '弹弹play' },
+    { id: 'bilibili', name: 'B站' },
+    { id: 'tencent', name: '腾讯视频' },
+  ]
+
+  function buildForSeed(opts: {
+    seeded?: boolean
+    storeEmpty?: boolean
+    manifests?: { id: string; name: string }[]
+    lang?: string
+  }) {
+    let seeded = opts.seeded ?? false
+    const seedIfEmpty = vi.fn(async () => opts.storeEmpty ?? true)
+    const markSeeded = vi.fn(async () => {
+      seeded = true
+    })
+    const hasSeeded = vi.fn(async () => seeded)
+    const providerConfigService = {
+      seedIfEmpty,
+      markSeeded,
+      hasSeeded,
+      getAll: vi.fn(async () => []),
+    } as unknown as ProviderConfigService
+
+    const listManifests = vi.fn(() => opts.manifests ?? DEFAULT_MANIFESTS)
+    const registry = {
+      ready: Promise.resolve(true),
+      update: vi.fn(async () => true),
+      getPendingUpdates: vi.fn(async () => []),
+      recordChecked: vi.fn(async () => {}),
+      listManifests,
+    } as unknown as ManifestRegistry
+
+    const extensionOptions = {
+      get: async () => ({ lang: opts.lang ?? 'zh' }),
+    } as unknown as ExtensionOptionsService
+
+    const service = new ProviderService(
+      {} as unknown as DanmakuService,
+      {} as unknown as SeasonService,
+      providerConfigService,
+      vi.fn(),
+      registry,
+      silentLogger,
+      extensionOptions
+    )
+
+    return { service, seedIfEmpty, markSeeded, hasSeeded, listManifests }
+  }
+
+  it('seeds the preloaded set with manifest-derived names on a fresh install', async () => {
+    const { service, seedIfEmpty, markSeeded } = buildForSeed({})
+
+    await service.seedDefaultProviders()
+
+    expect(seedIfEmpty).toHaveBeenCalledTimes(1)
+    const configs = seedIfEmpty.mock.calls[0][0] as ProviderConfig[]
+    expect(configs.map((c) => c.manifestId)).toEqual([
+      'dandanplay',
+      'bilibili',
+      'tencent',
+    ])
+    // Built-in instances key their id to the manifest id.
+    expect(configs.map((c) => c.id)).toEqual([
+      'dandanplay',
+      'bilibili',
+      'tencent',
+    ])
+    // Names derive from the manifest, not a hardcoded English label.
+    expect(configs.map((c) => c.name)).toEqual(['弹弹play', 'B站', '腾讯视频'])
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves names in the active UI language', async () => {
+    const { service, listManifests, seedIfEmpty } = buildForSeed({
+      lang: 'en',
+      manifests: [
+        { id: 'dandanplay', name: 'DanDanPlay' },
+        { id: 'bilibili', name: 'Bilibili' },
+        { id: 'tencent', name: 'Tencent Video' },
+      ],
+    })
+
+    await service.seedDefaultProviders()
+
+    expect(listManifests).toHaveBeenCalledWith('en')
+    const configs = seedIfEmpty.mock.calls[0][0] as ProviderConfig[]
+    expect(configs.find((c) => c.manifestId === 'tencent')?.name).toBe(
+      'Tencent Video'
+    )
+  })
+
+  it('maps the bare zh language to its manifest locale tag', async () => {
+    const { service, listManifests } = buildForSeed({ lang: 'zh' })
+
+    await service.seedDefaultProviders()
+
+    expect(listManifests).toHaveBeenCalledWith('zh-CN')
+  })
+
+  it('never double-seeds once the flag is set', async () => {
+    const { service, seedIfEmpty, markSeeded } = buildForSeed({ seeded: true })
+
+    await service.seedDefaultProviders()
+
+    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(markSeeded).not.toHaveBeenCalled()
+  })
+
+  it('leaves an existing user untouched: the empty-store guard no-ops the write but still locks the flag', async () => {
+    const { service, seedIfEmpty, markSeeded } = buildForSeed({
+      storeEmpty: false,
+    })
+
+    await service.seedDefaultProviders()
+
+    // seedIfEmpty is asked to write but its guard reports a non-empty store, so
+    // the existing configs are preserved verbatim. The flag is still set so we
+    // never re-evaluate.
+    expect(seedIfEmpty).toHaveBeenCalledTimes(1)
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays unseeded for a later retry when the catalog has no manifests yet', async () => {
+    const { service, seedIfEmpty, markSeeded } = buildForSeed({ manifests: [] })
+
+    await service.seedDefaultProviders()
+
+    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(markSeeded).not.toHaveBeenCalled()
+  })
+
+  it('locks the flag without seeding when an existing install updates', async () => {
+    const { service, seedIfEmpty, markSeeded, hasSeeded } = buildForSeed({})
+
+    service.setup()
+    const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
+    const listener = calls.at(-1)?.[0] as (details: {
+      reason: string
+    }) => Promise<void>
+    await listener({ reason: 'update' })
+
+    expect(markSeeded).toHaveBeenCalled()
+    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(hasSeeded).toHaveBeenCalled()
+  })
+
+  it('seeds when a brand-new install fires onInstalled', async () => {
+    const { service, seedIfEmpty, markSeeded } = buildForSeed({})
+
+    service.setup()
+    const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
+    const listener = calls.at(-1)?.[0] as (details: {
+      reason: string
+    }) => Promise<void>
+    await listener({ reason: 'install' })
+
+    expect(seedIfEmpty).toHaveBeenCalledTimes(1)
+    expect(markSeeded).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -481,20 +481,17 @@ describe('ProviderService.seedDefaultProviders', () => {
 
   function buildForSeed(opts: {
     seeded?: boolean
-    storeEmpty?: boolean
     manifests?: { id: string; name: string }[]
     lang?: string
   }) {
     let seeded = opts.seeded ?? false
-    const seedIfEmpty = vi.fn(
-      async (_configs: ProviderConfig[]) => opts.storeEmpty ?? true
-    )
+    const set = vi.fn(async (_configs: ProviderConfig[]) => {})
     const markSeeded = vi.fn(async () => {
       seeded = true
     })
     const hasSeeded = vi.fn(async () => seeded)
     const providerConfigService = {
-      seedIfEmpty,
+      options: { set },
       markSeeded,
       hasSeeded,
       getAll: vi.fn(async () => []),
@@ -523,16 +520,16 @@ describe('ProviderService.seedDefaultProviders', () => {
       extensionOptions
     )
 
-    return { service, seedIfEmpty, markSeeded, hasSeeded, listManifests }
+    return { service, set, markSeeded, hasSeeded, listManifests }
   }
 
   it('seeds the preloaded set with manifest-derived names on a fresh install', async () => {
-    const { service, seedIfEmpty, markSeeded } = buildForSeed({})
+    const { service, set, markSeeded } = buildForSeed({})
 
     await service.seedDefaultProviders()
 
-    expect(seedIfEmpty).toHaveBeenCalledTimes(1)
-    const configs = seedIfEmpty.mock.calls[0][0]
+    expect(set).toHaveBeenCalledTimes(1)
+    const configs = set.mock.calls[0][0]
     expect(configs.map((c) => c.manifestId)).toEqual([
       'dandanplay',
       'bilibili',
@@ -548,7 +545,7 @@ describe('ProviderService.seedDefaultProviders', () => {
   })
 
   it('resolves names in the active UI language', async () => {
-    const { service, listManifests, seedIfEmpty } = buildForSeed({
+    const { service, listManifests, set } = buildForSeed({
       lang: 'en',
       manifests: [
         { id: 'dandanplay', name: 'DanDanPlay' },
@@ -560,7 +557,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     await service.seedDefaultProviders()
 
     expect(listManifests).toHaveBeenCalledWith('en')
-    const configs = seedIfEmpty.mock.calls[0][0]
+    const configs = set.mock.calls[0][0]
     expect(configs.find((c) => c.manifestId === 'tencent')?.name).toBe(
       'Tencent Video'
     )
@@ -574,37 +571,26 @@ describe('ProviderService.seedDefaultProviders', () => {
     expect(listManifests).toHaveBeenCalledWith('zh-CN')
   })
 
-  it('never double-seeds once the flag is set', async () => {
-    const { service, seedIfEmpty, markSeeded } = buildForSeed({ seeded: true })
+  it('does not seed once the flag is set, leaving an existing user untouched', async () => {
+    const { service, set, markSeeded } = buildForSeed({ seeded: true })
 
     await service.seedDefaultProviders()
 
-    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
     expect(markSeeded).not.toHaveBeenCalled()
   })
 
-  it('leaves an existing user untouched: the empty-store guard no-ops the write but still locks the flag', async () => {
-    const { service, seedIfEmpty, markSeeded } = buildForSeed({
-      storeEmpty: false,
-    })
-
-    await service.seedDefaultProviders()
-
-    expect(seedIfEmpty).toHaveBeenCalledTimes(1)
-    expect(markSeeded).toHaveBeenCalledTimes(1)
-  })
-
   it('stays unseeded for a later retry when the catalog has no manifests yet', async () => {
-    const { service, seedIfEmpty, markSeeded } = buildForSeed({ manifests: [] })
+    const { service, set, markSeeded } = buildForSeed({ manifests: [] })
 
     await service.seedDefaultProviders()
 
-    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
     expect(markSeeded).not.toHaveBeenCalled()
   })
 
   it('does not seed (or lock) a partial set when one preloaded manifest is still missing', async () => {
-    const { service, seedIfEmpty, markSeeded } = buildForSeed({
+    const { service, set, markSeeded } = buildForSeed({
       manifests: [
         { id: 'dandanplay', name: '弹弹play' },
         { id: 'bilibili', name: 'B站' },
@@ -613,12 +599,12 @@ describe('ProviderService.seedDefaultProviders', () => {
 
     await service.seedDefaultProviders()
 
-    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
     expect(markSeeded).not.toHaveBeenCalled()
   })
 
   it('locks the flag without seeding when an existing install updates', async () => {
-    const { service, seedIfEmpty, markSeeded, hasSeeded } = buildForSeed({})
+    const { service, set, markSeeded, hasSeeded } = buildForSeed({})
 
     service.setup()
     const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
@@ -628,12 +614,12 @@ describe('ProviderService.seedDefaultProviders', () => {
     await listener({ reason: 'update' })
 
     expect(markSeeded).toHaveBeenCalled()
-    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
     expect(hasSeeded).toHaveBeenCalled()
   })
 
   it('seeds when a brand-new install fires onInstalled', async () => {
-    const { service, seedIfEmpty, markSeeded } = buildForSeed({})
+    const { service, set, markSeeded } = buildForSeed({})
 
     service.setup()
     const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
@@ -642,7 +628,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     }) => Promise<void>
     await listener({ reason: 'install' })
 
-    expect(seedIfEmpty).toHaveBeenCalledTimes(1)
+    expect(set).toHaveBeenCalledTimes(1)
     expect(markSeeded).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -486,7 +486,9 @@ describe('ProviderService.seedDefaultProviders', () => {
     lang?: string
   }) {
     let seeded = opts.seeded ?? false
-    const seedIfEmpty = vi.fn(async () => opts.storeEmpty ?? true)
+    const seedIfEmpty = vi.fn(
+      async (_configs: ProviderConfig[]) => opts.storeEmpty ?? true
+    )
     const markSeeded = vi.fn(async () => {
       seeded = true
     })
@@ -530,7 +532,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     await service.seedDefaultProviders()
 
     expect(seedIfEmpty).toHaveBeenCalledTimes(1)
-    const configs = seedIfEmpty.mock.calls[0][0] as ProviderConfig[]
+    const configs = seedIfEmpty.mock.calls[0][0]
     expect(configs.map((c) => c.manifestId)).toEqual([
       'dandanplay',
       'bilibili',
@@ -560,7 +562,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     await service.seedDefaultProviders()
 
     expect(listManifests).toHaveBeenCalledWith('en')
-    const configs = seedIfEmpty.mock.calls[0][0] as ProviderConfig[]
+    const configs = seedIfEmpty.mock.calls[0][0]
     expect(configs.find((c) => c.manifestId === 'tencent')?.name).toBe(
       'Tencent Video'
     )
@@ -599,6 +601,20 @@ describe('ProviderService.seedDefaultProviders', () => {
 
   it('stays unseeded for a later retry when the catalog has no manifests yet', async () => {
     const { service, seedIfEmpty, markSeeded } = buildForSeed({ manifests: [] })
+
+    await service.seedDefaultProviders()
+
+    expect(seedIfEmpty).not.toHaveBeenCalled()
+    expect(markSeeded).not.toHaveBeenCalled()
+  })
+
+  it('does not seed (or lock) a partial set when one preloaded manifest is still missing', async () => {
+    const { service, seedIfEmpty, markSeeded } = buildForSeed({
+      manifests: [
+        { id: 'dandanplay', name: '弹弹play' },
+        { id: 'bilibili', name: 'B站' },
+      ],
+    })
 
     await service.seedDefaultProviders()
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -538,13 +538,11 @@ describe('ProviderService.seedDefaultProviders', () => {
       'bilibili',
       'tencent',
     ])
-    // Built-in instances key their id to the manifest id.
     expect(configs.map((c) => c.id)).toEqual([
       'dandanplay',
       'bilibili',
       'tencent',
     ])
-    // Names derive from the manifest, not a hardcoded English label.
     expect(configs.map((c) => c.name)).toEqual(['弹弹play', 'B站', '腾讯视频'])
     expect(markSeeded).toHaveBeenCalledTimes(1)
   })
@@ -592,9 +590,6 @@ describe('ProviderService.seedDefaultProviders', () => {
 
     await service.seedDefaultProviders()
 
-    // seedIfEmpty is asked to write but its guard reports a non-empty store, so
-    // the existing configs are preserved verbatim. The flag is still set so we
-    // never re-evaluate.
     expect(seedIfEmpty).toHaveBeenCalledTimes(1)
     expect(markSeeded).toHaveBeenCalledTimes(1)
   })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -23,6 +23,7 @@ import {
   AUTO_IMPORT_PROVIDERS,
   autoImportToProviderConfig,
 } from '@/common/options/providerConfig/constant'
+import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type {
   ProviderLoginStatus,
@@ -352,12 +353,16 @@ export class ProviderService {
     const names = new Map(
       this.manifestRegistry.listManifests(locale).map((m) => [m.id, m.name])
     )
-    const configs = AUTO_IMPORT_PROVIDERS.flatMap((entry) => {
+    const configs: ProviderConfig[] = []
+    for (const entry of AUTO_IMPORT_PROVIDERS) {
       const name = names.get(entry.manifestId)
-      return name === undefined ? [] : [autoImportToProviderConfig(entry, name)]
-    })
-    if (configs.length === 0) {
-      return
+      if (name === undefined) {
+        // A preloaded manifest has not loaded yet. Seed nothing and leave the
+        // flag unset so the next sync retries, rather than seed a partial set
+        // and lock the missing source out forever.
+        return
+      }
+      configs.push(autoImportToProviderConfig(entry, name))
     }
     await this.providerConfigService.seedIfEmpty(configs)
     await this.providerConfigService.markSeeded()

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -354,7 +354,7 @@ export class ProviderService {
       }
       configs.push(autoImportToProviderConfig(entry, name))
     }
-    await this.providerConfigService.seedIfEmpty(configs)
+    await this.providerConfigService.options.set(configs)
     await this.providerConfigService.markSeeded()
   }
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -17,6 +17,12 @@ import type {
   DanmakuFetchRequest,
 } from '@/common/danmaku/dto'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
+import { toManifestLocale } from '@/common/localization/language'
+import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
+import {
+  AUTO_IMPORT_PROVIDERS,
+  autoImportToProviderConfig,
+} from '@/common/options/providerConfig/constant'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type {
   ProviderLoginStatus,
@@ -57,7 +63,9 @@ export class ProviderService {
     private danmakuProviderFactory: IDanmakuProviderFactory,
     @inject(ManifestRegistry)
     private manifestRegistry: ManifestRegistry,
-    @inject(LoggerSymbol) logger: ILogger
+    @inject(LoggerSymbol) logger: ILogger,
+    @inject(ExtensionOptionsService)
+    private extensionOptions: ExtensionOptionsService
   ) {
     invariant(
       isServiceWorker(),
@@ -273,14 +281,27 @@ export class ProviderService {
     }
   }
 
-  // Seed the catalog on install. The periodic refresh is scheduled by
-  // AlarmManager, which calls syncCatalog when the alarm fires.
+  // Seed the catalog (and the preloaded provider configs) on install. The
+  // periodic refresh is scheduled by AlarmManager, which calls syncCatalog when
+  // the alarm fires.
   setup(): void {
-    chrome.runtime.onInstalled.addListener(() => {
-      this.syncCatalog().catch((e) => {
-        this.logger.error('Catalog sync failed:', e)
+    chrome.runtime.onInstalled.addListener((details) => {
+      return this.onInstalled(details.reason).catch((e) => {
+        this.logger.error('Install handling failed:', e)
       })
     })
+  }
+
+  private async onInstalled(reason: string): Promise<void> {
+    if (reason === 'update') {
+      // An extension update is an existing install: lock the seed flag before
+      // any catalog work can seed, so its configs survive verbatim even if the
+      // user deleted them all. A fresh install ('install') seeds; a browser
+      // update ('chrome_update') leaves the flag to the normal seed path so an
+      // install that was offline at first run can still seed once reachable.
+      await this.providerConfigService.markSeeded()
+    }
+    await this.syncCatalog()
   }
 
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
@@ -313,6 +334,33 @@ export class ProviderService {
       }
     }
     await this.manifestRegistry.recordChecked()
+    await this.seedDefaultProviders()
+  }
+
+  // Seed the preloaded provider configs once, after the catalog has loaded so
+  // each name derives (and localizes) from its manifest. The one-shot flag and
+  // the empty-store guard together keep an existing user's configs untouched;
+  // a fresh install with an unreachable catalog stays unseeded and retries on
+  // the next sync.
+  async seedDefaultProviders(): Promise<void> {
+    if (await this.providerConfigService.hasSeeded()) {
+      return
+    }
+    await this.manifestRegistry.ready
+    const { lang } = await this.extensionOptions.get()
+    const locale = toManifestLocale(lang)
+    const names = new Map(
+      this.manifestRegistry.listManifests(locale).map((m) => [m.id, m.name])
+    )
+    const configs = AUTO_IMPORT_PROVIDERS.flatMap((entry) => {
+      const name = names.get(entry.manifestId)
+      return name === undefined ? [] : [autoImportToProviderConfig(entry, name)]
+    })
+    if (configs.length === 0) {
+      return
+    }
+    await this.providerConfigService.seedIfEmpty(configs)
+    await this.providerConfigService.markSeeded()
   }
 
   // Surfaces the host-relevant subset of a manifest so the popup can render

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -282,9 +282,6 @@ export class ProviderService {
     }
   }
 
-  // Seed the catalog (and the preloaded provider configs) on install. The
-  // periodic refresh is scheduled by AlarmManager, which calls syncCatalog when
-  // the alarm fires.
   setup(): void {
     chrome.runtime.onInstalled.addListener((details) => {
       return this.onInstalled(details.reason).catch((e) => {
@@ -295,11 +292,8 @@ export class ProviderService {
 
   private async onInstalled(reason: string): Promise<void> {
     if (reason === 'update') {
-      // An extension update is an existing install: lock the seed flag before
-      // any catalog work can seed, so its configs survive verbatim even if the
-      // user deleted them all. A fresh install ('install') seeds; a browser
-      // update ('chrome_update') leaves the flag to the normal seed path so an
-      // install that was offline at first run can still seed once reachable.
+      // Lock the flag for an existing install so its configs are never
+      // re-seeded, even if the user has deleted them all.
       await this.providerConfigService.markSeeded()
     }
     await this.syncCatalog()
@@ -338,28 +332,24 @@ export class ProviderService {
     await this.seedDefaultProviders()
   }
 
-  // Seed the preloaded provider configs once, after the catalog has loaded so
-  // each name derives (and localizes) from its manifest. The one-shot flag and
-  // the empty-store guard together keep an existing user's configs untouched;
-  // a fresh install with an unreachable catalog stays unseeded and retries on
-  // the next sync.
+  // Seed the preloaded configs once, after the catalog loads so each name comes
+  // from its manifest. Skips entirely until every preloaded manifest is present
+  // so a transient partial fetch never seeds a subset and then locks.
   async seedDefaultProviders(): Promise<void> {
     if (await this.providerConfigService.hasSeeded()) {
       return
     }
     await this.manifestRegistry.ready
     const { lang } = await this.extensionOptions.get()
-    const locale = toManifestLocale(lang)
     const names = new Map(
-      this.manifestRegistry.listManifests(locale).map((m) => [m.id, m.name])
+      this.manifestRegistry
+        .listManifests(toManifestLocale(lang))
+        .map((m) => [m.id, m.name])
     )
     const configs: ProviderConfig[] = []
     for (const entry of AUTO_IMPORT_PROVIDERS) {
       const name = names.get(entry.manifestId)
       if (name === undefined) {
-        // A preloaded manifest has not loaded yet. Seed nothing and leave the
-        // flag unset so the next sync retries, rather than seed a partial set
-        // and lock the missing source out forever.
         return
       }
       configs.push(autoImportToProviderConfig(entry, name))

--- a/packages/danmaku-anywhere/src/common/options/OptionsService/OptionsService.ts
+++ b/packages/danmaku-anywhere/src/common/options/OptionsService/OptionsService.ts
@@ -119,6 +119,26 @@ export class OptionsService<T extends OptionsSchema> {
     })
   }
 
+  // Atomically replace the stored data only when `shouldWrite` returns true for
+  // the current value. Runs inside the write queue so it can't race a
+  // concurrent set(), and writes at the latest version so it also works on an
+  // unset store (fresh install). Returns whether it wrote.
+  async setIf(shouldWrite: (current: T | undefined) => boolean, data: T) {
+    await this.readinessService.waitUntilReady()
+
+    return this.queueOperation(async () => {
+      const options = await this.storageService.read()
+      if (!shouldWrite(options?.data)) {
+        return false
+      }
+      await this.storageService.set({
+        data,
+        version: this.getLatestVersion().version,
+      })
+      return true
+    })
+  }
+
   // allow partial update
   async update(data: Partial<T>) {
     await this.readinessService.waitUntilReady()

--- a/packages/danmaku-anywhere/src/common/options/OptionsService/OptionsService.ts
+++ b/packages/danmaku-anywhere/src/common/options/OptionsService/OptionsService.ts
@@ -119,25 +119,6 @@ export class OptionsService<T extends OptionsSchema> {
     })
   }
 
-  // Replace the stored data only when `shouldWrite` accepts the current value.
-  // Queued so it can't race a concurrent set(), and writes at the latest version
-  // so it also works on an unset store. Returns whether it wrote.
-  async setIf(shouldWrite: (current: T | undefined) => boolean, data: T) {
-    await this.readinessService.waitUntilReady()
-
-    return this.queueOperation(async () => {
-      const options = await this.storageService.read()
-      if (!shouldWrite(options?.data)) {
-        return false
-      }
-      await this.storageService.set({
-        data,
-        version: this.getLatestVersion().version,
-      })
-      return true
-    })
-  }
-
   // allow partial update
   async update(data: Partial<T>) {
     await this.readinessService.waitUntilReady()

--- a/packages/danmaku-anywhere/src/common/options/OptionsService/OptionsService.ts
+++ b/packages/danmaku-anywhere/src/common/options/OptionsService/OptionsService.ts
@@ -119,10 +119,9 @@ export class OptionsService<T extends OptionsSchema> {
     })
   }
 
-  // Atomically replace the stored data only when `shouldWrite` returns true for
-  // the current value. Runs inside the write queue so it can't race a
-  // concurrent set(), and writes at the latest version so it also works on an
-  // unset store (fresh install). Returns whether it wrote.
+  // Replace the stored data only when `shouldWrite` accepts the current value.
+  // Queued so it can't race a concurrent set(), and writes at the latest version
+  // so it also works on an unset store. Returns whether it wrote.
   async setIf(shouldWrite: (current: T | undefined) => boolean, data: T) {
     await this.readinessService.waitUntilReady()
 

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/constant.ts
@@ -9,54 +9,88 @@ import type { ProviderConfig } from './schema'
 
 export const PROXY_DDP_BASE_URL = `${import.meta.env.VITE_PROXY_URL}/ddp`
 
-export const builtInDanDanPlayProvider: ProviderConfig = {
-  id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-  manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-  name: 'DanDanPlay',
-  impl: DanmakuSourceType.DanDanPlay,
-  enabled: true,
-  configValues: {
-    baseUrl: PROXY_DDP_BASE_URL,
-    chConvert: DanDanChConvert.None,
+// The preloaded set, kept lean: identity (manifestId) plus the few config
+// overrides that differ from the manifest's own defaults. The display name is
+// resolved from the manifest at seed time so it localizes; `fallbackName` only
+// applies where no manifest is available (legacy migrations, offline reset).
+export interface AutoImportProvider {
+  manifestId: string
+  impl: DanmakuSourceType
+  fallbackName: string
+  enabled: boolean
+  configValues: Record<string, unknown>
+}
+
+export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
+  {
+    manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
+    impl: DanmakuSourceType.DanDanPlay,
+    fallbackName: 'DanDanPlay',
+    enabled: true,
+    configValues: {
+      baseUrl: PROXY_DDP_BASE_URL,
+      chConvert: DanDanChConvert.None,
+    },
   },
-}
-
-export const builtInBilibiliProvider: ProviderConfig = {
-  id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
-  manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
-  name: 'Bilibili',
-  impl: DanmakuSourceType.Bilibili,
-  enabled: true,
-  // Pin xml explicitly so the user-visible default matches master. The
-  // manifest defaults to protobuf, which is the better long-term endpoint
-  // but would silently switch the format for existing users on upgrade.
-  configValues: {
-    danmakuFormat: 'xml',
+  {
+    manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
+    impl: DanmakuSourceType.Bilibili,
+    fallbackName: 'Bilibili',
+    enabled: true,
+    // Pin xml explicitly so the user-visible default matches master. The
+    // manifest defaults to protobuf, which is the better long-term endpoint
+    // but would silently switch the format for existing users on upgrade.
+    configValues: {
+      danmakuFormat: 'xml',
+    },
   },
-}
-
-export const builtInTencentProvider: ProviderConfig = {
-  id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
-  manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
-  name: 'Tencent',
-  impl: DanmakuSourceType.Tencent,
-  enabled: true,
-  configValues: {},
-}
-
-export const defaultProviderConfigs: ProviderConfig[] = [
-  builtInDanDanPlayProvider,
-  builtInBilibiliProvider,
-  builtInTencentProvider,
+  {
+    manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
+    impl: DanmakuSourceType.Tencent,
+    fallbackName: 'Tencent',
+    enabled: true,
+    configValues: {},
+  },
 ]
 
+// Built-in instances key their config id to the manifest id; season
+// providerConfigId references depend on this equality.
+export function autoImportToProviderConfig(
+  entry: AutoImportProvider,
+  name: string
+): ProviderConfig {
+  return {
+    id: entry.manifestId,
+    manifestId: entry.manifestId,
+    name,
+    impl: entry.impl,
+    enabled: entry.enabled,
+    configValues: { ...entry.configValues },
+  }
+}
+
+// Full configs carrying the hardcoded fallback names. Used only where no
+// manifest is available: legacy-data migrations for existing users and the
+// offline reset fallback. Fresh installs seed from the manifest instead so the
+// preloaded names localize (see ProviderService.seedDefaultProviders).
+export const defaultProviderConfigs: ProviderConfig[] =
+  AUTO_IMPORT_PROVIDERS.map((entry) =>
+    autoImportToProviderConfig(entry, entry.fallbackName)
+  )
+
+export const builtInDanDanPlayProvider = defaultProviderConfigs[0]
+export const builtInBilibiliProvider = defaultProviderConfigs[1]
+export const builtInTencentProvider = defaultProviderConfigs[2]
+
 export function createDefaultProviderConfig(
-  manifestId: string
+  manifestId: string,
+  name?: string
 ): ProviderConfig | undefined {
-  const config = defaultProviderConfigs.find((c) => c.manifestId === manifestId)
-  return config
-    ? { ...config, configValues: { ...config.configValues } }
-    : undefined
+  const entry = AUTO_IMPORT_PROVIDERS.find((e) => e.manifestId === manifestId)
+  if (!entry) {
+    return undefined
+  }
+  return autoImportToProviderConfig(entry, name ?? entry.fallbackName)
 }
 
 export function createCustomDanDanPlayProvider(

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/constant.ts
@@ -9,15 +9,9 @@ import type { ProviderConfig } from './schema'
 
 export const PROXY_DDP_BASE_URL = `${import.meta.env.VITE_PROXY_URL}/ddp`
 
-// The preloaded set, kept lean: identity (manifestId) plus the few config
-// overrides that differ from the manifest's own defaults. The display name is
-// resolved from the manifest at seed time so it localizes; `fallbackName` only
-// applies where no manifest is available (legacy migrations, offline reset).
 export interface AutoImportProvider {
   manifestId: string
   impl: DanmakuSourceType
-  fallbackName: string
-  enabled: boolean
   configValues: Record<string, unknown>
 }
 
@@ -25,8 +19,6 @@ export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
   {
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
     impl: DanmakuSourceType.DanDanPlay,
-    fallbackName: 'DanDanPlay',
-    enabled: true,
     configValues: {
       baseUrl: PROXY_DDP_BASE_URL,
       chConvert: DanDanChConvert.None,
@@ -35,11 +27,8 @@ export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
   {
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
     impl: DanmakuSourceType.Bilibili,
-    fallbackName: 'Bilibili',
-    enabled: true,
-    // Pin xml explicitly so the user-visible default matches master. The
-    // manifest defaults to protobuf, which is the better long-term endpoint
-    // but would silently switch the format for existing users on upgrade.
+    // Pin xml; the manifest defaults to protobuf, which would change the format
+    // for users who never picked it.
     configValues: {
       danmakuFormat: 'xml',
     },
@@ -47,14 +36,11 @@ export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
   {
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
     impl: DanmakuSourceType.Tencent,
-    fallbackName: 'Tencent',
-    enabled: true,
     configValues: {},
   },
 ]
 
-// Built-in instances key their config id to the manifest id; season
-// providerConfigId references depend on this equality.
+// id equals manifestId; season providerConfigId references depend on it.
 export function autoImportToProviderConfig(
   entry: AutoImportProvider,
   name: string
@@ -64,33 +50,17 @@ export function autoImportToProviderConfig(
     manifestId: entry.manifestId,
     name,
     impl: entry.impl,
-    enabled: entry.enabled,
+    enabled: true,
     configValues: { ...entry.configValues },
   }
 }
 
-// Full configs carrying the hardcoded fallback names. Used only where no
-// manifest is available: legacy-data migrations for existing users and the
-// offline reset fallback. Fresh installs seed from the manifest instead so the
-// preloaded names localize (see ProviderService.seedDefaultProviders).
-export const defaultProviderConfigs: ProviderConfig[] =
-  AUTO_IMPORT_PROVIDERS.map((entry) =>
-    autoImportToProviderConfig(entry, entry.fallbackName)
-  )
-
-export const builtInDanDanPlayProvider = defaultProviderConfigs[0]
-export const builtInBilibiliProvider = defaultProviderConfigs[1]
-export const builtInTencentProvider = defaultProviderConfigs[2]
-
 export function createDefaultProviderConfig(
   manifestId: string,
-  name?: string
+  name: string
 ): ProviderConfig | undefined {
   const entry = AUTO_IMPORT_PROVIDERS.find((e) => e.manifestId === manifestId)
-  if (!entry) {
-    return undefined
-  }
-  return autoImportToProviderConfig(entry, name ?? entry.fallbackName)
+  return entry ? autoImportToProviderConfig(entry, name) : undefined
 }
 
 export function createCustomDanDanPlayProvider(

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
@@ -6,13 +6,30 @@ import {
 } from '@danmaku-anywhere/danmaku-converter'
 import { DanDanChConvert } from '@danmaku-anywhere/danmaku-provider/ddp'
 import {
-  builtInBilibiliProvider,
-  builtInDanDanPlayProvider,
-  builtInTencentProvider,
-  defaultProviderConfigs,
+  AUTO_IMPORT_PROVIDERS,
+  autoImportToProviderConfig,
   PROXY_DDP_BASE_URL,
 } from './constant'
 import { type ProviderConfig, providerConfigSchema } from './schema'
+
+// Names for built-ins migrated from storage older than the manifest catalog.
+// Fresh installs take the name from the manifest instead (see ProviderService).
+const LEGACY_BUILTIN_NAMES: Record<string, string> = {
+  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay]]: 'DanDanPlay',
+  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili]]: 'Bilibili',
+  [PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent]]: 'Tencent',
+}
+
+export const defaultProviderConfigs: ProviderConfig[] =
+  AUTO_IMPORT_PROVIDERS.map((entry) =>
+    autoImportToProviderConfig(entry, LEGACY_BUILTIN_NAMES[entry.manifestId])
+  )
+
+const [
+  builtInDanDanPlayProvider,
+  builtInBilibiliProvider,
+  builtInTencentProvider,
+] = defaultProviderConfigs
 
 // Drop undefined-valued keys so manifest configSchema defaults can apply.
 function pruneUndefined(obj: Record<string, unknown>): Record<string, unknown> {

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
@@ -59,12 +59,8 @@ export function migrateDanmakuSourcesToProviders(
             return builtInDanDanPlayProvider
           }
           return {
-            id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-            manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-            name: 'DanDanPlay',
-            impl: DanmakuSourceType.DanDanPlay,
+            ...builtInDanDanPlayProvider,
             enabled: oldSources.dandanplay.enabled ?? true,
-            isBuiltIn: true,
             configValues: pruneUndefined({
               baseUrl: PROXY_DDP_BASE_URL,
               chConvert:
@@ -84,11 +80,7 @@ export function migrateDanmakuSourcesToProviders(
             return builtInBilibiliProvider
           }
           return {
-            id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
-            manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
-            name: 'Bilibili',
-            impl: DanmakuSourceType.Bilibili,
-            isBuiltIn: true,
+            ...builtInBilibiliProvider,
             enabled: oldSources.bilibili.enabled ?? false,
             configValues: pruneUndefined({
               danmakuFormat: oldSources.bilibili.danmakuTypePreference,
@@ -107,11 +99,7 @@ export function migrateDanmakuSourcesToProviders(
             return builtInTencentProvider
           }
           return {
-            id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
-            manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
-            name: 'Tencent',
-            impl: DanmakuSourceType.Tencent,
-            isBuiltIn: true,
+            ...builtInTencentProvider,
             enabled: oldSources.tencent.enabled ?? false,
             configValues: {},
           }

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -96,14 +96,6 @@ export class ProviderConfigService implements IStoreService {
     await this.seededFlag.set(true)
   }
 
-  // Atomic so it can never overwrite configs an existing user already has.
-  async seedIfEmpty(configs: ProviderConfig[]): Promise<boolean> {
-    return this.options.setIf(
-      (current) => !current || current.length === 0,
-      configs
-    )
-  }
-
   async isIdUnique(id: string, excludeId?: string): Promise<boolean> {
     const configs = await this.options.get()
     return !configs.some((item) => item.id === id && item.id !== excludeId)

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -11,8 +11,8 @@ import type { OptionsService } from '@/common/options/OptionsService/OptionsServ
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { ExtStorageService } from '@/common/storage/ExtStorageService'
 import { isServiceWorker } from '@/common/utils/utils'
-import { defaultProviderConfigs } from './constant'
 import {
+  defaultProviderConfigs,
   ensureBuiltinProviders,
   migrateBuiltinPrefixedProviderIds,
   migrateDanDanPlayApiBaseUrl,
@@ -26,9 +26,8 @@ export class ProviderConfigService implements IStoreService {
   public readonly name = 'providerConfig'
   public readonly options: OptionsService<ProviderConfig[]>
 
-  // One-shot guard so the preloaded set seeds once and a user who deletes every
-  // config is never re-seeded. Stored in sync alongside the configs so a second
-  // signed-in device reads the same flag and does not re-seed the shared store.
+  // Stored in sync alongside the configs so a second signed-in device reads the
+  // same flag and does not re-seed the shared store.
   private readonly seededFlag = new ExtStorageService<boolean>(
     'providerConfigSeeded',
     { storageType: 'sync' }
@@ -42,9 +41,7 @@ export class ProviderConfigService implements IStoreService {
   ) {
     this.options = this.optionServiceFactory<ProviderConfig[]>(
       'providerConfig',
-      // Fresh installs start empty; the preloaded set is seeded after the
-      // manifest catalog loads so its names derive (and localize) from the
-      // manifest. defaultProviderConfigs stays the offline fallback below.
+      // Fresh installs start empty and are seeded after the catalog loads.
       [],
       this.logger
     )
@@ -99,11 +96,10 @@ export class ProviderConfigService implements IStoreService {
     await this.seededFlag.set(true)
   }
 
-  // Write the preloaded set only while the store is still empty, atomically, so
-  // it can never overwrite configs an existing user already has.
+  // Atomic so it can never overwrite configs an existing user already has.
   async seedIfEmpty(configs: ProviderConfig[]): Promise<boolean> {
     return this.options.setIf(
-      (current) => current === undefined || current.length === 0,
+      (current) => !current || current.length === 0,
       configs
     )
   }

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -26,11 +26,12 @@ export class ProviderConfigService implements IStoreService {
   public readonly name = 'providerConfig'
   public readonly options: OptionsService<ProviderConfig[]>
 
-  // One-shot guard: seeding the preloaded providers runs once per install, so a
-  // user who deletes every config is never re-seeded on a later boot.
+  // One-shot guard so the preloaded set seeds once and a user who deletes every
+  // config is never re-seeded. Stored in sync alongside the configs so a second
+  // signed-in device reads the same flag and does not re-seed the shared store.
   private readonly seededFlag = new ExtStorageService<boolean>(
     'providerConfigSeeded',
-    { storageType: 'local' }
+    { storageType: 'sync' }
   )
 
   constructor(

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -9,6 +9,7 @@ import {
 } from '@/common/options/OptionsService/OptionServiceFactory'
 import type { OptionsService } from '@/common/options/OptionsService/OptionsService'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { ExtStorageService } from '@/common/storage/ExtStorageService'
 import { isServiceWorker } from '@/common/utils/utils'
 import { defaultProviderConfigs } from './constant'
 import {
@@ -25,6 +26,13 @@ export class ProviderConfigService implements IStoreService {
   public readonly name = 'providerConfig'
   public readonly options: OptionsService<ProviderConfig[]>
 
+  // One-shot guard: seeding the preloaded providers runs once per install, so a
+  // user who deletes every config is never re-seeded on a later boot.
+  private readonly seededFlag = new ExtStorageService<boolean>(
+    'providerConfigSeeded',
+    { storageType: 'local' }
+  )
+
   constructor(
     @inject(LoggerSymbol)
     private readonly logger: ILogger,
@@ -33,7 +41,10 @@ export class ProviderConfigService implements IStoreService {
   ) {
     this.options = this.optionServiceFactory<ProviderConfig[]>(
       'providerConfig',
-      defaultProviderConfigs,
+      // Fresh installs start empty; the preloaded set is seeded after the
+      // manifest catalog loads so its names derive (and localize) from the
+      // manifest. defaultProviderConfigs stays the offline fallback below.
+      [],
       this.logger
     )
       .version(2, {
@@ -78,6 +89,24 @@ export class ProviderConfigService implements IStoreService {
         },
       })
   }
+
+  async hasSeeded(): Promise<boolean> {
+    return (await this.seededFlag.read()) === true
+  }
+
+  async markSeeded(): Promise<void> {
+    await this.seededFlag.set(true)
+  }
+
+  // Write the preloaded set only while the store is still empty, atomically, so
+  // it can never overwrite configs an existing user already has.
+  async seedIfEmpty(configs: ProviderConfig[]): Promise<boolean> {
+    return this.options.setIf(
+      (current) => current === undefined || current.length === 0,
+      configs
+    )
+  }
+
   async isIdUnique(id: string, excludeId?: string): Promise<boolean> {
     const configs = await this.options.get()
     return !configs.some((item) => item.id === id && item.id !== excludeId)

--- a/packages/danmaku-anywhere/src/devApi/namespaces/ProviderConfigNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/ProviderConfigNamespace.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify'
-import { defaultProviderConfigs } from '@/common/options/providerConfig/constant'
+import { defaultProviderConfigs } from '@/common/options/providerConfig/migration'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import { type AnyMethodDef, type DevNamespace, defineMethod } from '../registry'

--- a/packages/danmaku-anywhere/src/devApi/namespaces/ProviderConfigNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/ProviderConfigNamespace.ts
@@ -10,6 +10,8 @@ export interface ProviderConfigApi {
   set(configs: ProviderConfig[]): Promise<void>
   toggle(id: string, enabled?: boolean): Promise<ProviderConfig>
   reset(): Promise<void>
+  hasSeeded(): Promise<boolean>
+  markSeeded(): Promise<void>
 }
 
 @injectable('Singleton')
@@ -60,6 +62,18 @@ export class ProviderConfigNamespace implements DevNamespace {
         description: 'Reset provider configs to defaults',
         kind: 'write',
         handler: () => this.service.options.set([...defaultProviderConfigs]),
+      }),
+      defineMethod({
+        name: 'hasSeeded',
+        description: 'Whether the preloaded providers have been seeded',
+        kind: 'read',
+        handler: () => this.service.hasSeeded(),
+      }),
+      defineMethod({
+        name: 'markSeeded',
+        description: 'Mark the preloaded providers as seeded',
+        kind: 'write',
+        handler: () => this.service.markSeeded(),
       }),
     ]
   }

--- a/packages/danmaku-anywhere/src/popup/pages/providers/pages/ProvidersPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/pages/ProvidersPage.tsx
@@ -110,7 +110,7 @@ export const ProvidersPage = (): ReactElement => {
   }
 
   const handleImport = (manifest: ProviderManifestInfo) => {
-    const seeded = createDefaultProviderConfig(manifest.id)
+    const seeded = createDefaultProviderConfig(manifest.id, manifest.name)
     if (seeded) {
       createConfig(seeded)
       return
@@ -125,7 +125,10 @@ export const ProvidersPage = (): ReactElement => {
   }
 
   const handleAddDefaultInstance = (manifestId: string) => {
-    const seeded = createDefaultProviderConfig(manifestId)
+    const seeded = createDefaultProviderConfig(
+      manifestId,
+      manifestById.get(manifestId)?.name
+    )
     if (seeded) {
       createConfig(seeded)
     }

--- a/packages/danmaku-anywhere/src/popup/pages/providers/pages/ProvidersPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/pages/ProvidersPage.tsx
@@ -125,10 +125,11 @@ export const ProvidersPage = (): ReactElement => {
   }
 
   const handleAddDefaultInstance = (manifestId: string) => {
-    const seeded = createDefaultProviderConfig(
-      manifestId,
-      manifestById.get(manifestId)?.name
-    )
+    const manifest = manifestById.get(manifestId)
+    if (!manifest) {
+      return
+    }
+    const seeded = createDefaultProviderConfig(manifestId, manifest.name)
     if (seeded) {
       createConfig(seeded)
     }


### PR DESCRIPTION
## Summary
- Move preloaded provider seeding out of the options migration (which runs before manifests exist) to after the manifest catalog loads, so each seeded config derives its display name from the manifest and localizes.
- Replace the hardcoded `defaultProviderConfigs` / parallel migration blocks with one lean `AUTO_IMPORT_PROVIDERS` list (`{ manifestId, impl, configValues }`). The seed path has no fallback: it reads names from the loaded manifests and seeds the full set, or seeds nothing and retries on the next sync.
- Seeding is gated by a one-shot `providerConfigSeeded` flag (sync storage, alongside the configs): fresh install seeds once; an extension `update` locks the flag without seeding. The legacy-data fallback (`defaultProviderConfigs`, hardcoded names) lives in `migration.ts` and is used only for existing-user migration, which runs before manifests are available.

## Re-localize vs freeze decision
Preloaded names are **frozen at seed time** (resolved from the manifest in the UI language active at install), not re-localized live on language switch. `config.name` is a stored, user-editable label (the editor exposes a Name field; custom DanDanPlay instances are user-named), so live re-localization would clobber a rename or require reintroducing a built-in/default distinction the schema just deprecated. The catalog and config-editor already show live-localized manifest strings; the installed list shows the user's stored label. Existing users keep their stored names verbatim (migration safety).

## Migration safety (primary requirement)
- Existing users are never re-seeded or wiped: an extension `update` locks the seeded flag without seeding; a populated store is preserved verbatim.
- The flag lives in sync storage so a second signed-in device reads the same flag and does not re-seed the shared store.
- Fresh install seeds once after the catalog loads, all-or-nothing (a partial catalog stays unseeded and retries rather than locking a missing source out).

## Notes
- Seeding is a plain flag-gated `options.set`; the earlier atomic `seedIfEmpty`/`setIf` guard was removed. It only existed to stop the e2e `applyProfile` helper racing the first-boot seed, which is a test-setup concern: `applyProfile` now waits for the first-boot seed to settle, rebuilds storage via `runUpgrade`, and stamps the seeded flag so the profile owns the state.
- Added `providerConfig.hasSeeded`/`markSeeded` to the dev API so the harness reads the flag through a typed accessor instead of a raw storage key. Deferred testability items (a catalog-sync trigger + a direct empty-store re-seed e2e) are tracked on DA-611.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` — focused seeding/migration-safety coverage in `src/background/services/providers/ProviderService.test.ts` (fresh-install seeds the expected localized set; idempotent once flagged; `update` locks without seeding; partial/empty catalog stays unseeded) plus `src/common/options/providerConfig/migration.test.ts`.
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- e2e/specs/lifecycle/install.spec.ts e2e/specs/migration/migration-smoke.spec.ts` — fresh install seeds the three preloaded configs with manifest-derived (zh-default) names; a prior install's configs survive the swap upgrade.
- Verified locally: `providers` + `sources` + `lifecycle` + `migration` specs pass; `pnpm lint` / `tsc` clean (4 known pre-existing zod/hookform errors aside).