### PR TITLE
(extension) cache inactive search source results for 30m [DA-617]

### DIFF
--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/SearchForm.tsx
@@ -85,6 +85,7 @@ export function SearchForm({
       enabled:
         !!committedSearchTerm && !isUrl && provider.id === activeProviderId,
       staleTime: Number.POSITIVE_INFINITY,
+      gcTime: 30 * 60 * 1000,
       retry: false,
     })),
   })


### PR DESCRIPTION
## Summary
- Set an explicit `gcTime` of 30 minutes on the per-provider search queries in `SearchForm.tsx`. They already use `staleTime: Infinity`, but inactive (non-active-chip) queries were garbage-collected on React Query's default 5-minute `gcTime`, so switching back to a recently-viewed source flipped the results to a skeleton and re-fetched.

## Test plan
- [ ] Search a keyword, view source A's results, switch to source B, then switch back to A within 30 minutes: A shows instantly with no skeleton/reload.
- e2e coverage skipped: the behavior hinges on a 30-minute cache-eviction timer, which is not practical to assert in the e2e suite without faking timers across the React Query client boundary. The change is a single query-option value.