### PR TITLE
(extension) derive provider tag from manifestId [DA-598]

### DIFF
--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
@@ -18,9 +18,10 @@ import type { ManifestRegistry } from './ManifestRegistry'
  * a ManifestProviderService configured for the source, or the legacy
  * MacCmsProviderService for `legacy:maccms` configs. Any non-maccms
  * manifestId (built-in or catalog) resolves to a ManifestProviderService
- * that stamps `config.impl` as the provider tag. Custom DanDanPlay servers
- * share the `dandanplay` manifest and thread their baseUrl/auth through
- * configValues; there is no DDP-compat special case.
+ * whose provider tag is derived from the manifestId, not read from the
+ * persisted `config.impl`. Custom DanDanPlay servers share the `dandanplay`
+ * manifest and thread their baseUrl/auth through configValues; there is no
+ * DDP-compat special case.
  */
 
 const RUN_OPTS = MANIFEST_RUN_OPTIONS
@@ -181,12 +182,12 @@ describe('ProviderFactory dispatch', () => {
     expect((service as unknown as { tag?: string }).tag).toBe('maccms-legacy')
   })
 
-  it('resolves a non-built-in catalog manifestId to ManifestProviderService stamping config.impl', async () => {
+  it('resolves a non-built-in catalog manifestId to ManifestProviderService with the derived tag, ignoring a stale impl', async () => {
     const factory = await buildFactory()
     const service = factory({
       id: 'iqiyi-1',
       manifestId: 'iqiyi',
-      impl: DanmakuSourceType.DanDanPlay,
+      impl: DanmakuSourceType.Bilibili,
       name: 'iQIYI',
       enabled: true,
       isBuiltIn: false,
@@ -202,18 +203,19 @@ describe('ProviderFactory dispatch', () => {
     )
   })
 
-  it('rejects a non-maccms config that carries the Custom impl', async () => {
+  it('derives the tag from the manifestId even when the stored impl is Custom', async () => {
     const factory = await buildFactory()
-    expect(() =>
-      factory({
-        id: 'bad-1',
-        manifestId: 'iqiyi',
-        impl: DanmakuSourceType.Custom,
-        name: 'Bad',
-        enabled: true,
-        isBuiltIn: false,
-        configValues: {},
-      })
-    ).toThrow(/cannot use the Custom impl/)
+    const service = factory({
+      id: 'iqiyi-2',
+      manifestId: 'iqiyi',
+      impl: DanmakuSourceType.Custom,
+      name: 'iQIYI',
+      enabled: true,
+      isBuiltIn: false,
+      configValues: {},
+    })
+
+    expect(service).toBeInstanceOf(ManifestProviderService)
+    expect(service.forProvider).toBe(DanmakuSourceType.DanDanPlay)
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.ts
@@ -1,12 +1,11 @@
 import {
-  DanmakuSourceType,
   LEGACY_MACCMS_ID,
+  providerTypeFromManifestId,
 } from '@danmaku-anywhere/danmaku-converter'
 import type { ResolutionContext } from 'inversify'
 import type { IDanmakuProvider } from '@/background/services/providers/IDanmakuProvider'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
-import { invariant } from '@/common/utils/utils'
 import { MacCmsProviderService } from './MacCmsProviderService'
 import { ManifestProviderService } from './ManifestProviderService'
 import { ManifestRegistry } from './ManifestRegistry'
@@ -26,17 +25,10 @@ function createDanmakuProvider(
   if (config.manifestId === LEGACY_MACCMS_ID) {
     return new MacCmsProviderService(config, logger)
   }
-  // The Custom impl shares MacCMS's enum value; a manifest source carrying it
-  // would be read as custom danmaku by `isNotCustom` consumers. Identity is the
-  // manifestId, so impl is only the persisted provider tag and must stay real.
-  invariant(
-    config.impl !== DanmakuSourceType.Custom,
-    `Provider config ${config.id} (${config.manifestId}) cannot use the Custom impl`
-  )
   return new ManifestProviderService(
     {
       manifestId: config.manifestId,
-      provider: config.impl,
+      provider: providerTypeFromManifestId(config.manifestId),
       providerConfigId: config.id,
       configValues: config.configValues,
     },

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SourceFilterChips.tsx
@@ -1,3 +1,4 @@
+import { providerTypeFromManifestId } from '@danmaku-anywhere/danmaku-converter'
 import { Box, ButtonBase, CircularProgress, styled } from '@mui/material'
 import {
   type ReactNode,
@@ -202,7 +203,7 @@ export function SourceFilterChips({
             active={active}
             onClick={() => onChange(provider.id)}
             aria-pressed={active}
-            data-testid={`source-chip-${provider.impl}`}
+            data-testid={`source-chip-${providerTypeFromManifestId(provider.manifestId)}`}
           >
             {chipBody(provider, active, states[provider.id])}
           </Chip>

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/useProviderConfig.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/useProviderConfig.ts
@@ -1,7 +1,6 @@
 import { arrayMove } from '@dnd-kit/sortable'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import type { DanmakuSourceType } from '@/common/danmaku/enums'
 import { useInjectService } from '@/common/hooks/useInjectService'
 import { storageQueryKeys } from '@/common/queries/queryKeys'
 import { useSuspenseExtStorageQuery } from '@/common/storage/hooks/useSuspenseExtStorageQuery'
@@ -22,21 +21,13 @@ export const useProviderConfig = () => {
   const methods = useMemo(() => {
     const enabledProviders = configs.filter((config) => config.enabled)
 
-    const enabledProviderTypes = enabledProviders.map((config) => config.impl)
-
     const getProviderById = (id: string) => {
       return configs.find((config) => config.id === id)
     }
 
-    const getProvidersBySourceType = (sourceType: DanmakuSourceType) => {
-      return configs.filter((config) => config.impl === sourceType)
-    }
-
     return {
       enabledProviders,
-      enabledProviderTypes,
       getProviderById,
-      getProvidersBySourceType,
     }
   }, [configs])
 

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/utils.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/utils.ts
@@ -1,16 +1,11 @@
-import type { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { LEGACY_MACCMS_ID } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from './schema'
 
-// Defensive runtime check. Does NOT narrow `configValues` — that field is
-// opaque at the type level. Use local cast helpers in the consumer when
-// reading typed fields.
-export function assertProviderConfigImpl(
-  config: ProviderConfig,
-  impl: DanmakuSourceType
-): void {
-  if (config.impl !== impl) {
+// Defensive runtime check before rendering the legacy MacCMS episode UI.
+export function assertMacCmsConfig(config: ProviderConfig): void {
+  if (config.manifestId !== LEGACY_MACCMS_ID) {
     throw new Error(
-      `Provider type mismatch: expected ${impl}, got ${config.impl}`
+      `Provider type mismatch: expected ${LEGACY_MACCMS_ID}, got ${config.manifestId}`
     )
   }
 }

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SeasonDetailsPage.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/pages/search/SeasonDetailsPage.tsx
@@ -1,9 +1,8 @@
-import {
-  type CustomSeason,
-  DanmakuSourceType,
-  type EpisodeMeta,
-  type Season,
-  type WithSeason,
+import type {
+  CustomSeason,
+  EpisodeMeta,
+  Season,
+  WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Search } from '@mui/icons-material'
 import {
@@ -25,7 +24,7 @@ import { ScrollBox } from '@/common/components/layout/ScrollBox'
 import { TabLayout } from '@/common/components/layout/TabLayout'
 import { TabToolbar } from '@/common/components/layout/TabToolbar'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
-import { assertProviderConfigImpl } from '@/common/options/providerConfig/utils'
+import { assertMacCmsConfig } from '@/common/options/providerConfig/utils'
 import { useLoadDanmaku } from '@/content/controller/common/hooks/useLoadDanmaku'
 
 type SeasonDetailsPageProps = {
@@ -124,7 +123,7 @@ export const SeasonDetailsPage = ({
               renderCustomEpisode={(data) => {
                 const { loadGenericMutation } = useLoadDanmaku()
 
-                assertProviderConfigImpl(provider, DanmakuSourceType.MacCMS)
+                assertMacCmsConfig(provider)
 
                 return (
                   <MacCmsEpisodeListItem

--- a/packages/danmaku-anywhere/src/popup/pages/search/seasonDetails/SeasonDetailsPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/search/seasonDetails/SeasonDetailsPage.tsx
@@ -1,7 +1,6 @@
-import {
-  DanmakuSourceType,
-  type EpisodeMeta,
-  type WithSeason,
+import type {
+  EpisodeMeta,
+  WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Search } from '@mui/icons-material'
 import {
@@ -24,7 +23,7 @@ import { TabLayout } from '@/common/components/layout/TabLayout'
 import { TabToolbar } from '@/common/components/layout/TabToolbar'
 import { useFetchDanmaku } from '@/common/danmaku/queries/useFetchDanmaku'
 import { useFetchGenericDanmaku } from '@/common/danmaku/queries/useFetchGenericDanmaku'
-import { assertProviderConfigImpl } from '@/common/options/providerConfig/utils'
+import { assertMacCmsConfig } from '@/common/options/providerConfig/utils'
 import { useGoBack } from '@/popup/hooks/useGoBack'
 import { useStore } from '@/popup/store'
 
@@ -118,7 +117,7 @@ export const SeasonDetailsPage = () => {
               renderCustomEpisode={(data) => {
                 const mutation = useFetchGenericDanmaku()
 
-                assertProviderConfigImpl(provider, DanmakuSourceType.MacCMS)
+                assertMacCmsConfig(provider)
 
                 return (
                   <MacCmsEpisodeListItem

--- a/packages/danmaku-converter/src/canonical/provider/provider.test.ts
+++ b/packages/danmaku-converter/src/canonical/provider/provider.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DanmakuSourceType,
+  LEGACY_MACCMS_ID,
+  providerTypeFromManifestId,
+} from './provider.js'
+
+describe('providerTypeFromManifestId', () => {
+  it('maps the fixed built-in ids 1:1', () => {
+    expect(providerTypeFromManifestId('dandanplay')).toBe(
+      DanmakuSourceType.DanDanPlay
+    )
+    expect(providerTypeFromManifestId('bilibili')).toBe(
+      DanmakuSourceType.Bilibili
+    )
+    expect(providerTypeFromManifestId('tencent')).toBe(
+      DanmakuSourceType.Tencent
+    )
+  })
+
+  it('maps the legacy maccms id to MacCMS', () => {
+    expect(providerTypeFromManifestId(LEGACY_MACCMS_ID)).toBe(
+      DanmakuSourceType.MacCMS
+    )
+  })
+
+  it('falls back to DanDanPlay for generic catalog manifests', () => {
+    expect(providerTypeFromManifestId('iqiyi')).toBe(
+      DanmakuSourceType.DanDanPlay
+    )
+    expect(providerTypeFromManifestId('')).toBe(DanmakuSourceType.DanDanPlay)
+  })
+
+  it('never returns the Custom tag for a generic manifest', () => {
+    expect(providerTypeFromManifestId('sohu')).not.toBe(
+      DanmakuSourceType.Custom
+    )
+  })
+})

--- a/packages/danmaku-converter/src/canonical/provider/provider.ts
+++ b/packages/danmaku-converter/src/canonical/provider/provider.ts
@@ -15,9 +15,12 @@ export const PROVIDER_TO_BUILTIN_ID = {
   [DanmakuSourceType.MacCMS]: LEGACY_MACCMS_ID, // not built-in, but used for migrations to indicate this is a migrated option
 } as const satisfies Record<DanmakuSourceType, string>
 
-const BUILTIN_ID_TO_PROVIDER = Object.fromEntries(
-  Object.entries(PROVIDER_TO_BUILTIN_ID).map(([provider, id]) => [id, provider])
-) as Record<string, DanmakuSourceType>
+const BUILTIN_ID_TO_PROVIDER: Record<string, DanmakuSourceType> = {
+  dandanplay: DanmakuSourceType.DanDanPlay,
+  bilibili: DanmakuSourceType.Bilibili,
+  tencent: DanmakuSourceType.Tencent,
+  [LEGACY_MACCMS_ID]: DanmakuSourceType.MacCMS,
+}
 
 // A generic catalog manifest must not fall back to the Custom tag, which would
 // make the source read as custom danmaku; DanDanPlay is the neutral default.

--- a/packages/danmaku-converter/src/canonical/provider/provider.ts
+++ b/packages/danmaku-converter/src/canonical/provider/provider.ts
@@ -15,6 +15,18 @@ export const PROVIDER_TO_BUILTIN_ID = {
   [DanmakuSourceType.MacCMS]: LEGACY_MACCMS_ID, // not built-in, but used for migrations to indicate this is a migrated option
 } as const satisfies Record<DanmakuSourceType, string>
 
+const BUILTIN_ID_TO_PROVIDER = Object.fromEntries(
+  Object.entries(PROVIDER_TO_BUILTIN_ID).map(([provider, id]) => [id, provider])
+) as Record<string, DanmakuSourceType>
+
+// A generic catalog manifest must not fall back to the Custom tag, which would
+// make the source read as custom danmaku; DanDanPlay is the neutral default.
+export function providerTypeFromManifestId(
+  manifestId: string
+): DanmakuSourceType {
+  return BUILTIN_ID_TO_PROVIDER[manifestId] ?? DanmakuSourceType.DanDanPlay
+}
+
 const BUILTIN_ID_PREFIX = 'builtin:'
 
 // Strip the `builtin:` id prefix. Ids without it (e.g. legacy:maccms) are


### PR DESCRIPTION
## Summary
- Stop reading the persisted `ProviderConfig.impl` field. Derive the `DanmakuSourceType` provider tag from `manifestId` via one helper, `providerTypeFromManifestId` (the inverse of `PROVIDER_TO_BUILTIN_ID`, with a DanDanPlay fallback for generic catalog manifests). Continues the earlier provider-resolution enum-decouple: `manifestId` is identity, the tag is now a deterministic function of it instead of a free-floating per-config field that could let a generic source masquerade as a built-in.
- `ProviderFactory` stamps the derived tag; the now-unreachable Custom-impl `invariant` is removed.
- The MacCMS render guard (`assertProviderConfigImpl` -> `assertMacCmsConfig`) keys off `manifestId === LEGACY_MACCMS_ID` instead of `impl`; both `SeasonDetailsPage` callers updated.
- `SourceFilterChips` `source-chip-${tag}` testid now derives the tag (same value as before for every config).
- Removed two dead, unused methods from `useProviderConfig` that grouped/filtered configs by `impl`.
- The persisted `impl` stays in the schema and storage (read-removal only, no migration). The legacy migration that reads old stored `impl` is unchanged.

## Test plan
- [x] `pnpm build:packages`, `pnpm type-check`, `pnpm lint`
- [x] Unit: new `packages/danmaku-converter/.../provider.test.ts` (fixed ids 1:1, legacy maccms, generic fallback, never Custom); updated `ProviderFactory.test.ts` (derives tag from manifestId, ignores a stale/Custom impl)
- [x] e2e: `e2e/specs/sources/search-source-chips.spec.ts`, `search-styling.spec.ts`, `dandanplay.spec.ts` (exercise the source-chip testid and popup search -> details flow)

## Notes
- Dropping `impl` from the schema/persisted storage is intentionally out of scope; it can be removed later once nothing reads it.