### PR TITLE
(extension) e2e coverage for migrate-on-import path [DA-608]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/BackupPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/BackupPage.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test'
+
+const SELECTORS = {
+  restoreInput: '[data-testid="backup-restore-input"]',
+}
+
+interface FilePayload {
+  name: string
+  mimeType: string
+  buffer: Buffer
+}
+
+// The /options/backup sub-page. Restore drives a hidden file input wired to
+// the backupImport RPC.
+export class BackupPage {
+  constructor(private readonly page: Page) {}
+
+  async restoreFromFile(file: FilePayload): Promise<void> {
+    await this.page.locator(SELECTORS.restoreInput).setInputFiles(file)
+  }
+}

--- a/packages/danmaku-anywhere/e2e/pom/ImportPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ImportPage.ts
@@ -1,0 +1,28 @@
+import type { Page } from '@playwright/test'
+import { ImportResultDialog } from './ImportResultDialog'
+
+const SELECTORS = {
+  fileInput: '[data-testid="danmaku-import-file-input"]',
+}
+
+// The standalone danmaku import page (#/import). Opened detached so it fills
+// the viewport and the file picker runs in-place.
+export class ImportPage {
+  readonly result: ImportResultDialog
+
+  private constructor(private readonly page: Page) {
+    this.result = new ImportResultDialog(page)
+  }
+
+  static async open(page: Page, extensionId: string): Promise<ImportPage> {
+    await page.goto(
+      `chrome-extension://${extensionId}/pages/popup.html?detached=1#/import`
+    )
+    await page.locator('#root').waitFor({ state: 'visible' })
+    return new ImportPage(page)
+  }
+
+  async selectFiles(files: string | string[]): Promise<void> {
+    await this.page.locator(SELECTORS.fileInput).setInputFiles(files)
+  }
+}

--- a/packages/danmaku-anywhere/e2e/pom/ImportResultDialog.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ImportResultDialog.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, type Page } from '@playwright/test'
 
 const SELECTORS = {
   confirm: '[data-testid="import-result-confirm"]',
+  success: '[data-testid="import-result-success"]',
 }
 
 interface ExpectOptions {
@@ -24,5 +25,12 @@ export class ImportResultDialog {
     const { timeout = 5_000 } = options
     await this.expectVisible({ timeout })
     await this.confirmButton.click({ timeout })
+  }
+
+  // A backup import parses and migrates every file before the result renders,
+  // so a large fixture can take longer than the default expect timeout.
+  async expectSuccess(options: ExpectOptions = {}): Promise<void> {
+    const { timeout = 15_000 } = options
+    await expect(this.page.locator(SELECTORS.success)).toBeVisible({ timeout })
   }
 }

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test'
+import { BackupPage } from './BackupPage'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ImportResultDialog } from './ImportResultDialog'
 import { MountPage } from './MountPage'
@@ -15,6 +16,7 @@ export class Popup {
   readonly seasonDetails: SeasonDetailsPage
   readonly providers: ProvidersPage
   readonly options: OptionsPage
+  readonly backup: BackupPage
   readonly toast: Toast
   readonly dialog: ConfirmDialog
   readonly urlImport: UrlImportDialog
@@ -26,6 +28,7 @@ export class Popup {
     this.seasonDetails = new SeasonDetailsPage(page)
     this.providers = new ProvidersPage(page)
     this.options = new OptionsPage(page)
+    this.backup = new BackupPage(page)
     this.toast = new Toast(page)
     this.dialog = new ConfirmDialog(page)
     this.urlImport = new UrlImportDialog(page)

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -1,0 +1,105 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gunzipSync } from 'node:zlib'
+import { ImportResultDialog } from '../../pom/ImportResultDialog'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+
+/**
+ * Migrate-on-import: the current build ingests a v1.5.0 backup and danmaku
+ * export and migrates them on the way in (restoreState -> options.upgrade,
+ * parseBackupMany -> episode v1->v4). Complements migration-smoke, which only
+ * exercises startup migration of already-stored data. Asserts the restore
+ * success toast and the danmaku import-result success, then that the imported
+ * config and danmaku land in the current schema (bare provider ids, stripped
+ * custom DanDanPlay baseUrl, resolvable season provider ids).
+ */
+
+const FIXTURES_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'fixtures',
+  'migration'
+)
+const BACKUP_GZ = path.join(FIXTURES_DIR, 'backup.json.gz')
+const DANMAKU_ZIP = path.join(FIXTURES_DIR, 'danmaku.zip')
+
+// The backup page mounts the cloud-backup section, which reads the auth
+// session over the network. Stub it to "no session" so the page renders signed
+// out without a live backend call.
+test.beforeEach(async ({ context }) => {
+  await context.route('**/auth/get-session*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'null',
+    })
+  )
+})
+
+test('current build migrates an imported v1.5.0 backup and danmaku export', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const popup = await Popup.open(page, extensionId, '/options/backup')
+
+  const backup = gunzipSync(await readFile(BACKUP_GZ))
+  await page.locator('input[type="file"][accept=".json"]').setInputFiles({
+    name: 'backup.json',
+    mimeType: 'application/json',
+    buffer: backup,
+  })
+  await popup.toast.expectSuccess(/Import success|成功导入备份/)
+
+  await page.goto(
+    `chrome-extension://${extensionId}/pages/popup.html?detached=1#/import`
+  )
+  await page.locator('#root').waitFor({ state: 'visible' })
+  await page.locator('input[type="file"][accept]').setInputFiles(DANMAKU_ZIP)
+  await new ImportResultDialog(page).confirm()
+  // The danmaku fixture carries a ~2MB comment file that is parsed and
+  // migrated before the success alert renders, so allow more than the default.
+  await expect(
+    page
+      .locator('[role="alert"]')
+      .filter({ hasText: /Successfully imported|成功导入/ })
+  ).toBeVisible({ timeout: 15_000 })
+
+  const da = await getDaClient(context)
+
+  const providers = await da.providerConfig.list()
+  expect(providers.length).toBeGreaterThan(0)
+  expect(
+    providers.filter((p) => p.id.startsWith('builtin:')),
+    'provider config ids migrated to bare'
+  ).toEqual([])
+  const ddpBaseUrls = providers
+    .filter((p) => p.isBuiltIn === false && p.manifestId === 'dandanplay')
+    .map((p) => p.configValues.baseUrl as string | undefined)
+  expect(
+    ddpBaseUrls,
+    'restored custom DanDanPlay baseUrl had its /api suffix stripped'
+  ).toContain('https://api.dandanplay.net')
+  for (const url of ddpBaseUrls) {
+    expect(
+      url?.endsWith('/api'),
+      `${url} should not retain a /api suffix`
+    ).toBe(false)
+  }
+
+  const seasons = await da.season.list()
+  expect(seasons.length, 'seasons imported').toBeGreaterThan(0)
+  const customEpisodes = await da.episode.listCustom()
+  expect(customEpisodes.length, 'custom danmaku imported').toBeGreaterThan(0)
+  const providerIds = new Set(providers.map((p) => p.id))
+  for (const season of seasons) {
+    expect(
+      providerIds.has(season.providerConfigId),
+      `season provider id ${season.providerConfigId} resolves to a config`
+    ).toBe(true)
+  }
+})

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -53,7 +53,7 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
     mimeType: 'application/json',
     buffer: backup,
   })
-  await popup.toast.expectSuccess(/Import success|成功导入备份/)
+  await popup.toast.expectSuccess(/^(Import success|成功导入备份)$/)
 
   const importPage = await ImportPage.open(page, extensionId)
   await importPage.selectFiles(DANMAKU_ZIP)

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -79,7 +79,7 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
     expect(
       url?.endsWith('/api'),
       `${url} should not retain a /api suffix`
-    ).toBe(false)
+    ).not.toBe(true)
   }
 
   const seasons = await da.season.list()

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { gunzipSync } from 'node:zlib'
-import { ImportResultDialog } from '../../pom/ImportResultDialog'
+import { ImportPage } from '../../pom/ImportPage'
 import { Popup } from '../../pom/Popup'
 import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
@@ -48,26 +48,17 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
   const popup = await Popup.open(page, extensionId, '/options/backup')
 
   const backup = gunzipSync(await readFile(BACKUP_GZ))
-  await page.locator('input[type="file"][accept=".json"]').setInputFiles({
+  await popup.backup.restoreFromFile({
     name: 'backup.json',
     mimeType: 'application/json',
     buffer: backup,
   })
   await popup.toast.expectSuccess(/Import success|成功导入备份/)
 
-  await page.goto(
-    `chrome-extension://${extensionId}/pages/popup.html?detached=1#/import`
-  )
-  await page.locator('#root').waitFor({ state: 'visible' })
-  await page.locator('input[type="file"][accept]').setInputFiles(DANMAKU_ZIP)
-  await new ImportResultDialog(page).confirm()
-  // The danmaku fixture carries a ~2MB comment file that is parsed and
-  // migrated before the success alert renders, so allow more than the default.
-  await expect(
-    page
-      .locator('[role="alert"]')
-      .filter({ hasText: /Successfully imported|成功导入/ })
-  ).toBeVisible({ timeout: 15_000 })
+  const importPage = await ImportPage.open(page, extensionId)
+  await importPage.selectFiles(DANMAKU_ZIP)
+  await importPage.result.confirm()
+  await importPage.result.expectSuccess()
 
   const da = await getDaClient(context)
 

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -76,10 +76,11 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
     'restored custom DanDanPlay baseUrl had its /api suffix stripped'
   ).toContain('https://api.dandanplay.net')
   for (const url of ddpBaseUrls) {
+    expect(url, 'custom DanDanPlay config has a baseUrl').toBeDefined()
     expect(
       url?.endsWith('/api'),
       `${url} should not retain a /api suffix`
-    ).not.toBe(true)
+    ).toBe(false)
   }
 
   const seasons = await da.season.list()

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/HiddenImportInputs.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/HiddenImportInputs.tsx
@@ -28,6 +28,7 @@ export function HiddenImportInputs({
         onChange={handleChange}
         accept={[...VALID_EXTENSIONS, '.zip'].join(',')}
         multiple
+        data-testid="danmaku-import-file-input"
       />
       <input
         type="file"

--- a/packages/danmaku-anywhere/src/common/components/ImportPageCore/ImportResultContent.tsx
+++ b/packages/danmaku-anywhere/src/common/components/ImportPageCore/ImportResultContent.tsx
@@ -110,7 +110,7 @@ export const ImportResultContent = ({
         <Stack spacing={2}>
           {(totalImportedCount > 0 || totalSkipped > 0) && (
             <>
-              <Alert severity="success">
+              <Alert severity="success" data-testid="import-result-success">
                 {t('importPage.importSuccess', {
                   count: totalImportedCount,
                 })}

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/components/LocalBackupSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/components/LocalBackupSection.tsx
@@ -131,6 +131,7 @@ export function LocalBackupSection({
         ref={fileInputRef}
         accept=".json"
         onChange={handleFileChange}
+        data-testid="backup-restore-input"
       />
     </>
   )


### PR DESCRIPTION
## Summary
- Add `e2e/specs/migration/import-migrate.spec.ts`: asserts the **current build** migrates an imported v1.5.0 config backup and danmaku export *on the way in* (`restoreState` -> `options.upgrade`, `parseBackupMany` -> episode v1->v4).
- This path had no end-to-end coverage. `migration-smoke` only exercises **startup** migration of already-stored data (seed on prior build -> swap), and `ConfigStateService.test.ts` only asserts `upgrade()` is called on mocked services, never that real old data comes out migrated.

## What it does
- Restores the existing v1.5.0 `backup.json.gz` via the popup backup page (hidden `.json` input -> `backupImport`); asserts the success toast.
- Imports the existing v1.5.0 `danmaku.zip` via `/import`; asserts the import-result success alert.
- Verifies migrated state through the dev API (`getDaClient`, same harness pattern as `settings.spec.ts`): provider ids are bare (no `builtin:`), the restored custom DanDanPlay baseUrl had its `/api` suffix stripped, seasons imported with `providerConfigId`s that resolve to a config, and custom danmaku imported.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- e2e/specs/migration/import-migrate.spec.ts` (passes locally, ~3s, 3/3 on `--repeat-each=3`)
- Reuses the committed fixtures under `e2e/fixtures/migration/` (`backup.json.gz`, `danmaku.zip`); no new fixtures.

## Notes
- Uses the standard `e2e/setup/fixtures` harness on the current build (no prior-release download, no swap), so it runs in the normal e2e lane rather than the slow migration-swap path. `migration-smoke.spec.ts` is left untouched.
- An earlier draft extracted `migration-smoke`'s raw IndexedDB/storage probes into a shared module; self-review replaced that with the typed dev client, since those raw probes exist only because the v1.5.0 build `migration-smoke` boots predates the dev API. Typed reads are schema-validated, so a half-migrated record fails the read.
- Out of scope (separate task): mount-config / xpath-policy sharing (share code + config file import) does not migrate on import and embeds no version; it needs a rethink.