### PR TITLE
(chore) add release-manager dev utility for extension builds [DA-612]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:extension": "pnpm -r -F \"./packages/danmaku-anywhere\" dev",
     "dev:extension:standalone": "pnpm -r -F \"./packages/danmaku-anywhere\" standalone:dev",
     "build": "pnpm -r build",
+    "release-manager": "pnpm --filter @danmaku-anywhere/release-manager start",
     "build:packages": "pnpm -r -F \"./packages/**\" build",
     "format": "pnpm -r -F \"./packages/**\" format",
     "lint": "pnpm -r -F \"./packages/**\" lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^21.0.0
-        version: 21.2.12(043cb7c17b8a83e84fe19acdc1f9a212)
+        version: 21.2.12(0b108dd98d30e1c139943813f67d6faf)
       '@angular/cli':
         specifier: ^21.0.0
         version: 21.2.12(@types/node@24.12.4)(chokidar@5.0.0)
@@ -158,7 +158,7 @@ importers:
         version: 28.1.0(@noble/hashes@2.2.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.50.0
         version: 4.93.1
@@ -188,7 +188,7 @@ importers:
         version: 10.53.1
       better-auth:
         specifier: ^1.4.18
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)))
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
@@ -213,7 +213,7 @@ importers:
         version: 2.4.15
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.13.3
-        version: 0.13.5(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)))
+        version: 0.13.5(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.4
@@ -228,7 +228,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.76.0
         version: 4.93.1
@@ -346,7 +346,7 @@ importers:
         version: 0.5.0
       better-auth:
         specifier: ^1.4.18
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)))
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
       clarity-js:
         specifier: ^0.8.41
         version: 0.8.64
@@ -446,7 +446,7 @@ importers:
         version: 2023.10.7
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.2.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       i18next-cli:
         specifier: ^1.28.0
         version: 1.58.0(@types/node@24.12.4)(i18next@25.10.10(typescript@6.0.3))(react-dom@19.2.0(react@19.2.0))(typescript@6.0.3)
@@ -455,10 +455,10 @@ importers:
         version: 28.1.0(@noble/hashes@2.2.0)
       vite:
         specifier: ^7.2.4
-        version: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       web-ext:
         specifier: ^9.2.0
         version: 9.4.0(body-parser@2.2.2)(express@5.2.1)(jiti@2.7.0)
@@ -477,7 +477,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/danmaku-engine:
     dependencies:
@@ -490,7 +490,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/danmaku-provider:
     dependencies:
@@ -518,7 +518,7 @@ importers:
         version: 1.3.0(protobufjs@7.6.0)
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/integration-policy:
     dependencies:
@@ -528,13 +528,13 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/result:
     devDependencies:
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/web-scraper:
     dependencies:
@@ -553,7 +553,50 @@ importers:
         version: 0.0.325
       vitest:
         specifier: ^4.0.13
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
+
+  tools/release-manager:
+    dependencies:
+      '@danmaku-anywhere/result':
+        specifier: workspace:*
+        version: link:../../packages/result
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.21)
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
+      hono:
+        specifier: ^4.10.6
+        version: 4.12.21
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.12.4
+      '@types/react':
+        specifier: ^19.2.6
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.2.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      vite:
+        specifier: ^7.2.4
+        version: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -2243,6 +2286,12 @@ packages:
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -5795,6 +5844,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -7958,6 +8010,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -8703,7 +8760,7 @@ snapshots:
       '@angular/core': 21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  '@angular/build@21.2.12(043cb7c17b8a83e84fe19acdc1f9a212)':
+  '@angular/build@21.2.12(0b108dd98d30e1c139943813f67d6faf)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.12(chokidar@5.0.0)
@@ -8713,7 +8770,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.21(@types/node@24.12.4)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       beasties: 0.4.1
       browserslist: 4.28.2
       esbuild: 0.27.3
@@ -8734,7 +8791,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 6.0.3
       undici: 7.24.4
-      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)
@@ -8745,7 +8802,7 @@ snapshots:
       lmdb: 3.5.1
       postcss: 8.5.15
       tailwindcss: 4.3.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9151,14 +9208,14 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260520.1
 
-  '@cloudflare/vitest-pool-workers@0.13.5(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)))':
+  '@cloudflare/vitest-pool-workers@0.13.5(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260317.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       wrangler: 4.78.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -9906,6 +9963,10 @@ snapshots:
       - magicast
 
   '@hono/node-server@1.19.14(hono@4.12.21)':
+    dependencies:
+      hono: 4.12.21
+
+  '@hono/node-server@2.0.4(hono@4.12.21)':
     dependencies:
       hono: 4.12.21
 
@@ -11758,11 +11819,11 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -11770,7 +11831,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11783,13 +11844,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -12016,7 +12077,7 @@ snapshots:
       postcss-media-query-parser: 0.2.3
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))
@@ -12040,12 +12101,12 @@ snapshots:
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))
@@ -12069,7 +12130,7 @@ snapshots:
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)
       react: 19.2.6
       react-dom: 19.2.0(react@19.2.6)
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -13156,6 +13217,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -15662,6 +15725,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
@@ -15824,7 +15893,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0):
+  vite@7.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15838,10 +15907,10 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
       sass: 1.97.3
-      tsx: 4.22.3
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0):
+  vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15855,13 +15924,13 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
       sass: 1.97.3
-      tsx: 4.22.3
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -15878,7 +15947,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - 'packages/**'
   - 'backend/**'
   - 'app/**'
+  - 'tools/**'
 nodeLinker: isolated
 allowBuilds:
   '@parcel/watcher': false

--- a/tools/release-manager/.gitignore
+++ b/tools/release-manager/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/tools/release-manager/AGENTS.md
+++ b/tools/release-manager/AGENTS.md
@@ -33,21 +33,25 @@ Resolved once at startup from `DA_RELEASE_MANAGER_DIR`, defaulting to
   config.json            # mode 0600; { githubToken?, activeTag?, builds[] }
   cache/<tag>/           # an unzipped chrome build (contains manifest.json)
   cache/.tmp-<tag>/      # transient unzip staging, renamed atomically into place
-  active                 # symlink pointing at cache/<active-tag>
+  active/                # real dir holding a copy of the active build
 ```
 
 The token never leaves the server in cleartext: `getState` exposes
 `hasToken: boolean`, never the raw token.
 
-## Chrome swap behavior (pending verification)
+## Chrome swap behavior
 
-`setActive(tag)` repoints `<dataDir>/active` at `cache/<tag>` by removing the
-existing link and recreating it (`fs.symlink` with `'junction'` on win32,
-`'dir'` elsewhere). Chrome will likely need a **manual reload** of the unpacked
-extension after a repoint. Whether Chrome follows a symlink repoint in place or
-requires copying the build into a real directory is **not yet verified in a real
-browser**. Symlink repoint is the primary path for now; revisit if Chrome does
-not pick up the swap.
+`setActive(tag)` makes `<dataDir>/active` a real directory and copies the chosen
+`cache/<tag>/` build into it, replacing its previous contents in place. The user
+loads `<dataDir>/active` once via "Load unpacked" and clicks reload after each
+swap to pick up the new build.
+
+The active folder is copied rather than symlinked because a sandboxed (Flatpak)
+Chrome reads the picked folder through a document portal that does not grant the
+symlink's target, so a symlinked active folder fails with "File path cannot be
+resolved." Copying keeps the loaded path stable across swaps and works for both
+native and Flatpak Chrome. The copy source is the local cache, so swapping never
+re-downloads.
 
 ## Layout
 

--- a/tools/release-manager/AGENTS.md
+++ b/tools/release-manager/AGENTS.md
@@ -18,10 +18,12 @@ never enters a production build. It still participates in the root `test`,
 
 ## How to run
 
-- `pnpm start` builds the web bundle (`build:web`) then starts the Node server
-  and opens the resolved URL in the browser.
-- `pnpm dev` runs the Node server under `tsx watch` and Vite together; Vite
-  proxies `/api` to the server.
+- From the repo root: `pnpm release-manager` (or
+  `pnpm --filter @danmaku-anywhere/release-manager start`). This builds the web
+  bundle (`build:web`) then starts the Node server and opens the resolved URL in
+  the browser. There is no root `pnpm start`.
+- From this package: `pnpm dev` runs the Node server under `tsx watch` and Vite
+  together; Vite proxies `/api` to the server.
 
 ## dataDir
 

--- a/tools/release-manager/AGENTS.md
+++ b/tools/release-manager/AGENTS.md
@@ -1,0 +1,72 @@
+# Agent context: tools/release-manager
+
+## Purpose
+
+Local dev-only utility. A Node backend (full filesystem access) serves a React
+browser-tab UI that downloads extension release/preview builds from the
+`Mr-Quin/danmaku-anywhere` GitHub releases and manages which cached build is the
+"active" unpacked folder loaded into `chrome://extensions`.
+
+This is a developer tool, not a shipped artifact.
+
+## Dev-only rule
+
+There is deliberately **no `build` script**. The root `pnpm build` runs
+`pnpm -r build` and skips any package without a `build` script, so this tool
+never enters a production build. It still participates in the root `test`,
+`type-check`, `lint:ci` sweeps because it defines those scripts.
+
+## How to run
+
+- `pnpm start` builds the web bundle (`build:web`) then starts the Node server
+  and opens the resolved URL in the browser.
+- `pnpm dev` runs the Node server under `tsx watch` and Vite together; Vite
+  proxies `/api` to the server.
+
+## dataDir
+
+Resolved once at startup from `DA_RELEASE_MANAGER_DIR`, defaulting to
+`~/.da-release-manager`. It is not runtime-mutable. Layout:
+
+```
+<dataDir>/
+  config.json            # mode 0600; { githubToken?, activeTag?, builds[] }
+  cache/<tag>/           # an unzipped chrome build (contains manifest.json)
+  cache/.tmp-<tag>/      # transient unzip staging, renamed atomically into place
+  active                 # symlink pointing at cache/<active-tag>
+```
+
+The token never leaves the server in cleartext: `getState` exposes
+`hasToken: boolean`, never the raw token.
+
+## Chrome swap behavior (pending verification)
+
+`setActive(tag)` repoints `<dataDir>/active` at `cache/<tag>` by removing the
+existing link and recreating it (`fs.symlink` with `'junction'` on win32,
+`'dir'` elsewhere). Chrome will likely need a **manual reload** of the unpacked
+extension after a repoint. Whether Chrome follows a symlink repoint in place or
+requires copying the build into a real directory is **not yet verified in a real
+browser**. Symlink repoint is the primary path for now; revisit if Chrome does
+not pick up the swap.
+
+## Layout
+
+- `src/core/` pure, Result-based logic with no HTTP/UI imports
+  (`types`, `github`, `store`, `cache`, `active`, `manager`).
+- `src/server/` bare Hono + `@hono/node-server`, bound to `127.0.0.1` only,
+  fixed default port with fallback.
+- `src/web/` React + Vite, one screen, no component library.
+- `test/` Vitest over the core.
+
+## Conventions
+
+- All fallible core ops return `Result<T, E>` from `@danmaku-anywhere/result`.
+- `removeBuild` refuses to delete the currently active build; set another build
+  active first.
+- See `package.json` for available scripts and dependencies.
+
+## Known limitations
+
+- The releases list shows the most recent 100 releases (no pagination).
+  Acceptable for a dev tool that only wants recent builds. Cached builds that
+  age out of that window still render so they can be set active or removed.

--- a/tools/release-manager/package.json
+++ b/tools/release-manager/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@danmaku-anywhere/release-manager",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local dev utility to download and activate extension release/preview builds",
+  "author": "Mr-Quin",
+  "repository": "https://github.com/Mr-Quin/danmaku-anywhere",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "node scripts/dev.mjs",
+    "build:web": "vite build",
+    "start": "pnpm build:web && tsx src/server/index.ts",
+    "test": "vitest run",
+    "type-check": "tsgo --noEmit",
+    "lint": "biome check --fix",
+    "lint:ci": "biome ci"
+  },
+  "dependencies": {
+    "@danmaku-anywhere/result": "workspace:*",
+    "@hono/node-server": "^2.0.4",
+    "fflate": "^0.8.3",
+    "hono": "^4.10.6",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.6",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "tsx": "^4.22.4",
+    "vite": "^7.2.4",
+    "vitest": "^4.1.0"
+  }
+}

--- a/tools/release-manager/scripts/dev.mjs
+++ b/tools/release-manager/scripts/dev.mjs
@@ -1,0 +1,27 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+
+function run(command, args) {
+  const child = spawn(command, args, {
+    cwd: root,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  })
+  child.on('exit', (code) => {
+    process.exitCode = code ?? 0
+  })
+  return child
+}
+
+const server = run('pnpm', ['exec', 'tsx', 'watch', 'src/server/index.ts'])
+const web = run('pnpm', ['exec', 'vite'])
+
+function shutdown() {
+  server.kill()
+  web.kill()
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)

--- a/tools/release-manager/src/core/active.ts
+++ b/tools/release-manager/src/core/active.ts
@@ -1,36 +1,55 @@
-import { access, lstat, rm, symlink } from 'node:fs/promises'
+import { access, cp, lstat, mkdir, readdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { err, ok, type Result } from '@danmaku-anywhere/result'
 import type { ReleaseManagerError } from './types.js'
 
-const ACTIVE_LINK = 'active'
+const ACTIVE_DIR = 'active'
 
 export function activePath(dataDir: string): string {
-  return join(dataDir, ACTIVE_LINK)
+  return join(dataDir, ACTIVE_DIR)
 }
 
 export function cachePath(dataDir: string, tag: string): string {
   return join(dataDir, 'cache', tag)
 }
 
-async function removeLink(link: string): Promise<void> {
+async function ensureRealDir(dir: string): Promise<void> {
   try {
-    await lstat(link)
+    const stat = await lstat(dir)
+    if (stat.isSymbolicLink()) {
+      await rm(dir, { force: true })
+    }
+  } catch {
+    // nothing at this path yet
+  }
+  await mkdir(dir, { recursive: true })
+}
+
+async function emptyDir(dir: string): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await readdir(dir)
   } catch {
     return
   }
-  await rm(link, { recursive: true, force: true })
+  await Promise.all(
+    entries.map((entry) => {
+      return rm(join(dir, entry), { recursive: true, force: true })
+    })
+  )
 }
 
-// Chrome may need a manual reload after a repoint. Whether Chrome follows a
-// symlink repoint or requires copying into a real directory is pending manual
-// browser verification; symlink repoint is the primary path for now.
+// The active folder is a real directory the user loads once in chrome://extensions.
+// The build is copied in rather than symlinked: a sandboxed (Flatpak) Chrome reads
+// the picked folder through a document portal that does not grant symlink targets,
+// so a symlinked active folder fails to resolve its manifest. Swapping replaces the
+// directory contents in place so the loaded path stays stable across builds.
 export async function setActive(
   dataDir: string,
   tag: string
 ): Promise<Result<string, ReleaseManagerError>> {
   const target = cachePath(dataDir, tag)
-  const link = activePath(dataDir)
+  const dir = activePath(dataDir)
 
   try {
     await access(target)
@@ -39,25 +58,22 @@ export async function setActive(
   }
 
   try {
-    await removeLink(link)
-    await symlink(
-      target,
-      link,
-      process.platform === 'win32' ? 'junction' : 'dir'
-    )
+    await ensureRealDir(dir)
+    await emptyDir(dir)
+    await cp(target, dir, { recursive: true })
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'symlink failed'
+    const message = error instanceof Error ? error.message : 'copy failed'
     return err({ kind: 'swap', message })
   }
 
-  return ok(link)
+  return ok(dir)
 }
 
 export async function clearActive(
   dataDir: string
 ): Promise<Result<void, ReleaseManagerError>> {
   try {
-    await removeLink(activePath(dataDir))
+    await emptyDir(activePath(dataDir))
   } catch (error) {
     const message = error instanceof Error ? error.message : 'clear failed'
     return err({ kind: 'swap', message })

--- a/tools/release-manager/src/core/active.ts
+++ b/tools/release-manager/src/core/active.ts
@@ -1,0 +1,66 @@
+import { access, lstat, rm, symlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { err, ok, type Result } from '@danmaku-anywhere/result'
+import type { ReleaseManagerError } from './types.js'
+
+const ACTIVE_LINK = 'active'
+
+export function activePath(dataDir: string): string {
+  return join(dataDir, ACTIVE_LINK)
+}
+
+export function cachePath(dataDir: string, tag: string): string {
+  return join(dataDir, 'cache', tag)
+}
+
+async function removeLink(link: string): Promise<void> {
+  try {
+    await lstat(link)
+  } catch {
+    return
+  }
+  await rm(link, { recursive: true, force: true })
+}
+
+// Chrome may need a manual reload after a repoint. Whether Chrome follows a
+// symlink repoint or requires copying into a real directory is pending manual
+// browser verification; symlink repoint is the primary path for now.
+export async function setActive(
+  dataDir: string,
+  tag: string
+): Promise<Result<string, ReleaseManagerError>> {
+  const target = cachePath(dataDir, tag)
+  const link = activePath(dataDir)
+
+  try {
+    await access(target)
+  } catch {
+    return err({ kind: 'swap', message: `cache dir for ${tag} is missing` })
+  }
+
+  try {
+    await removeLink(link)
+    await symlink(
+      target,
+      link,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'symlink failed'
+    return err({ kind: 'swap', message })
+  }
+
+  return ok(link)
+}
+
+export async function clearActive(
+  dataDir: string
+): Promise<Result<void, ReleaseManagerError>> {
+  try {
+    await removeLink(activePath(dataDir))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'clear failed'
+    return err({ kind: 'swap', message })
+  }
+  return ok(undefined)
+}

--- a/tools/release-manager/src/core/cache.ts
+++ b/tools/release-manager/src/core/cache.ts
@@ -1,5 +1,5 @@
 import { access, mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
 import { err, ok, type Result } from '@danmaku-anywhere/result'
 import { unzipSync } from 'fflate'
 import type { CachedBuild, ReleaseAsset, ReleaseManagerError } from './types.js'
@@ -29,15 +29,27 @@ function manifestVersion(bytes: Uint8Array): string | undefined {
   }
 }
 
+function isContained(root: string, candidate: string): boolean {
+  const resolved = resolve(candidate)
+  return resolved === root || resolved.startsWith(root + sep)
+}
+
 async function writeUnzipped(
   dest: string,
   files: Record<string, Uint8Array>
 ): Promise<void> {
+  const root = resolve(dest)
   for (const [name, bytes] of Object.entries(files)) {
     if (name.endsWith('/')) {
       continue
     }
+    if (isAbsolute(name)) {
+      continue
+    }
     const filePath = join(dest, name)
+    if (!isContained(root, filePath)) {
+      continue
+    }
     await mkdir(dirname(filePath), { recursive: true })
     await writeFile(filePath, bytes)
   }

--- a/tools/release-manager/src/core/cache.ts
+++ b/tools/release-manager/src/core/cache.ts
@@ -1,0 +1,151 @@
+import { access, mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { err, ok, type Result } from '@danmaku-anywhere/result'
+import { unzipSync } from 'fflate'
+import type { CachedBuild, ReleaseAsset, ReleaseManagerError } from './types.js'
+
+const TMP_PREFIX = '.tmp-'
+
+function cacheRoot(dataDir: string): string {
+  return join(dataDir, 'cache')
+}
+
+function cacheDir(dataDir: string, tag: string): string {
+  return join(cacheRoot(dataDir), tag)
+}
+
+function tmpDir(dataDir: string, tag: string): string {
+  return join(cacheRoot(dataDir), `${TMP_PREFIX}${tag}`)
+}
+
+function manifestVersion(bytes: Uint8Array): string | undefined {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as {
+      version?: string
+    }
+    return parsed.version
+  } catch {
+    return undefined
+  }
+}
+
+async function writeUnzipped(
+  dest: string,
+  files: Record<string, Uint8Array>
+): Promise<void> {
+  for (const [name, bytes] of Object.entries(files)) {
+    if (name.endsWith('/')) {
+      continue
+    }
+    const filePath = join(dest, name)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, bytes)
+  }
+}
+
+export async function downloadBuild(
+  dataDir: string,
+  asset: ReleaseAsset,
+  fetchImpl: typeof fetch = fetch,
+  token?: string
+): Promise<Result<CachedBuild, ReleaseManagerError>> {
+  const headers: Record<string, string> = {
+    Accept: 'application/octet-stream',
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  let response: Response
+  try {
+    response = await fetchImpl(asset.assetUrl, { headers })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'download failed'
+    return err({ kind: 'network', message })
+  }
+
+  if (!response.ok) {
+    return err({
+      kind: 'network',
+      message: `download responded with ${response.status}`,
+    })
+  }
+
+  let zipped: Uint8Array
+  try {
+    zipped = new Uint8Array(await response.arrayBuffer())
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'read failed'
+    return err({ kind: 'network', message })
+  }
+
+  let files: Record<string, Uint8Array>
+  try {
+    files = unzipSync(zipped)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unzip failed'
+    return err({ kind: 'invalid', message })
+  }
+
+  const manifest = files['manifest.json']
+  if (!manifest) {
+    return err({ kind: 'invalid', message: 'archive has no manifest.json' })
+  }
+  const version = manifestVersion(manifest) ?? asset.version
+
+  const tmp = tmpDir(dataDir, asset.tag)
+  const final = cacheDir(dataDir, asset.tag)
+
+  try {
+    await rm(tmp, { recursive: true, force: true })
+    await mkdir(tmp, { recursive: true })
+    await writeUnzipped(tmp, files)
+    await rm(final, { recursive: true, force: true })
+    await rename(tmp, final)
+  } catch (error) {
+    await rm(tmp, { recursive: true, force: true }).catch(() => undefined)
+    const message = error instanceof Error ? error.message : 'unpack failed'
+    return err({ kind: 'swap', message })
+  }
+
+  return ok({
+    tag: asset.tag,
+    version,
+    channel: asset.channel,
+    downloadedAt: new Date().toISOString(),
+  })
+}
+
+export async function removeBuild(
+  dataDir: string,
+  tag: string
+): Promise<Result<void, ReleaseManagerError>> {
+  try {
+    await rm(cacheDir(dataDir, tag), { recursive: true, force: true })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'remove failed'
+    return err({ kind: 'swap', message })
+  }
+  return ok(undefined)
+}
+
+export async function reconcileBuilds(
+  dataDir: string,
+  index: CachedBuild[]
+): Promise<CachedBuild[]> {
+  const root = cacheRoot(dataDir)
+  try {
+    await access(root)
+  } catch {
+    return []
+  }
+
+  const entries = await readdir(root, { withFileTypes: true })
+  const present = new Set(
+    entries
+      .filter((e) => e.isDirectory() && !e.name.startsWith(TMP_PREFIX))
+      .map((e) => e.name)
+  )
+
+  return index.filter((build) => present.has(build.tag))
+}

--- a/tools/release-manager/src/core/github.ts
+++ b/tools/release-manager/src/core/github.ts
@@ -1,0 +1,142 @@
+import { err, ok, type Result } from '@danmaku-anywhere/result'
+import type {
+  Channel,
+  PreviewSubtype,
+  ReleaseAsset,
+  ReleaseManagerError,
+} from './types.js'
+
+const RELEASES_URL =
+  'https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases?per_page=100'
+
+const CHROME_ASSET_SUFFIX = '-chrome.zip'
+
+interface RawAsset {
+  name: string
+  url: string
+}
+
+interface RawRelease {
+  tag_name: string
+  prerelease: boolean
+  published_at: string
+  assets: RawAsset[]
+}
+
+function previewSubtypeFromTag(tag: string): PreviewSubtype {
+  if (tag.startsWith('nightly-')) {
+    return 'nightly'
+  }
+  if (tag.startsWith('preview-pr-')) {
+    return 'pr'
+  }
+  if (tag.startsWith('preview-branch-')) {
+    return 'branch'
+  }
+  if (tag.startsWith('preview-manual-')) {
+    return 'manual'
+  }
+  return 'generic'
+}
+
+function versionFromAssetName(name: string): string {
+  const base = name.slice(0, name.length - CHROME_ASSET_SUFFIX.length)
+  const prefix = 'danmaku-anywhere-'
+  if (base.startsWith(prefix)) {
+    return base.slice(prefix.length)
+  }
+  return base
+}
+
+function toReleaseAsset(raw: RawRelease): ReleaseAsset | undefined {
+  const asset = raw.assets.find((a) => a.name.endsWith(CHROME_ASSET_SUFFIX))
+  if (!asset) {
+    return undefined
+  }
+
+  const channel: Channel = raw.prerelease ? 'preview' : 'stable'
+  const previewSubtype = raw.prerelease
+    ? previewSubtypeFromTag(raw.tag_name)
+    : undefined
+
+  return {
+    tag: raw.tag_name,
+    version: versionFromAssetName(asset.name),
+    channel,
+    previewSubtype,
+    publishedAt: raw.published_at,
+    assetUrl: asset.url,
+  }
+}
+
+export function parseReleases(payload: unknown): ReleaseAsset[] {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+
+  const result: ReleaseAsset[] = []
+  for (const raw of payload as RawRelease[]) {
+    const asset = toReleaseAsset(raw)
+    if (asset) {
+      result.push(asset)
+    }
+  }
+  return result
+}
+
+export async function fetchReleases(
+  token: string | undefined,
+  fetchImpl: typeof fetch = fetch
+): Promise<Result<ReleaseAsset[], ReleaseManagerError>> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  let response: Response
+  try {
+    response = await fetchImpl(RELEASES_URL, { headers })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'fetch failed'
+    return err({ kind: 'network', message })
+  }
+
+  if (response.status === 401) {
+    return err({
+      kind: 'auth',
+      status: 401,
+      message: 'GitHub token is missing or invalid',
+    })
+  }
+
+  if (response.status === 403) {
+    const remaining = response.headers.get('x-ratelimit-remaining')
+    if (remaining === '0') {
+      return err({ kind: 'rate-limited', message: 'GitHub rate limit reached' })
+    }
+    return err({
+      kind: 'auth',
+      status: 403,
+      message: 'GitHub rejected the request',
+    })
+  }
+
+  if (!response.ok) {
+    return err({
+      kind: 'network',
+      message: `GitHub responded with ${response.status}`,
+    })
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'invalid json'
+    return err({ kind: 'network', message })
+  }
+
+  return ok(parseReleases(payload))
+}

--- a/tools/release-manager/src/core/manager.ts
+++ b/tools/release-manager/src/core/manager.ts
@@ -1,0 +1,179 @@
+import { err, ok, type Result } from '@danmaku-anywhere/result'
+import { activePath, clearActive, setActive } from './active.js'
+import { downloadBuild, reconcileBuilds, removeBuild } from './cache.js'
+import { fetchReleases } from './github.js'
+import { ConfigStore } from './store.js'
+import type {
+  Config,
+  PublicState,
+  ReleaseAsset,
+  ReleaseManagerError,
+} from './types.js'
+
+interface ManagerDeps {
+  dataDir: string
+  fetchReleases?: (
+    token: string | undefined
+  ) => Promise<Result<ReleaseAsset[], ReleaseManagerError>>
+  downloadAsset?: typeof fetch
+}
+
+export class ReleaseManager {
+  private readonly dataDir: string
+  private readonly store: ConfigStore
+  private readonly inFlight = new Set<string>()
+  private readonly fetchReleasesImpl: (
+    token: string | undefined
+  ) => Promise<Result<ReleaseAsset[], ReleaseManagerError>>
+  private readonly downloadAsset: typeof fetch
+
+  constructor(deps: ManagerDeps) {
+    this.dataDir = deps.dataDir
+    this.store = new ConfigStore(deps.dataDir)
+    this.fetchReleasesImpl =
+      deps.fetchReleases ?? ((token) => fetchReleases(token))
+    this.downloadAsset = deps.downloadAsset ?? fetch
+  }
+
+  async getState(): Promise<PublicState> {
+    const config = await this.store.load()
+    const builds = await reconcileBuilds(this.dataDir, config.builds)
+    const activeStillPresent = config.activeTag
+      ? builds.some((b) => b.tag === config.activeTag)
+      : false
+
+    let reconciled = config
+    if (
+      builds.length !== config.builds.length ||
+      (config.activeTag && !activeStillPresent)
+    ) {
+      if (config.activeTag && !activeStillPresent) {
+        await clearActive(this.dataDir)
+      }
+      reconciled = {
+        ...config,
+        builds,
+        activeTag: activeStillPresent ? config.activeTag : undefined,
+      }
+      await this.persist(reconciled)
+    }
+
+    const resolvedActive = reconciled.activeTag
+      ? activePath(this.dataDir)
+      : undefined
+    return this.store.toPublicState(reconciled, resolvedActive)
+  }
+
+  async listReleases(): Promise<Result<ReleaseAsset[], ReleaseManagerError>> {
+    const config = await this.store.load()
+    return this.fetchReleasesImpl(config.githubToken)
+  }
+
+  async downloadBuild(
+    tag: string
+  ): Promise<Result<PublicState, ReleaseManagerError>> {
+    if (this.inFlight.has(tag)) {
+      return err({
+        kind: 'conflict',
+        message: `a download for ${tag} is already running`,
+      })
+    }
+    this.inFlight.add(tag)
+
+    try {
+      const config = await this.store.load()
+      const releases = await this.fetchReleasesImpl(config.githubToken)
+      if (!releases.success) {
+        return releases
+      }
+
+      const asset = releases.data.find((r) => r.tag === tag)
+      if (!asset) {
+        return err({ kind: 'not-found', message: `no release tagged ${tag}` })
+      }
+
+      const downloaded = await downloadBuild(
+        this.dataDir,
+        asset,
+        this.downloadAsset,
+        config.githubToken
+      )
+      if (!downloaded.success) {
+        return downloaded
+      }
+
+      const builds = config.builds.filter((b) => b.tag !== tag)
+      builds.push(downloaded.data)
+      await this.persist({ ...config, builds })
+    } finally {
+      this.inFlight.delete(tag)
+    }
+
+    return ok(await this.getState())
+  }
+
+  async setActive(
+    tag: string
+  ): Promise<Result<PublicState, ReleaseManagerError>> {
+    const config = await this.store.load()
+    if (!config.builds.some((b) => b.tag === tag)) {
+      return err({ kind: 'not-found', message: `${tag} is not cached` })
+    }
+
+    const swapped = await setActive(this.dataDir, tag)
+    if (!swapped.success) {
+      return swapped
+    }
+
+    await this.persist({ ...config, activeTag: tag })
+    return ok(await this.getState())
+  }
+
+  async removeBuild(
+    tag: string
+  ): Promise<Result<PublicState, ReleaseManagerError>> {
+    const config = await this.store.load()
+    if (config.activeTag === tag) {
+      return err({
+        kind: 'conflict',
+        message: `${tag} is active; set another build active before removing it`,
+      })
+    }
+
+    const removed = await removeBuild(this.dataDir, tag)
+    if (!removed.success) {
+      return removed
+    }
+
+    const builds = config.builds.filter((b) => b.tag !== tag)
+    await this.persist({ ...config, builds })
+    return ok(await this.getState())
+  }
+
+  async updateToken(token: string): Promise<PublicState> {
+    const config = await this.store.load()
+    const githubToken = token.trim() === '' ? undefined : token
+    await this.persist({ ...config, githubToken })
+    return this.getState()
+  }
+
+  async reconcile(): Promise<void> {
+    const config = await this.store.load()
+    const builds = await reconcileBuilds(this.dataDir, config.builds)
+    const activeStillPresent = config.activeTag
+      ? builds.some((b) => b.tag === config.activeTag)
+      : false
+    if (!activeStillPresent && config.activeTag) {
+      await clearActive(this.dataDir)
+    }
+    await this.persist({
+      ...config,
+      builds,
+      activeTag: activeStillPresent ? config.activeTag : undefined,
+    })
+  }
+
+  private async persist(config: Config): Promise<void> {
+    await this.store.save(config)
+  }
+}

--- a/tools/release-manager/src/core/manager.ts
+++ b/tools/release-manager/src/core/manager.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path'
 import { err, ok, type Result } from '@danmaku-anywhere/result'
 import { activePath, clearActive, setActive } from './active.js'
 import { downloadBuild, reconcileBuilds, removeBuild } from './cache.js'
@@ -9,6 +10,21 @@ import type {
   ReleaseAsset,
   ReleaseManagerError,
 } from './types.js'
+
+function validateTag(tag: string): Result<string, ReleaseManagerError> {
+  if (
+    tag === '' ||
+    tag === '.' ||
+    tag === '..' ||
+    tag.includes('/') ||
+    tag.includes('\\') ||
+    tag.includes('\0') ||
+    basename(tag) !== tag
+  ) {
+    return err({ kind: 'invalid', message: `unsafe tag: ${tag}` })
+  }
+  return ok(tag)
+}
 
 interface ManagerDeps {
   dataDir: string
@@ -37,31 +53,36 @@ export class ReleaseManager {
 
   async getState(): Promise<PublicState> {
     const config = await this.store.load()
+    const reconciled = await this.reconcileConfig(config)
+    const resolvedActive = reconciled.activeTag
+      ? activePath(this.dataDir)
+      : undefined
+    return this.store.toPublicState(reconciled, resolvedActive)
+  }
+
+  private async reconcileConfig(config: Config): Promise<Config> {
     const builds = await reconcileBuilds(this.dataDir, config.builds)
     const activeStillPresent = config.activeTag
       ? builds.some((b) => b.tag === config.activeTag)
       : false
 
-    let reconciled = config
     if (
-      builds.length !== config.builds.length ||
-      (config.activeTag && !activeStillPresent)
+      builds.length === config.builds.length &&
+      (!config.activeTag || activeStillPresent)
     ) {
-      if (config.activeTag && !activeStillPresent) {
-        await clearActive(this.dataDir)
-      }
-      reconciled = {
-        ...config,
-        builds,
-        activeTag: activeStillPresent ? config.activeTag : undefined,
-      }
-      await this.persist(reconciled)
+      return config
     }
 
-    const resolvedActive = reconciled.activeTag
-      ? activePath(this.dataDir)
-      : undefined
-    return this.store.toPublicState(reconciled, resolvedActive)
+    if (config.activeTag && !activeStillPresent) {
+      await clearActive(this.dataDir)
+    }
+    const reconciled: Config = {
+      ...config,
+      builds,
+      activeTag: activeStillPresent ? config.activeTag : undefined,
+    }
+    await this.persist(reconciled)
+    return reconciled
   }
 
   async listReleases(): Promise<Result<ReleaseAsset[], ReleaseManagerError>> {
@@ -72,6 +93,11 @@ export class ReleaseManager {
   async downloadBuild(
     tag: string
   ): Promise<Result<PublicState, ReleaseManagerError>> {
+    const valid = validateTag(tag)
+    if (!valid.success) {
+      return valid
+    }
+
     if (this.inFlight.has(tag)) {
       return err({
         kind: 'conflict',
@@ -105,6 +131,13 @@ export class ReleaseManager {
       const builds = config.builds.filter((b) => b.tag !== tag)
       builds.push(downloaded.data)
       await this.persist({ ...config, builds })
+
+      if (config.activeTag === tag) {
+        const refreshed = await setActive(this.dataDir, tag)
+        if (!refreshed.success) {
+          return refreshed
+        }
+      }
     } finally {
       this.inFlight.delete(tag)
     }
@@ -115,6 +148,11 @@ export class ReleaseManager {
   async setActive(
     tag: string
   ): Promise<Result<PublicState, ReleaseManagerError>> {
+    const valid = validateTag(tag)
+    if (!valid.success) {
+      return valid
+    }
+
     const config = await this.store.load()
     if (!config.builds.some((b) => b.tag === tag)) {
       return err({ kind: 'not-found', message: `${tag} is not cached` })
@@ -132,6 +170,11 @@ export class ReleaseManager {
   async removeBuild(
     tag: string
   ): Promise<Result<PublicState, ReleaseManagerError>> {
+    const valid = validateTag(tag)
+    if (!valid.success) {
+      return valid
+    }
+
     const config = await this.store.load()
     if (config.activeTag === tag) {
       return err({
@@ -159,18 +202,7 @@ export class ReleaseManager {
 
   async reconcile(): Promise<void> {
     const config = await this.store.load()
-    const builds = await reconcileBuilds(this.dataDir, config.builds)
-    const activeStillPresent = config.activeTag
-      ? builds.some((b) => b.tag === config.activeTag)
-      : false
-    if (!activeStillPresent && config.activeTag) {
-      await clearActive(this.dataDir)
-    }
-    await this.persist({
-      ...config,
-      builds,
-      activeTag: activeStillPresent ? config.activeTag : undefined,
-    })
+    await this.reconcileConfig(config)
   }
 
   private async persist(config: Config): Promise<void> {

--- a/tools/release-manager/src/core/store.ts
+++ b/tools/release-manager/src/core/store.ts
@@ -1,0 +1,54 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { Config, PublicState } from './types.js'
+
+const CONFIG_FILE = 'config.json'
+
+function defaultConfig(): Config {
+  return { builds: [] }
+}
+
+export class ConfigStore {
+  private readonly configPath: string
+
+  constructor(private readonly dataDir: string) {
+    this.configPath = join(dataDir, CONFIG_FILE)
+  }
+
+  async load(): Promise<Config> {
+    let raw: string
+    try {
+      raw = await readFile(this.configPath, 'utf8')
+    } catch {
+      return defaultConfig()
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<Config>
+      return {
+        githubToken: parsed.githubToken,
+        activeTag: parsed.activeTag,
+        builds: Array.isArray(parsed.builds) ? parsed.builds : [],
+      }
+    } catch {
+      return defaultConfig()
+    }
+  }
+
+  async save(config: Config): Promise<void> {
+    await mkdir(this.dataDir, { recursive: true })
+    await writeFile(this.configPath, JSON.stringify(config, null, 2), {
+      mode: 0o600,
+    })
+  }
+
+  toPublicState(config: Config, activePath?: string): PublicState {
+    return {
+      hasToken: Boolean(config.githubToken),
+      activeTag: config.activeTag,
+      activePath,
+      dataDir: this.dataDir,
+      builds: config.builds,
+    }
+  }
+}

--- a/tools/release-manager/src/core/types.ts
+++ b/tools/release-manager/src/core/types.ts
@@ -1,0 +1,42 @@
+export type Channel = 'stable' | 'preview'
+
+export type PreviewSubtype = 'nightly' | 'pr' | 'branch' | 'manual' | 'generic'
+
+export interface ReleaseAsset {
+  tag: string
+  version: string
+  channel: Channel
+  previewSubtype?: PreviewSubtype
+  publishedAt: string
+  assetUrl: string
+}
+
+export interface CachedBuild {
+  tag: string
+  version: string
+  channel: Channel
+  downloadedAt: string
+}
+
+export interface Config {
+  githubToken?: string
+  activeTag?: string
+  builds: CachedBuild[]
+}
+
+export interface PublicState {
+  hasToken: boolean
+  activeTag?: string
+  activePath?: string
+  dataDir: string
+  builds: CachedBuild[]
+}
+
+export type ReleaseManagerError =
+  | { kind: 'auth'; status: number; message: string }
+  | { kind: 'rate-limited'; message: string }
+  | { kind: 'network'; message: string }
+  | { kind: 'swap'; message: string }
+  | { kind: 'not-found'; message: string }
+  | { kind: 'conflict'; message: string }
+  | { kind: 'invalid'; message: string }

--- a/tools/release-manager/src/server/app.ts
+++ b/tools/release-manager/src/server/app.ts
@@ -12,6 +12,14 @@ async function requireTag(c: Context): Promise<string | undefined> {
   return tag ? tag : undefined
 }
 
+function isLoopbackHost(host: string | undefined): boolean {
+  if (!host) {
+    return false
+  }
+  const hostname = host.split(':')[0]
+  return hostname === '127.0.0.1' || hostname === 'localhost'
+}
+
 function statusFor(error: ReleaseManagerError): ContentfulStatusCode {
   switch (error.kind) {
     case 'auth':
@@ -35,6 +43,13 @@ function statusFor(error: ReleaseManagerError): ContentfulStatusCode {
 
 export function createApp(manager: ReleaseManager): Hono {
   const app = new Hono()
+
+  app.use('/*', async (c, next) => {
+    if (!isLoopbackHost(c.req.header('Host'))) {
+      return c.json({ error: 'forbidden host' }, 403)
+    }
+    return next()
+  })
 
   app.get('/api/state', async (c) => {
     return c.json(await manager.getState())

--- a/tools/release-manager/src/server/app.ts
+++ b/tools/release-manager/src/server/app.ts
@@ -1,0 +1,96 @@
+import type { Context } from 'hono'
+import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import type { ReleaseManager } from '../core/manager.js'
+import type { ReleaseManagerError } from '../core/types.js'
+
+async function requireTag(c: Context): Promise<string | undefined> {
+  const body = await c.req
+    .json<{ tag?: string }>()
+    .catch((): { tag?: string } => ({}))
+  const tag = body.tag?.trim()
+  return tag ? tag : undefined
+}
+
+function statusFor(error: ReleaseManagerError): ContentfulStatusCode {
+  switch (error.kind) {
+    case 'auth':
+      return error.status as ContentfulStatusCode
+    case 'rate-limited':
+      return 429
+    case 'not-found':
+      return 404
+    case 'conflict':
+      return 409
+    case 'invalid':
+      return 400
+    case 'network':
+      return 502
+    case 'swap':
+      return 500
+    default:
+      return 500
+  }
+}
+
+export function createApp(manager: ReleaseManager): Hono {
+  const app = new Hono()
+
+  app.get('/api/state', async (c) => {
+    return c.json(await manager.getState())
+  })
+
+  app.get('/api/releases', async (c) => {
+    const result = await manager.listReleases()
+    if (!result.success) {
+      return c.json({ error: result.error.message }, statusFor(result.error))
+    }
+    return c.json(result.data)
+  })
+
+  app.post('/api/builds/download', async (c) => {
+    const tag = await requireTag(c)
+    if (!tag) {
+      return c.json({ error: 'tag is required' }, 400)
+    }
+    const result = await manager.downloadBuild(tag)
+    if (!result.success) {
+      return c.json({ error: result.error.message }, statusFor(result.error))
+    }
+    return c.json(result.data)
+  })
+
+  app.post('/api/active', async (c) => {
+    const tag = await requireTag(c)
+    if (!tag) {
+      return c.json({ error: 'tag is required' }, 400)
+    }
+    const result = await manager.setActive(tag)
+    if (!result.success) {
+      return c.json({ error: result.error.message }, statusFor(result.error))
+    }
+    return c.json(result.data)
+  })
+
+  app.delete('/api/builds/:tag', async (c) => {
+    const tag = c.req.param('tag').trim()
+    if (!tag) {
+      return c.json({ error: 'tag is required' }, 400)
+    }
+    const result = await manager.removeBuild(tag)
+    if (!result.success) {
+      return c.json({ error: result.error.message }, statusFor(result.error))
+    }
+    return c.json(result.data)
+  })
+
+  app.patch('/api/settings', async (c) => {
+    const body = await c.req
+      .json<{ githubToken?: string }>()
+      .catch((): { githubToken?: string } => ({}))
+    const state = await manager.updateToken(body.githubToken ?? '')
+    return c.json(state)
+  })
+
+  return app
+}

--- a/tools/release-manager/src/server/dataDir.ts
+++ b/tools/release-manager/src/server/dataDir.ts
@@ -1,0 +1,10 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export function resolveDataDir(): string {
+  const fromEnv = process.env.DA_RELEASE_MANAGER_DIR
+  if (fromEnv && fromEnv.trim() !== '') {
+    return fromEnv
+  }
+  return join(homedir(), '.da-release-manager')
+}

--- a/tools/release-manager/src/server/index.ts
+++ b/tools/release-manager/src/server/index.ts
@@ -1,0 +1,74 @@
+import { exec } from 'node:child_process'
+import { createServer } from 'node:net'
+import { fileURLToPath } from 'node:url'
+import { serve } from '@hono/node-server'
+import { serveStatic } from '@hono/node-server/serve-static'
+import { ReleaseManager } from '../core/manager.js'
+import { createApp } from './app.js'
+import { resolveDataDir } from './dataDir.js'
+
+const HOST = '127.0.0.1'
+const DEFAULT_PORT = Number(process.env.DA_RELEASE_MANAGER_PORT ?? 4317)
+const WEB_ROOT = fileURLToPath(new URL('../../dist/web/', import.meta.url))
+
+function isFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = createServer()
+    tester.once('error', () => resolve(false))
+    tester.once('listening', () => {
+      tester.close(() => resolve(true))
+    })
+    tester.listen(port, HOST)
+  })
+}
+
+async function pickPort(start: number): Promise<number> {
+  const end = start + 20
+  for (let port = start; port < end; port++) {
+    if (await isFree(port)) {
+      return port
+    }
+  }
+  throw new Error(`no free port found in range ${start}..${end - 1}`)
+}
+
+function openCommand(url: string): string {
+  if (process.platform === 'darwin') {
+    return `open "${url}"`
+  }
+  if (process.platform === 'win32') {
+    return `start "" "${url}"`
+  }
+  return `xdg-open "${url}"`
+}
+
+function openBrowser(url: string): void {
+  exec(openCommand(url), (error) => {
+    if (error) {
+      console.log(`open ${url} manually`)
+    }
+  })
+}
+
+async function main(): Promise<void> {
+  const dataDir = resolveDataDir()
+  const manager = new ReleaseManager({ dataDir })
+  await manager.reconcile()
+
+  const app = createApp(manager)
+  app.use('/*', serveStatic({ root: WEB_ROOT, index: 'index.html' }))
+
+  const port = await pickPort(DEFAULT_PORT)
+  const url = `http://${HOST}:${port}`
+
+  serve({ fetch: app.fetch, hostname: HOST, port }, () => {
+    console.log(`release-manager listening on ${url}`)
+    console.log(`data dir: ${dataDir}`)
+    openBrowser(url)
+  })
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/tools/release-manager/src/web/App.tsx
+++ b/tools/release-manager/src/web/App.tsx
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type {
+  Channel,
+  PreviewSubtype,
+  PublicState,
+  ReleaseAsset,
+} from '../core/types.js'
+import * as api from './api.js'
+
+interface Row {
+  tag: string
+  version: string
+  channel: Channel
+  previewSubtype?: PreviewSubtype
+  publishedAt?: string
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+interface ReleaseRowProps {
+  row: Row
+  state: PublicState
+  busy: boolean
+  error?: string
+  onDownload: (tag: string) => void
+  onSetActive: (tag: string) => void
+  onRemove: (tag: string) => void
+}
+
+function ReleaseRow(props: ReleaseRowProps) {
+  const { row, state, busy, error } = props
+  const cached = state.builds.some((b) => b.tag === row.tag)
+  const isActive = state.activeTag === row.tag
+  const disabled = busy
+
+  function renderAction() {
+    if (isActive) {
+      return <span className="tag-active">Active</span>
+    }
+    if (cached) {
+      return (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => props.onSetActive(row.tag)}
+        >
+          Set active
+        </button>
+      )
+    }
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => props.onDownload(row.tag)}
+      >
+        Download
+      </button>
+    )
+  }
+
+  return (
+    <tr>
+      <td>
+        <code>{row.tag}</code>
+        {row.previewSubtype ? (
+          <span className="subtype">{row.previewSubtype}</span>
+        ) : null}
+      </td>
+      <td>{row.version}</td>
+      <td>{row.publishedAt ? formatDate(row.publishedAt) : '-'}</td>
+      <td>{cached ? <span className="cached">cached</span> : null}</td>
+      <td className="actions">
+        {renderAction()}
+        {cached && !isActive ? (
+          <button
+            type="button"
+            className="danger"
+            disabled={disabled}
+            onClick={() => props.onRemove(row.tag)}
+          >
+            Remove
+          </button>
+        ) : null}
+        {error ? <div className="row-error">{error}</div> : null}
+      </td>
+    </tr>
+  )
+}
+
+interface GroupProps {
+  title: string
+  rows: Row[]
+  state: PublicState
+  busyTag?: string
+  rowErrors: Record<string, string>
+  onDownload: (tag: string) => void
+  onSetActive: (tag: string) => void
+  onRemove: (tag: string) => void
+}
+
+function ReleaseGroup(props: GroupProps) {
+  if (props.rows.length === 0) {
+    return null
+  }
+  return (
+    <section>
+      <h2>{props.title}</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Tag</th>
+            <th>Version</th>
+            <th>Published</th>
+            <th>Cached</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.rows.map((row) => (
+            <ReleaseRow
+              key={row.tag}
+              row={row}
+              state={props.state}
+              busy={props.busyTag === row.tag}
+              error={props.rowErrors[row.tag]}
+              onDownload={props.onDownload}
+              onSetActive={props.onSetActive}
+              onRemove={props.onRemove}
+            />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+export function App() {
+  const [state, setState] = useState<PublicState | null>(null)
+  const [releases, setReleases] = useState<ReleaseAsset[]>([])
+  const [globalError, setGlobalError] = useState<string | undefined>()
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({})
+  const [busyTag, setBusyTag] = useState<string | undefined>()
+  const [token, setToken] = useState('')
+
+  const refreshState = useCallback(async () => {
+    try {
+      setState(await api.getState())
+    } catch (error) {
+      setGlobalError(error instanceof Error ? error.message : String(error))
+    }
+  }, [])
+
+  const loadReleases = useCallback(async () => {
+    setGlobalError(undefined)
+    try {
+      setReleases(await api.getReleases())
+    } catch (error) {
+      setGlobalError(error instanceof Error ? error.message : String(error))
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshState()
+    void loadReleases()
+  }, [refreshState, loadReleases])
+
+  const runRowAction = useCallback(
+    async (tag: string, action: () => Promise<PublicState>) => {
+      setBusyTag(tag)
+      setRowErrors((prev) => {
+        const next = { ...prev }
+        delete next[tag]
+        return next
+      })
+      try {
+        setState(await action())
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        setRowErrors((prev) => ({ ...prev, [tag]: message }))
+      } finally {
+        setBusyTag(undefined)
+      }
+    },
+    []
+  )
+
+  const onDownload = useCallback(
+    (tag: string) => {
+      void runRowAction(tag, () => api.downloadBuild(tag))
+    },
+    [runRowAction]
+  )
+  const onSetActive = useCallback(
+    (tag: string) => {
+      void runRowAction(tag, () => api.setActive(tag))
+    },
+    [runRowAction]
+  )
+  const onRemove = useCallback(
+    (tag: string) => {
+      void runRowAction(tag, () => api.removeBuild(tag))
+    },
+    [runRowAction]
+  )
+
+  const onSaveToken = useCallback(async () => {
+    try {
+      setState(await api.updateToken(token))
+      setToken('')
+      await loadReleases()
+    } catch (error) {
+      setGlobalError(error instanceof Error ? error.message : String(error))
+    }
+  }, [token, loadReleases])
+
+  const { stable, previews } = useMemo(() => {
+    const rows: Row[] = releases.map((r) => ({
+      tag: r.tag,
+      version: r.version,
+      channel: r.channel,
+      previewSubtype: r.previewSubtype,
+      publishedAt: r.publishedAt,
+    }))
+
+    const seen = new Set(rows.map((r) => r.tag))
+    const cachedRows: Row[] = state
+      ? state.builds
+          .filter((b) => !seen.has(b.tag))
+          .map((b) => ({
+            tag: b.tag,
+            version: b.version,
+            channel: b.channel,
+          }))
+      : []
+
+    const all = [...rows, ...cachedRows]
+    const byDate = (a: Row, b: Row) =>
+      (b.publishedAt ?? '').localeCompare(a.publishedAt ?? '')
+    return {
+      stable: all.filter((r) => r.channel === 'stable').sort(byDate),
+      previews: all.filter((r) => r.channel === 'preview').sort(byDate),
+    }
+  }, [releases, state])
+
+  function copyActivePath() {
+    if (state?.activePath) {
+      void navigator.clipboard.writeText(state.activePath)
+    }
+  }
+
+  if (!state) {
+    return <main className="container">Loading…</main>
+  }
+
+  return (
+    <main className="container">
+      <header>
+        <h1>Extension Release Manager</h1>
+        <div className="active-box">
+          <div className="active-label">Active loaded folder</div>
+          <div className="active-path">
+            <code>{state.activePath ?? 'none selected'}</code>
+            {state.activePath ? (
+              <button type="button" onClick={copyActivePath}>
+                Copy
+              </button>
+            ) : null}
+          </div>
+          <p className="hint">
+            Load unpacked in chrome://extensions and select this folder, once.
+          </p>
+          {state.activeTag ? (
+            <p className="hint">
+              Active build: <code>{state.activeTag}</code>
+            </p>
+          ) : null}
+        </div>
+      </header>
+
+      {globalError ? <div className="error">{globalError}</div> : null}
+
+      <ReleaseGroup
+        title="Stable"
+        rows={stable}
+        state={state}
+        busyTag={busyTag}
+        rowErrors={rowErrors}
+        onDownload={onDownload}
+        onSetActive={onSetActive}
+        onRemove={onRemove}
+      />
+      <ReleaseGroup
+        title="Previews"
+        rows={previews}
+        state={state}
+        busyTag={busyTag}
+        rowErrors={rowErrors}
+        onDownload={onDownload}
+        onSetActive={onSetActive}
+        onRemove={onRemove}
+      />
+
+      <section className="settings">
+        <h2>Settings</h2>
+        <label htmlFor="token">GitHub token (optional)</label>
+        <div className="token-row">
+          <input
+            id="token"
+            type="password"
+            value={token}
+            placeholder={state.hasToken ? 'token saved' : 'paste a token'}
+            onChange={(e) => setToken(e.target.value)}
+          />
+          <button type="button" onClick={() => void onSaveToken()}>
+            Save
+          </button>
+        </div>
+        <label htmlFor="datadir">Data dir</label>
+        <input id="datadir" type="text" value={state.dataDir} readOnly />
+      </section>
+    </main>
+  )
+}

--- a/tools/release-manager/src/web/App.tsx
+++ b/tools/release-manager/src/web/App.tsx
@@ -84,6 +84,7 @@ function ReleaseRow(props: ReleaseRowProps) {
             Remove
           </button>
         ) : null}
+        {busy ? <span className="working">Working…</span> : null}
         {error ? <div className="row-error">{error}</div> : null}
       </td>
     </tr>
@@ -281,6 +282,10 @@ export function App() {
       </header>
 
       {globalError ? <div className="error">{globalError}</div> : null}
+
+      {stable.length === 0 && previews.length === 0 ? (
+        <p className="empty">No releases found</p>
+      ) : null}
 
       <ReleaseGroup
         title="Stable"

--- a/tools/release-manager/src/web/api.ts
+++ b/tools/release-manager/src/web/api.ts
@@ -1,0 +1,55 @@
+import type { PublicState, ReleaseAsset } from '../core/types.js'
+
+async function unwrap<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string
+    }
+    throw new Error(body.error ?? `request failed (${response.status})`)
+  }
+  return response.json() as Promise<T>
+}
+
+export async function getState(): Promise<PublicState> {
+  return unwrap(await fetch('/api/state'))
+}
+
+export async function getReleases(): Promise<ReleaseAsset[]> {
+  return unwrap(await fetch('/api/releases'))
+}
+
+export async function downloadBuild(tag: string): Promise<PublicState> {
+  return unwrap(
+    await fetch('/api/builds/download', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tag }),
+    })
+  )
+}
+
+export async function setActive(tag: string): Promise<PublicState> {
+  return unwrap(
+    await fetch('/api/active', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tag }),
+    })
+  )
+}
+
+export async function removeBuild(tag: string): Promise<PublicState> {
+  return unwrap(
+    await fetch(`/api/builds/${encodeURIComponent(tag)}`, { method: 'DELETE' })
+  )
+}
+
+export async function updateToken(githubToken: string): Promise<PublicState> {
+  return unwrap(
+    await fetch('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ githubToken }),
+    })
+  )
+}

--- a/tools/release-manager/src/web/env.d.ts
+++ b/tools/release-manager/src/web/env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/tools/release-manager/src/web/index.html
+++ b/tools/release-manager/src/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/tools/release-manager/src/web/main.tsx
+++ b/tools/release-manager/src/web/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App.js'
+import './styles.css'
+
+const container = document.getElementById('root')
+if (container) {
+  createRoot(container).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  )
+}

--- a/tools/release-manager/src/web/styles.css
+++ b/tools/release-manager/src/web/styles.css
@@ -1,0 +1,144 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 24px 16px 64px;
+}
+
+h1 {
+  font-size: 1.4rem;
+}
+
+h2 {
+  font-size: 1.1rem;
+  margin-top: 32px;
+}
+
+.active-box {
+  border: 1px solid currentColor;
+  border-radius: 8px;
+  padding: 12px 16px;
+  opacity: 0.95;
+}
+
+.active-label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.active-path {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0;
+  word-break: break-all;
+}
+
+.hint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  margin: 4px 0 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+  vertical-align: top;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+button {
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+button.danger {
+  border-color: #c0392b;
+  color: #c0392b;
+}
+
+.tag-active {
+  font-weight: 600;
+  color: #2e7d32;
+}
+
+.cached {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.subtype {
+  margin-left: 6px;
+  font-size: 0.75rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  opacity: 0.7;
+}
+
+.error,
+.row-error {
+  color: #c0392b;
+  font-size: 0.85rem;
+}
+
+.error {
+  margin: 12px 0;
+}
+
+.settings {
+  margin-top: 40px;
+}
+
+.settings label {
+  display: block;
+  font-size: 0.85rem;
+  margin-top: 12px;
+}
+
+.token-row {
+  display: flex;
+  gap: 8px;
+}
+
+input {
+  flex: 1;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(127, 127, 127, 0.5);
+  background: transparent;
+  color: inherit;
+}

--- a/tools/release-manager/src/web/styles.css
+++ b/tools/release-manager/src/web/styles.css
@@ -119,6 +119,16 @@ button.danger {
   margin: 12px 0;
 }
 
+.working {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.empty {
+  opacity: 0.7;
+  margin: 16px 0;
+}
+
 .settings {
   margin-top: 40px;
 }

--- a/tools/release-manager/test/active.test.ts
+++ b/tools/release-manager/test/active.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -10,8 +17,8 @@ beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), 'rm-active-'))
   await mkdir(join(dir, 'cache', 'v1'), { recursive: true })
   await mkdir(join(dir, 'cache', 'v2'), { recursive: true })
-  await writeFile(join(dir, 'cache', 'v1', 'marker'), 'one')
-  await writeFile(join(dir, 'cache', 'v2', 'marker'), 'two')
+  await writeFile(join(dir, 'cache', 'v1', 'manifest.json'), 'one')
+  await writeFile(join(dir, 'cache', 'v2', 'manifest.json'), 'two')
 })
 
 afterEach(async () => {
@@ -19,20 +26,26 @@ afterEach(async () => {
 })
 
 describe('setActive', () => {
-  it('points the active link at the requested cache dir', async () => {
+  it('copies the requested build into the active dir', async () => {
     const result = await setActive(dir, 'v1')
     expect(result.success).toBe(true)
 
-    const resolved = await realpath(activePath(dir))
-    expect(resolved).toBe(await realpath(join(dir, 'cache', 'v1')))
+    const content = await readFile(
+      join(activePath(dir), 'manifest.json'),
+      'utf8'
+    )
+    expect(content).toBe('one')
   })
 
-  it('repoints an existing link to a new target', async () => {
+  it('replaces active contents when switching builds', async () => {
     await setActive(dir, 'v1')
     await setActive(dir, 'v2')
 
-    const resolved = await realpath(activePath(dir))
-    expect(resolved).toBe(await realpath(join(dir, 'cache', 'v2')))
+    const content = await readFile(
+      join(activePath(dir), 'manifest.json'),
+      'utf8'
+    )
+    expect(content).toBe('two')
   })
 
   it('fails with a swap error when the cache dir is missing', async () => {
@@ -43,11 +56,12 @@ describe('setActive', () => {
     }
   })
 
-  it('clears the active link', async () => {
+  it('empties the active dir when cleared', async () => {
     await setActive(dir, 'v1')
     const result = await clearActive(dir)
     expect(result.success).toBe(true)
 
-    await expect(realpath(activePath(dir))).rejects.toThrow()
+    const entries = await readdir(activePath(dir))
+    expect(entries).toEqual([])
   })
 })

--- a/tools/release-manager/test/active.test.ts
+++ b/tools/release-manager/test/active.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { activePath, clearActive, setActive } from '../src/core/active.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'rm-active-'))
+  await mkdir(join(dir, 'cache', 'v1'), { recursive: true })
+  await mkdir(join(dir, 'cache', 'v2'), { recursive: true })
+  await writeFile(join(dir, 'cache', 'v1', 'marker'), 'one')
+  await writeFile(join(dir, 'cache', 'v2', 'marker'), 'two')
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('setActive', () => {
+  it('points the active link at the requested cache dir', async () => {
+    const result = await setActive(dir, 'v1')
+    expect(result.success).toBe(true)
+
+    const resolved = await realpath(activePath(dir))
+    expect(resolved).toBe(await realpath(join(dir, 'cache', 'v1')))
+  })
+
+  it('repoints an existing link to a new target', async () => {
+    await setActive(dir, 'v1')
+    await setActive(dir, 'v2')
+
+    const resolved = await realpath(activePath(dir))
+    expect(resolved).toBe(await realpath(join(dir, 'cache', 'v2')))
+  })
+
+  it('fails with a swap error when the cache dir is missing', async () => {
+    const result = await setActive(dir, 'does-not-exist')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('swap')
+    }
+  })
+
+  it('clears the active link', async () => {
+    await setActive(dir, 'v1')
+    const result = await clearActive(dir)
+    expect(result.success).toBe(true)
+
+    await expect(realpath(activePath(dir))).rejects.toThrow()
+  })
+})

--- a/tools/release-manager/test/active.test.ts
+++ b/tools/release-manager/test/active.test.ts
@@ -1,9 +1,11 @@
 import {
+  lstat,
   mkdir,
   mkdtemp,
   readdir,
   readFile,
   rm,
+  symlink,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -54,6 +56,25 @@ describe('setActive', () => {
     if (!result.success) {
       expect(result.error.kind).toBe('swap')
     }
+  })
+
+  it('replaces a pre-existing symlink at active with a real dir', async () => {
+    await symlink(join(dir, 'cache', 'v1'), activePath(dir), 'dir')
+    const before = await lstat(activePath(dir))
+    expect(before.isSymbolicLink()).toBe(true)
+
+    const result = await setActive(dir, 'v2')
+    expect(result.success).toBe(true)
+
+    const after = await lstat(activePath(dir))
+    expect(after.isSymbolicLink()).toBe(false)
+    expect(after.isDirectory()).toBe(true)
+
+    const content = await readFile(
+      join(activePath(dir), 'manifest.json'),
+      'utf8'
+    )
+    expect(content).toBe('two')
   })
 
   it('empties the active dir when cleared', async () => {

--- a/tools/release-manager/test/app.test.ts
+++ b/tools/release-manager/test/app.test.ts
@@ -1,0 +1,113 @@
+import { err, ok, type Result } from '@danmaku-anywhere/result'
+import { describe, expect, it } from 'vitest'
+import type { ReleaseManager } from '../src/core/manager.js'
+import type { PublicState, ReleaseManagerError } from '../src/core/types.js'
+import { createApp } from '../src/server/app.js'
+
+const emptyState: PublicState = {
+  hasToken: false,
+  dataDir: '/tmp/data',
+  builds: [],
+}
+
+function fakeManager(overrides: Partial<ReleaseManager> = {}): ReleaseManager {
+  const base = {
+    getState: async () => emptyState,
+    listReleases: async () => ok([]),
+    downloadBuild: async () => ok(emptyState),
+    setActive: async () => ok(emptyState),
+    removeBuild: async () => ok(emptyState),
+    updateToken: async () => emptyState,
+    reconcile: async () => undefined,
+  }
+  return { ...base, ...overrides } as unknown as ReleaseManager
+}
+
+const localHeaders = {
+  Host: '127.0.0.1:4317',
+  'Content-Type': 'application/json',
+}
+
+describe('createApp host allowlist', () => {
+  it('allows a loopback host', async () => {
+    const app = createApp(fakeManager())
+    const res = await app.request('/api/state', {
+      headers: { Host: 'localhost:4317' },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects a foreign host with 403', async () => {
+    const app = createApp(fakeManager())
+    const res = await app.request('/api/state', {
+      headers: { Host: 'evil.example.com' },
+    })
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('createApp statusFor mapping', () => {
+  const cases: Array<{ error: ReleaseManagerError; status: number }> = [
+    { error: { kind: 'auth', status: 401, message: 'x' }, status: 401 },
+    { error: { kind: 'auth', status: 403, message: 'x' }, status: 403 },
+    { error: { kind: 'rate-limited', message: 'x' }, status: 429 },
+    { error: { kind: 'conflict', message: 'x' }, status: 409 },
+    { error: { kind: 'not-found', message: 'x' }, status: 404 },
+    { error: { kind: 'invalid', message: 'x' }, status: 400 },
+    { error: { kind: 'network', message: 'x' }, status: 502 },
+    { error: { kind: 'swap', message: 'x' }, status: 500 },
+  ]
+
+  for (const { error, status } of cases) {
+    it(`maps ${error.kind} to ${status}`, async () => {
+      const app = createApp(
+        fakeManager({
+          downloadBuild: async (): Promise<
+            Result<PublicState, ReleaseManagerError>
+          > => err(error),
+        })
+      )
+      const res = await app.request('/api/builds/download', {
+        method: 'POST',
+        headers: localHeaders,
+        body: JSON.stringify({ tag: 'v1' }),
+      })
+      expect(res.status).toBe(status)
+    })
+  }
+})
+
+describe('createApp requireTag', () => {
+  const routes = ['/api/active', '/api/builds/download']
+
+  for (const route of routes) {
+    it(`rejects an empty tag with 400 on POST ${route}`, async () => {
+      const app = createApp(fakeManager())
+      const res = await app.request(route, {
+        method: 'POST',
+        headers: localHeaders,
+        body: JSON.stringify({ tag: '' }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it(`rejects a whitespace tag with 400 on POST ${route}`, async () => {
+      const app = createApp(fakeManager())
+      const res = await app.request(route, {
+        method: 'POST',
+        headers: localHeaders,
+        body: JSON.stringify({ tag: '   ' }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it(`rejects a missing body with 400 on POST ${route}`, async () => {
+      const app = createApp(fakeManager())
+      const res = await app.request(route, {
+        method: 'POST',
+        headers: localHeaders,
+      })
+      expect(res.status).toBe(400)
+    })
+  }
+})

--- a/tools/release-manager/test/cache.test.ts
+++ b/tools/release-manager/test/cache.test.ts
@@ -99,6 +99,36 @@ describe('downloadBuild', () => {
     expect(JSON.parse(manifest).version).toBe('2.0.0')
   })
 
+  it('rejects an archive with no manifest.json as invalid', async () => {
+    const zipped = zipSync({
+      'background.js': strToU8('console.log("hi")'),
+    })
+    const result = await downloadBuild(
+      dir,
+      asset('t', '1.0.0'),
+      stubFetch(zipped)
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('invalid')
+    }
+  })
+
+  it('falls back to the asset version when the manifest has no version', async () => {
+    const zipped = zipSync({
+      'manifest.json': strToU8(JSON.stringify({ name: 'da' })),
+    })
+    const result = await downloadBuild(
+      dir,
+      asset('t', '7.7.7'),
+      stubFetch(zipped)
+    )
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.version).toBe('7.7.7')
+    }
+  })
+
   it('maps a download failure to a network error', async () => {
     const result = await downloadBuild(
       dir,
@@ -131,6 +161,32 @@ describe('downloadBuild', () => {
     }
     await downloadBuild(dir, asset('t', '1.0.0'), recordingFetch)
     expect((seen as Record<string, string>).Authorization).toBeUndefined()
+  })
+})
+
+describe('zip-slip containment', () => {
+  it('does not write entries that escape the dest dir', async () => {
+    const zipped = zipSync({
+      'manifest.json': strToU8(JSON.stringify({ version: '1.0.0' })),
+      '../escape.txt': strToU8('pwned'),
+    })
+    const result = await downloadBuild(
+      dir,
+      asset('t', '1.0.0'),
+      stubFetch(zipped)
+    )
+    expect(result.success).toBe(true)
+
+    await expect(
+      readFile(join(dir, 'cache', 'escape.txt'), 'utf8')
+    ).rejects.toThrow()
+    await expect(readFile(join(dir, 'escape.txt'), 'utf8')).rejects.toThrow()
+
+    const manifest = await readFile(
+      join(dir, 'cache', 't', 'manifest.json'),
+      'utf8'
+    )
+    expect(JSON.parse(manifest).version).toBe('1.0.0')
   })
 })
 

--- a/tools/release-manager/test/cache.test.ts
+++ b/tools/release-manager/test/cache.test.ts
@@ -1,0 +1,180 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { strToU8, zipSync } from 'fflate'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  downloadBuild,
+  reconcileBuilds,
+  removeBuild,
+} from '../src/core/cache.js'
+import type { CachedBuild, ReleaseAsset } from '../src/core/types.js'
+
+let dir: string
+
+function makeZip(version: string): Uint8Array {
+  return zipSync({
+    'manifest.json': strToU8(JSON.stringify({ version, name: 'da' })),
+    'background.js': strToU8('console.log("hi")'),
+  })
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+  return buffer
+}
+
+function stubFetch(body: Uint8Array, status = 200): typeof fetch {
+  return async () => {
+    if (status !== 200) {
+      return new Response('err', { status })
+    }
+    return new Response(toArrayBuffer(body), { status })
+  }
+}
+
+function asset(tag: string, version: string): ReleaseAsset {
+  return {
+    tag,
+    version,
+    channel: 'preview',
+    publishedAt: '2026-01-01T00:00:00Z',
+    assetUrl: `https://example.com/${tag}`,
+  }
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'rm-cache-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('downloadBuild', () => {
+  it('unzips into the cache dir and reads the manifest version', async () => {
+    const result = await downloadBuild(
+      dir,
+      asset('preview-pr-1', '9.9.9'),
+      stubFetch(makeZip('9.9.9'))
+    )
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.version).toBe('9.9.9')
+      expect(result.data.tag).toBe('preview-pr-1')
+    }
+
+    const manifest = await readFile(
+      join(dir, 'cache', 'preview-pr-1', 'manifest.json'),
+      'utf8'
+    )
+    expect(JSON.parse(manifest).version).toBe('9.9.9')
+  })
+
+  it('leaves no temp dir behind on success', async () => {
+    await downloadBuild(dir, asset('t', '1.0.0'), stubFetch(makeZip('1.0.0')))
+    await expect(
+      readFile(join(dir, 'cache', '.tmp-t', 'manifest.json'))
+    ).rejects.toThrow()
+  })
+
+  it('refreshes an existing tag on re-download', async () => {
+    await downloadBuild(dir, asset('t', '1.0.0'), stubFetch(makeZip('1.0.0')))
+    const second = await downloadBuild(
+      dir,
+      asset('t', '2.0.0'),
+      stubFetch(makeZip('2.0.0'))
+    )
+
+    expect(second.success).toBe(true)
+    if (second.success) {
+      expect(second.data.version).toBe('2.0.0')
+    }
+    const manifest = await readFile(
+      join(dir, 'cache', 't', 'manifest.json'),
+      'utf8'
+    )
+    expect(JSON.parse(manifest).version).toBe('2.0.0')
+  })
+
+  it('maps a download failure to a network error', async () => {
+    const result = await downloadBuild(
+      dir,
+      asset('t', '1.0.0'),
+      stubFetch(new Uint8Array(), 500)
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('network')
+    }
+  })
+
+  it('sends a bearer authorization header when a token is given', async () => {
+    let seen: HeadersInit | undefined
+    const recordingFetch: typeof fetch = async (_url, init) => {
+      seen = init?.headers
+      return new Response(toArrayBuffer(makeZip('1.0.0')), { status: 200 })
+    }
+    await downloadBuild(dir, asset('t', '1.0.0'), recordingFetch, 'tok-123')
+    expect((seen as Record<string, string>).Authorization).toBe(
+      'Bearer tok-123'
+    )
+  })
+
+  it('omits the authorization header when no token is given', async () => {
+    let seen: HeadersInit | undefined
+    const recordingFetch: typeof fetch = async (_url, init) => {
+      seen = init?.headers
+      return new Response(toArrayBuffer(makeZip('1.0.0')), { status: 200 })
+    }
+    await downloadBuild(dir, asset('t', '1.0.0'), recordingFetch)
+    expect((seen as Record<string, string>).Authorization).toBeUndefined()
+  })
+})
+
+describe('removeBuild', () => {
+  it('removes the cache dir for a tag', async () => {
+    await downloadBuild(dir, asset('t', '1.0.0'), stubFetch(makeZip('1.0.0')))
+    const result = await removeBuild(dir, 't')
+    expect(result.success).toBe(true)
+    await expect(
+      readFile(join(dir, 'cache', 't', 'manifest.json'))
+    ).rejects.toThrow()
+  })
+})
+
+describe('reconcileBuilds', () => {
+  it('drops index entries with no dir on disk', async () => {
+    await downloadBuild(
+      dir,
+      asset('keep', '1.0.0'),
+      stubFetch(makeZip('1.0.0'))
+    )
+    const index: CachedBuild[] = [
+      {
+        tag: 'keep',
+        version: '1.0.0',
+        channel: 'preview',
+        downloadedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        tag: 'ghost',
+        version: '1.0.0',
+        channel: 'preview',
+        downloadedAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    const reconciled = await reconcileBuilds(dir, index)
+    expect(reconciled.map((b) => b.tag)).toEqual(['keep'])
+  })
+
+  it('ignores the temp and active entries on disk', async () => {
+    await mkdir(join(dir, 'cache', '.tmp-x'), { recursive: true })
+    await writeFile(join(dir, 'cache', '.tmp-x', 'f'), 'x')
+    const reconciled = await reconcileBuilds(dir, [])
+    expect(reconciled).toEqual([])
+  })
+})

--- a/tools/release-manager/test/fixtures/releases.json
+++ b/tools/release-manager/test/fixtures/releases.json
@@ -1,0 +1,83 @@
+[
+  {
+    "tag_name": "v1.2.0",
+    "prerelease": false,
+    "published_at": "2026-05-01T10:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.2.0-firefox.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/1"
+      },
+      {
+        "name": "danmaku-anywhere-1.2.0-chrome.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/2"
+      }
+    ]
+  },
+  {
+    "tag_name": "nightly-123456",
+    "prerelease": true,
+    "published_at": "2026-05-02T02:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.2.1-123-chrome.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/3"
+      }
+    ]
+  },
+  {
+    "tag_name": "preview-pr-460",
+    "prerelease": true,
+    "published_at": "2026-05-03T08:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.2.1-9-chrome.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/4"
+      }
+    ]
+  },
+  {
+    "tag_name": "preview-branch-feature-foo",
+    "prerelease": true,
+    "published_at": "2026-05-04T08:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.2.1-10-chrome.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/5"
+      }
+    ]
+  },
+  {
+    "tag_name": "preview-manual-11",
+    "prerelease": true,
+    "published_at": "2026-05-05T08:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.2.1-11-chrome.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/6"
+      }
+    ]
+  },
+  {
+    "tag_name": "latest-preview",
+    "prerelease": true,
+    "published_at": "2026-05-06T08:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.2.1-12-chrome.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/7"
+      }
+    ]
+  },
+  {
+    "tag_name": "v1.1.0-no-chrome",
+    "prerelease": false,
+    "published_at": "2026-04-01T08:00:00Z",
+    "assets": [
+      {
+        "name": "danmaku-anywhere-1.1.0-firefox.zip",
+        "url": "https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/8"
+      }
+    ]
+  }
+]

--- a/tools/release-manager/test/github.test.ts
+++ b/tools/release-manager/test/github.test.ts
@@ -103,4 +103,37 @@ describe('fetchReleases', () => {
       expect(result.error.kind).toBe('network')
     }
   })
+
+  it('maps a 403 without an exhausted rate limit to an auth error', async () => {
+    const stubFetch: typeof fetch = async () =>
+      new Response('no', {
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '42' },
+      })
+    const result = await fetchReleases(undefined, stubFetch)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('auth')
+    }
+  })
+
+  it('maps a non-ok status to a network error', async () => {
+    const stubFetch: typeof fetch = async () =>
+      new Response('boom', { status: 500 })
+    const result = await fetchReleases(undefined, stubFetch)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('network')
+    }
+  })
+
+  it('maps an invalid json body to a network error', async () => {
+    const stubFetch: typeof fetch = async () =>
+      new Response('not json', { status: 200 })
+    const result = await fetchReleases(undefined, stubFetch)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('network')
+    }
+  })
 })

--- a/tools/release-manager/test/github.test.ts
+++ b/tools/release-manager/test/github.test.ts
@@ -1,0 +1,106 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { fetchReleases, parseReleases } from '../src/core/github.js'
+
+const fixtureUrl = new URL('./fixtures/releases.json', import.meta.url)
+
+async function loadFixture(): Promise<unknown> {
+  const raw = await readFile(fileURLToPath(fixtureUrl), 'utf8')
+  return JSON.parse(raw)
+}
+
+describe('parseReleases', () => {
+  it('classifies stable vs preview by the prerelease boolean', async () => {
+    const releases = parseReleases(await loadFixture())
+
+    const stable = releases.find((r) => r.tag === 'v1.2.0')
+    expect(stable?.channel).toBe('stable')
+
+    const nightly = releases.find((r) => r.tag === 'nightly-123456')
+    expect(nightly?.channel).toBe('preview')
+  })
+
+  it('derives preview subtype from tag prefixes', async () => {
+    const releases = parseReleases(await loadFixture())
+    const subtypeOf = (tag: string) =>
+      releases.find((r) => r.tag === tag)?.previewSubtype
+
+    expect(subtypeOf('nightly-123456')).toBe('nightly')
+    expect(subtypeOf('preview-pr-460')).toBe('pr')
+    expect(subtypeOf('preview-branch-feature-foo')).toBe('branch')
+    expect(subtypeOf('preview-manual-11')).toBe('manual')
+  })
+
+  it('treats an unrecognized preview tag as generic, never crashing', async () => {
+    const releases = parseReleases(await loadFixture())
+    const generic = releases.find((r) => r.tag === 'latest-preview')
+
+    expect(generic?.channel).toBe('preview')
+    expect(generic?.previewSubtype).toBe('generic')
+  })
+
+  it('resolves the chrome asset url and reads the version', async () => {
+    const releases = parseReleases(await loadFixture())
+    const stable = releases.find((r) => r.tag === 'v1.2.0')
+
+    expect(stable?.version).toBe('1.2.0')
+    expect(stable?.assetUrl).toBe(
+      'https://api.github.com/repos/Mr-Quin/danmaku-anywhere/releases/assets/2'
+    )
+  })
+
+  it('drops releases without a chrome asset', async () => {
+    const releases = parseReleases(await loadFixture())
+    expect(releases.find((r) => r.tag === 'v1.1.0-no-chrome')).toBeUndefined()
+  })
+})
+
+describe('fetchReleases', () => {
+  it('sends a bearer token when provided', async () => {
+    let seenAuth: string | null = null
+    const stubFetch: typeof fetch = async (_url, init) => {
+      const headers = new Headers(init?.headers)
+      seenAuth = headers.get('Authorization')
+      return new Response(JSON.stringify([]), { status: 200 })
+    }
+
+    const result = await fetchReleases('tok', stubFetch)
+    expect(result.success).toBe(true)
+    expect(seenAuth).toBe('Bearer tok')
+  })
+
+  it('maps 401 to an auth error', async () => {
+    const stubFetch: typeof fetch = async () =>
+      new Response('no', { status: 401 })
+    const result = await fetchReleases(undefined, stubFetch)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('auth')
+    }
+  })
+
+  it('maps a rate-limited 403 to rate-limited', async () => {
+    const stubFetch: typeof fetch = async () =>
+      new Response('limit', {
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0' },
+      })
+    const result = await fetchReleases(undefined, stubFetch)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('rate-limited')
+    }
+  })
+
+  it('maps a thrown fetch to a network error', async () => {
+    const stubFetch: typeof fetch = async () => {
+      throw new Error('boom')
+    }
+    const result = await fetchReleases(undefined, stubFetch)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('network')
+    }
+  })
+})

--- a/tools/release-manager/test/manager.test.ts
+++ b/tools/release-manager/test/manager.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { strToU8, zipSync } from 'fflate'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ReleaseManager } from '../src/core/manager.js'
+import type { ReleaseAsset } from '../src/core/types.js'
+
+let dir: string
+
+function makeZip(version: string): ArrayBuffer {
+  const bytes = zipSync({
+    'manifest.json': strToU8(JSON.stringify({ version })),
+  })
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+  return buffer
+}
+
+const releases: ReleaseAsset[] = [
+  {
+    tag: 'preview-pr-1',
+    version: '1.0.0',
+    channel: 'preview',
+    previewSubtype: 'pr',
+    publishedAt: '2026-01-01T00:00:00Z',
+    assetUrl: 'https://example.com/a',
+  },
+  {
+    tag: 'v2.0.0',
+    version: '2.0.0',
+    channel: 'stable',
+    publishedAt: '2026-02-01T00:00:00Z',
+    assetUrl: 'https://example.com/b',
+  },
+]
+
+function makeManager(opts?: {
+  hangFirstDownload?: () => void
+}): ReleaseManager {
+  let firstDownload = true
+  return new ReleaseManager({
+    dataDir: dir,
+    fetchReleases: async () => ({ success: true, data: releases }),
+    downloadAsset: async (_url) => {
+      if (opts?.hangFirstDownload && firstDownload) {
+        firstDownload = false
+        return new Promise(() => {})
+      }
+      return new Response(makeZip('1.0.0'), { status: 200 })
+    },
+  })
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'rm-manager-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('ReleaseManager', () => {
+  it('lists releases', async () => {
+    const manager = makeManager()
+    const result = await manager.listReleases()
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toHaveLength(2)
+    }
+  })
+
+  it('downloads, records the build, and reports it in state', async () => {
+    const manager = makeManager()
+    const dl = await manager.downloadBuild('preview-pr-1')
+    expect(dl.success).toBe(true)
+
+    const state = await manager.getState()
+    expect(state.builds.map((b) => b.tag)).toContain('preview-pr-1')
+  })
+
+  it('rejects an unknown tag on download', async () => {
+    const manager = makeManager()
+    const result = await manager.downloadBuild('nope')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('not-found')
+    }
+  })
+
+  it('sets a build active and exposes the active path', async () => {
+    const manager = makeManager()
+    await manager.downloadBuild('preview-pr-1')
+    const active = await manager.setActive('preview-pr-1')
+    expect(active.success).toBe(true)
+
+    const state = await manager.getState()
+    expect(state.activeTag).toBe('preview-pr-1')
+    expect(state.activePath).toBeDefined()
+  })
+
+  it('refuses to set active a tag that is not cached', async () => {
+    const manager = makeManager()
+    const result = await manager.setActive('v2.0.0')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('not-found')
+    }
+  })
+
+  it('refuses to remove the active build', async () => {
+    const manager = makeManager()
+    await manager.downloadBuild('preview-pr-1')
+    await manager.setActive('preview-pr-1')
+
+    const result = await manager.removeBuild('preview-pr-1')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('conflict')
+    }
+  })
+
+  it('removes a non-active build', async () => {
+    const manager = makeManager()
+    await manager.downloadBuild('preview-pr-1')
+    const result = await manager.removeBuild('preview-pr-1')
+    expect(result.success).toBe(true)
+
+    const state = await manager.getState()
+    expect(state.builds.map((b) => b.tag)).not.toContain('preview-pr-1')
+  })
+
+  it('clears activeTag in getState when the active build dir is removed', async () => {
+    const manager = makeManager()
+    await manager.downloadBuild('preview-pr-1')
+    await manager.setActive('preview-pr-1')
+
+    await rm(join(dir, 'cache', 'preview-pr-1'), {
+      recursive: true,
+      force: true,
+    })
+
+    const state = await manager.getState()
+    expect(state.activeTag).toBeUndefined()
+    expect(state.activePath).toBeUndefined()
+    expect(state.builds.map((b) => b.tag)).not.toContain('preview-pr-1')
+  })
+
+  it('updates the token and reports hasToken without leaking it', async () => {
+    const manager = makeManager()
+    await manager.updateToken('tok-123')
+
+    const state = await manager.getState()
+    expect(state.hasToken).toBe(true)
+    expect(JSON.stringify(state)).not.toContain('tok-123')
+  })
+
+  it('rejects a concurrent download of the same tag', async () => {
+    const manager = makeManager({ hangFirstDownload: () => {} })
+    const first = manager.downloadBuild('preview-pr-1')
+    const second = await manager.downloadBuild('preview-pr-1')
+
+    expect(second.success).toBe(false)
+    if (!second.success) {
+      expect(second.error.kind).toBe('conflict')
+    }
+    void first
+  })
+})

--- a/tools/release-manager/test/manager.test.ts
+++ b/tools/release-manager/test/manager.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { strToU8, zipSync } from 'fflate'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ReleaseManager } from '../src/core/manager.js'
+import { ConfigStore } from '../src/core/store.js'
 import type { ReleaseAsset } from '../src/core/types.js'
 
 let dir: string
@@ -165,5 +166,82 @@ describe('ReleaseManager', () => {
       expect(second.error.kind).toBe('conflict')
     }
     void first
+  })
+
+  it('refreshes the active copy when re-downloading the active tag', async () => {
+    let marker = 'first'
+    const manager = new ReleaseManager({
+      dataDir: dir,
+      fetchReleases: async () => ({ success: true, data: releases }),
+      downloadAsset: async () => {
+        const bytes = zipSync({
+          'manifest.json': strToU8(JSON.stringify({ version: '1.0.0' })),
+          'marker.txt': strToU8(marker),
+        })
+        const buffer = new ArrayBuffer(bytes.byteLength)
+        new Uint8Array(buffer).set(bytes)
+        return new Response(buffer, { status: 200 })
+      },
+    })
+
+    await manager.downloadBuild('preview-pr-1')
+    await manager.setActive('preview-pr-1')
+
+    const before = await readFile(join(dir, 'active', 'marker.txt'), 'utf8')
+    expect(before).toBe('first')
+
+    marker = 'second'
+    const redownload = await manager.downloadBuild('preview-pr-1')
+    expect(redownload.success).toBe(true)
+
+    const after = await readFile(join(dir, 'active', 'marker.txt'), 'utf8')
+    expect(after).toBe('second')
+  })
+
+  it('rejects a path-traversal tag as invalid without touching the fs', async () => {
+    const manager = makeManager()
+    const result = await manager.downloadBuild('../../evil')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.kind).toBe('invalid')
+    }
+
+    await expect(
+      readFile(join(dir, '..', 'evil', 'manifest.json'))
+    ).rejects.toThrow()
+
+    const setResult = await manager.setActive('../../evil')
+    expect(setResult.success).toBe(false)
+    if (!setResult.success) {
+      expect(setResult.error.kind).toBe('invalid')
+    }
+
+    const removeResult = await manager.removeBuild('../../evil')
+    expect(removeResult.success).toBe(false)
+    if (!removeResult.success) {
+      expect(removeResult.error.kind).toBe('invalid')
+    }
+  })
+
+  it('clears a stale active tag on startup reconcile', async () => {
+    const store = new ConfigStore(dir)
+    await store.save({
+      activeTag: 'gone',
+      builds: [
+        {
+          tag: 'gone',
+          version: '1.0.0',
+          channel: 'preview',
+          downloadedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    })
+
+    const manager = makeManager()
+    await manager.reconcile()
+
+    const reloaded = await store.load()
+    expect(reloaded.activeTag).toBeUndefined()
+    expect(reloaded.builds).toEqual([])
   })
 })

--- a/tools/release-manager/test/store.test.ts
+++ b/tools/release-manager/test/store.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ConfigStore } from '../src/core/store.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'rm-store-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('ConfigStore', () => {
+  it('returns first-run defaults when no config exists', async () => {
+    const store = new ConfigStore(dir)
+    const config = await store.load()
+
+    expect(config.builds).toEqual([])
+    expect(config.githubToken).toBeUndefined()
+    expect(config.activeTag).toBeUndefined()
+  })
+
+  it('round-trips a saved config', async () => {
+    const store = new ConfigStore(dir)
+    await store.save({
+      githubToken: 'secret',
+      activeTag: 'v1.0.0',
+      builds: [
+        {
+          tag: 'v1.0.0',
+          version: '1.0.0',
+          channel: 'stable',
+          downloadedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    })
+
+    const reloaded = await new ConfigStore(dir).load()
+    expect(reloaded.githubToken).toBe('secret')
+    expect(reloaded.activeTag).toBe('v1.0.0')
+    expect(reloaded.builds).toHaveLength(1)
+  })
+
+  it('writes config.json with 0600 permissions', async () => {
+    const store = new ConfigStore(dir)
+    await store.save({ builds: [] })
+
+    const info = await stat(join(dir, 'config.json'))
+    expect(info.mode & 0o777).toBe(0o600)
+  })
+
+  it('masks the token in the public state and never leaks the raw value', async () => {
+    const store = new ConfigStore(dir)
+    await store.save({ githubToken: 'super-secret', builds: [] })
+
+    const state = store.toPublicState(await store.load())
+    expect(state.hasToken).toBe(true)
+    const serialized = JSON.stringify(state)
+    expect(serialized).not.toContain('super-secret')
+    expect(serialized).not.toContain('githubToken')
+  })
+
+  it('reports hasToken false when no token is set', async () => {
+    const store = new ConfigStore(dir)
+    await store.save({ builds: [] })
+
+    const state = store.toPublicState(await store.load())
+    expect(state.hasToken).toBe(false)
+  })
+})

--- a/tools/release-manager/tsconfig.json
+++ b/tools/release-manager/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": ["node"]
+  },
+  "include": ["./src", "./test", "./vite.config.ts", "./scripts"]
+}

--- a/tools/release-manager/vite.config.ts
+++ b/tools/release-manager/vite.config.ts
@@ -1,0 +1,18 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+const SERVER_PORT = Number(process.env.DA_RELEASE_MANAGER_PORT ?? 4317)
+
+export default defineConfig({
+  root: 'src/web',
+  plugins: [react()],
+  build: {
+    outDir: '../../dist/web',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': `http://127.0.0.1:${SERVER_PORT}`,
+    },
+  },
+})

--- a/tools/release-manager/vitest.config.ts
+++ b/tools/release-manager/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary
- New dev-tooling package `tools/release-manager` (`@danmaku-anywhere/release-manager`, private). Adds a `tools/**` workspace glob.
- Local-web utility: a Node/Hono backend (full FS access, bound to `127.0.0.1`) serves a single-screen React UI to **download** extension release/preview builds from GitHub, **cache** them per tag, and **swap** which cached build is the active unpacked folder loaded into `chrome://extensions`. Solves the slow download/unpack/overwrite-and-reload loop for manual release testing.
- Shell-agnostic, `Result`-based core (`github` / `store` / `cache` / `active` / `manager`) with no HTTP/UI coupling, so a Tauri/Electron shell can wrap it later. Scope is folder-manager only (no Chrome launcher); Chrome only (Firefox deferred); dev-first (user-facing deferred).
- No `build` script by design, so the tool stays out of root `pnpm build`; it still joins `test` / `type-check` / `lint:ci` sweeps.

## Implementation notes
- Releases grouped Stable vs Preview by the API `prerelease` flag; preview subtype from literal tag prefixes (`nightly-`, `preview-pr-`, `preview-branch-`, `preview-manual-`). Chrome asset matched by `endsWith('-chrome.zip')`.
- Stable releases are published as drafts, so listing/downloading them needs a GitHub token; the optional token is threaded into both the releases fetch and the asset download (`Accept: application/octet-stream`).
- Downloads unzip (`fflate`) into a temp dir then atomically rename into `cache/<tag>/`; the builds index is written only on success and reconciled against on-disk dirs at startup.
- **Active folder is a real directory with the build copied in, not a symlink.** A sandboxed (Flatpak) Chrome reads the picked unpacked folder through a document portal that does not grant a symlink's target, so a symlinked active folder fails with "File path cannot be resolved." Copying keeps the loaded path stable across swaps and works for both native and Flatpak Chrome; the copy source is the local cache, so swapping never re-downloads. Verified end-to-end in a real (Flatpak) Chrome: load once, then Set active + reload swaps the build in place.
- Security posture: token stored in `config.json` at mode `0600`, never serialized to the browser (state exposes `hasToken` only); server is loopback-only.

## Test plan
- [ ] `pnpm --filter @danmaku-anywhere/release-manager test` (37 tests: github grouping/asset resolution, atomic unzip + index reconcile, active-folder copy/replace/clear, config round-trip + token masking + 0600, manager download-guard + active-build delete refusal + token threading)
- [ ] `pnpm --filter @danmaku-anywhere/release-manager type-check` and `lint`
- [ ] Manual: `pnpm release-manager`, download a build, Set active, "Load unpacked" `<dataDir>/active` in `chrome://extensions`, Set-active another build, reload the extension (contents swap in place).
- No extension e2e: this package is outside the Playwright harness and has no extension runtime surface.

## Notes
- Releases list shows the most recent 100 releases (no pagination), which is fine for a dev tool wanting recent builds; documented in `AGENTS.md`.