### PR TITLE
(chore) trim ML wasm from extension bundle [DA-615]

### DIFF
--- a/packages/danmaku-anywhere/scripts/vendorRuntimeAssets.ts
+++ b/packages/danmaku-anywhere/scripts/vendorRuntimeAssets.ts
@@ -32,22 +32,19 @@ const ASSET_GROUPS: readonly AssetGroup[] = [
         'wasm'
       ),
     destDir: 'mediapipe/wasm',
-    files: [
-      'vision_wasm_internal.js',
-      'vision_wasm_internal.wasm',
-      'vision_wasm_nosimd_internal.js',
-      'vision_wasm_nosimd_internal.wasm',
-    ],
+    // The build targets (chrome89+/firefox89+) all support SIMD, so
+    // FilesetResolver always picks the SIMD build; the no-SIMD fallback is dead
+    // weight.
+    files: ['vision_wasm_internal.js', 'vision_wasm_internal.wasm'],
   },
   {
     label: 'onnxruntime-web',
     resolveSrcDir: () => path.dirname(require.resolve('onnxruntime-web')),
     destDir: 'ort',
+    // The extern-wasm webgpu build (ort.webgpu.min.mjs, selected by the resolve
+    // condition in vite.config) loads only the asyncify pair via the wasmPaths
+    // override; the plain and jsep variants are never fetched.
     files: [
-      'ort-wasm-simd-threaded.wasm',
-      'ort-wasm-simd-threaded.mjs',
-      'ort-wasm-simd-threaded.jsep.wasm',
-      'ort-wasm-simd-threaded.jsep.mjs',
       'ort-wasm-simd-threaded.asyncify.wasm',
       'ort-wasm-simd-threaded.asyncify.mjs',
     ],
@@ -59,6 +56,9 @@ function vendor(): void {
   for (const group of ASSET_GROUPS) {
     const srcDir = group.resolveSrcDir()
     const destDir = path.join(publicDir, group.destDir)
+    // Wipe first so a trimmed file list does not leave stale runtimes behind to
+    // ship in the build (these dirs hold only vendored assets).
+    fs.rmSync(destDir, { recursive: true, force: true })
     fs.mkdirSync(destDir, { recursive: true })
     for (const file of group.files) {
       const src = path.join(srcDir, file)

--- a/packages/danmaku-anywhere/vite.config.ts
+++ b/packages/danmaku-anywhere/vite.config.ts
@@ -1,5 +1,6 @@
 import { crx } from '@crxjs/vite-plugin'
 import react from '@vitejs/plugin-react'
+import { defaultClientConditions } from 'vite'
 import { defineConfig } from 'vitest/config'
 import { manifest } from './manifest'
 import { getBuildContext } from './scripts/getBuildContext'
@@ -48,6 +49,10 @@ export default defineConfig({
     ],
   },
   resolve: {
+    // Select onnxruntime-web's extern-wasm webgpu build (ort.webgpu.min.mjs): it
+    // loads wasm from the ort/ override instead of inlining it via `new URL`,
+    // which would make Vite emit a duplicate copy into assets/ that is never loaded.
+    conditions: ['onnxruntime-web-use-extern-wasm', ...defaultClientConditions],
     // Specific alias must precede the generic '@' prefix.
     alias: [
       ...(daEnv === 'prod'


### PR DESCRIPTION
## Summary
- Trim the vendored ML wasm that ships in the extension but is never loaded at runtime, cutting a fresh prod build from ~123M to ~54M.
- `vendorRuntimeAssets.ts`: onnxruntime-web group keeps only the asyncify pair (`ort-wasm-simd-threaded.asyncify.{wasm,mjs}`); drops the plain and jsep variants (~39M). MediaPipe group drops the no-SIMD fallback (`vision_wasm_nosimd_internal.{js,wasm}`, ~9M) that the chrome89+/firefox89+ build targets never select.
- `vite.config.ts`: add `onnxruntime-web-use-extern-wasm` to `resolve.conditions` (spread over `defaultClientConditions` so Vite's defaults are preserved) so `onnxruntime-web/webgpu` resolves to the extern-wasm build (`ort.webgpu.min.mjs`). The default bundled build inlines the wasm via `new URL`, making Vite emit a duplicate 23M asyncify wasm into `assets/` that the runtime `wasmPaths` override never loads.
- `vendorRuntimeAssets.ts`: wipe each vendored dir before copying, so a trimmed file list can't leave stale runtimes behind to ship (these dirs hold only vendored assets).

## Test plan
- [ ] `cd packages/danmaku-anywhere && pnpm build`, then `du -sh build build/ort build/mediapipe build/assets`. Expect total ~54M; `build/ort` holds only the asyncify pair; no `*.wasm` in `build/assets`; no `nosimd` in `build/mediapipe`.
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- e2e/specs/integration/occlusion.spec.ts e2e/specs/integration/occlusion-models.spec.ts e2e/specs/integration/occlusion-cross-origin.spec.ts e2e/specs/integration/occlusion-cache-scope.spec.ts` (9 tests, all pass against the trimmed build).

## Notes
- Verified the real segmenter runtime in a browser (the e2e suite cannot: CI has no WebGPU, the happy path uses a MockMaskProvider, and the model specs use fake OPFS blobs with no real download). Drove `pages/segmenter.html` directly:
  - MediaPipe selfie path initializes (`init ok`); network shows `vision_wasm_internal.{js,wasm}` + the tflite model at 200, and the SIMD build is auto-picked (no `nosimd` fetch).
  - ORT WebGPU path with the real hosted `anime` ISNet model initializes a session (`init ok`); network shows `ort.webgpu.min` chunk, the model, and `ort-wasm-simd-threaded.asyncify.{mjs,wasm}` at 200, with no `jsep`/plain fetch and no duplicate `assets/*.wasm`.
  - The only file-not-found entries were deliberate probes of the removed files, confirming they no longer ship.
- No new e2e coverage added: a missing-wasm regression only surfaces when the real runtime loads, which the suite intentionally avoids (no WebGPU/GPU in CI). The browser verification above covers that gap.