### PR TITLE
(extension) don't auto-open search history over source chips on return [DA-616]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
@@ -51,7 +51,6 @@ test('returning from season details keeps the history dropdown off the source ch
   await page.goBack()
 
   await expect(popup.search.input).toHaveValue('frieren')
-  await expect(popup.search.input).toBeFocused()
   await expect(popup.search.sourceChip('Bilibili')).toBeVisible()
   await expect(popup.search.historyOption('frieren')).toBeHidden()
 

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
@@ -51,6 +51,7 @@ test('returning from season details keeps the history dropdown off the source ch
   await page.goBack()
 
   await expect(popup.search.input).toHaveValue('frieren')
+  await expect(popup.search.input).toBeFocused()
   await expect(popup.search.sourceChip('Bilibili')).toBeVisible()
   await expect(popup.search.historyOption('frieren')).toBeHidden()
 

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
@@ -1,0 +1,90 @@
+import { expect } from '@playwright/test'
+import { mockBilibiliXml } from '../../network/bilibili'
+import { mockDandanplay } from '../../network/dandanplay'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { test } from '../../setup/fixtures'
+import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Returning from season details must not reopen the history dropdown over the
+ * source chips: the remount refocuses the input, but a committed search keeps
+ * openOnFocus suppressed so the chips stay clickable. Typing still reopens
+ * history, and a fresh popup with no committed search still auto-opens it.
+ */
+
+test('returning from season details keeps the history dropdown off the source chips', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: {
+      dandanplay: { enabled: true },
+      bilibili: { enabled: true },
+    },
+    network: [
+      mockDandanplay({
+        search: loadJsonFixture('ddp-search.json'),
+        bangumi: loadJsonFixture('ddp-bangumi.json'),
+        comments: loadJsonFixture('ddp-comments.json'),
+      }),
+      ...mockBilibiliXml({
+        searchBangumi: loadJsonFixture('bilibili-search-bangumi.json'),
+        searchFt: loadJsonFixture('bilibili-search-ft.json'),
+        season: loadJsonFixture('bilibili-season.json'),
+        xml: loadTextFixture('bilibili-xml.xml'),
+      }),
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+
+  await expect(popup.search.seasonCard('DanDanPlay')).toBeVisible()
+  await expect(popup.search.sourceChip('Bilibili')).toBeVisible()
+
+  await popup.search.openFirstResult('DanDanPlay')
+
+  await page.goBack()
+
+  await expect(popup.search.input).toHaveValue('frieren')
+  await expect(popup.search.sourceChip('Bilibili')).toBeVisible()
+  await expect(popup.search.historyOption('frieren')).toBeHidden()
+
+  await popup.search.sourceChip('Bilibili').click()
+  await expect(popup.search.sourceChip('Bilibili')).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  )
+  await expect(popup.search.seasonCard('Bilibili')).toBeVisible()
+
+  await popup.search.input.fill('fri')
+  await expect(popup.search.historyOption('frieren')).toBeVisible()
+})
+
+test('history auto-opens on focus for a fresh search', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: {
+      dandanplay: { enabled: true },
+    },
+    rawStorage: [
+      {
+        area: 'local',
+        key: 'searchHistory',
+        value: { data: { entries: ['frieren'] }, version: 1 },
+      },
+    ],
+  })
+
+  const popup = await Popup.open(page, extensionId)
+
+  await expect(popup.search.historyOption('frieren')).toBeVisible()
+})

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -260,6 +260,7 @@ export function SearchForm({
               onSubmit={handleInputSubmit}
               urlMode={isUrl}
               focusToken={focusToken}
+              hasCommittedSearch={!!committedSearchTerm}
             />
           </Box>
           {isUrl ? (

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchInput.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchInput.tsx
@@ -40,6 +40,7 @@ interface SearchInputProps {
   onSubmit: (value: string) => void
   urlMode?: boolean
   focusToken?: number
+  hasCommittedSearch?: boolean
 }
 
 export function SearchInput({
@@ -48,6 +49,7 @@ export function SearchInput({
   onSubmit,
   urlMode,
   focusToken,
+  hasCommittedSearch,
 }: SearchInputProps) {
   const showHotkey = focusToken !== undefined
   const isMacOs = getOS() === 'MacOS'
@@ -100,7 +102,7 @@ export function SearchInput({
   return (
     <Autocomplete
       freeSolo
-      openOnFocus={historyEnabled}
+      openOnFocus={historyEnabled && !hasCommittedSearch}
       options={filteredEntries}
       filterOptions={(options) => options}
       inputValue={value}


### PR DESCRIPTION
## Summary
- Returning from a season detail remounts the search input, which autofocuses and re-opened the history dropdown (MUI Autocomplete popper, zIndex 1403) over the `SourceFilterChips`, blocking the source selector whenever the page already had committed results.
- Thread `hasCommittedSearch={!!committedSearchTerm}` from `SearchForm` into `SearchInput` and gate `openOnFocus={historyEnabled && !hasCommittedSearch}`. History stays a "starting a search" aid: it still auto-opens on a fresh/empty search, still opens as soon as the user types a new query, and the input stays focused on return.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere exec playwright test e2e/specs/sources/search-history-open.spec.ts`
- New spec `packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts` covers the search to season-detail to back flow (history does not cover the chips, chips stay usable, input stays focused, typing reopens history) and a fresh popup (history auto-opens on focus).
- Verified in a real browser with live provider search: fresh search auto-opens history; open season then back keeps the chips uncovered; typing reopens history. No console errors.