### PR TITLE
(chore) babysit-pr: screen for settled re-flags before evaluating [DA-621]

### DIFF
--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -42,7 +42,9 @@ One GraphQL call returns: reviews, pending reviewers, open threads, reactions, c
 
 ### 2b. Classify each new comment
 
-Evaluate via the `reviewing-ai-feedback` skill. It defines the accept/decline rules, false-positive patterns, accept-signals, reply style, and the in-chat reporting format. Default stance is "verify against the code; the reviewer is probably right." Decline only with a named rule. Resolve every thread you handle (accepted or declined).
+**Screen for settled re-flags first.** On a multi-push PR the AI reviewer re-reads the whole diff on every push and will re-raise suggestions you already declined and resolved (the `ai-rereview` label re-triggers it each push, and the reviewer doesn't learn from a decline). So before evaluating, fetch resolved threads too and check each new open thread against them: if it re-raises a suggestion already declined + resolved on this PR (same file/region, same gist), skip the evaluation and resolve it with a one-line back-reference to the prior thread (per `reviewing-ai-feedback`). Reserve the full accept/decline pass for genuinely new threads. Once a PR has a few pushes this is the common case, and not screening for it is most of the loop's wasted cost.
+
+Evaluate the rest via the `reviewing-ai-feedback` skill. It defines the accept/decline rules, false-positive patterns, accept-signals, reply style, and the in-chat reporting format. Default stance is "verify against the code; the reviewer is probably right." Decline only with a named rule. Resolve every thread you handle (accepted or declined).
 
 ### 2c. Resolve mechanics
 


### PR DESCRIPTION
## Summary
- `babysit-pr` 2b now screens for **settled re-flags** before evaluating: if a new open thread re-raises a suggestion already declined + resolved on this PR, resolve it with a one-line back-reference instead of a full accept/decline pass. On a multi-push PR that re-evaluation was most of the loop's wasted cost.
- Deliberately did **not** change the `ai-rereview` CI trigger: gemini re-reads the whole diff on every push regardless, so the script can't stop the re-flagging without not-re-requesting at all, and the treadmill is on code PRs (a docs-only skip wouldn't touch it). The real, low-risk fix is making the agent's handling cheap.

## Test plan
- Verified: lint N/A (skill markdown) · tests N/A · e2e N/A · manual: 0 em dashes, well-formed, no absolute paths; complements the existing one-liner in `reviewing-ai-feedback`.
- Skill-doc only; nothing for a reviewer to run.