### PR TITLE
(extension) bump dango to 0.6.0: tolerate failed danmaku segments [DA-619]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/SeasonDetailsPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SeasonDetailsPage.ts
@@ -1,10 +1,12 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 
+// Matches the comment-count label in either zh ("条弹幕") or en ("comments").
+const COMMENT_LABEL = '条弹幕|comments?'
+
 const SELECTORS = {
   episodeForProvider: (provider: string) =>
     `[data-testid^="episode-list-item-${provider}-"]`,
-  // Matches either zh ("X条弹幕") or en ("X comments") locales.
-  COMMENT_COUNT_RE: /\d+\s*(条弹幕|comments?)/i,
+  COMMENT_COUNT_RE: new RegExp(`\\d+\\s*(${COMMENT_LABEL})`, 'i'),
 }
 
 export class SeasonDetailsPage {
@@ -36,7 +38,7 @@ export class SeasonDetailsPage {
     // Scope to the count caption: the flattened button text merges the
     // episode number with the count (e.g. "第1集" + "1" + "2条弹幕").
     const countNode = episode.getByText(
-      new RegExp(`^${count}\\s*(条弹幕|comments?)$`, 'i')
+      new RegExp(`^${count}\\s*(${COMMENT_LABEL})$`, 'i')
     )
     await expect(countNode).toBeVisible({ timeout })
   }

--- a/packages/danmaku-anywhere/e2e/pom/SeasonDetailsPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/SeasonDetailsPage.ts
@@ -27,4 +27,17 @@ export class SeasonDetailsPage {
   async expectCommentCount(episode: Locator, timeout = 15_000): Promise<void> {
     await expect(episode).toContainText(SELECTORS.COMMENT_COUNT_RE, { timeout })
   }
+
+  async expectCommentCountToBe(
+    episode: Locator,
+    count: number,
+    timeout = 15_000
+  ): Promise<void> {
+    // Scope to the count caption: the flattened button text merges the
+    // episode number with the count (e.g. "第1集" + "1" + "2条弹幕").
+    const countNode = episode.getByText(
+      new RegExp(`^${count}\\s*(条弹幕|comments?)$`, 'i')
+    )
+    await expect(countNode).toBeVisible({ timeout })
+  }
 }

--- a/packages/danmaku-anywhere/e2e/specs/sources/tencent.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/tencent.spec.ts
@@ -6,10 +6,11 @@ import { loadJsonFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Tencent happy path: MbSearch → GetPageData (episode list) → /barrage/base
- * → /barrage/segment/{name}. Exercises the segmented danmaku fetch flow
- * unique to Tencent and confirms episode-list rendering ends in a comment
- * count being shown.
+ * Tencent segmented danmaku fetch (MbSearch → GetPageData → /barrage/base →
+ * /barrage/segment/{name}). The happy path confirms a full multi-segment fetch
+ * renders a comment count. The partial-failure path 404s one of two segments
+ * and asserts the surviving segment's comments still render, so one missing
+ * segment doesn't drop the whole overlay.
  */
 
 test('tencent: search → season → episode → fetch danmaku', async ({
@@ -37,4 +38,32 @@ test('tencent: search → season → episode → fetch danmaku', async ({
   const episode =
     await popup.seasonDetails.fetchDanmakuForFirstEpisode('Tencent')
   await popup.seasonDetails.expectCommentCount(episode)
+})
+
+test('tencent: a failed danmaku segment does not drop the overlay', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  await applyProfile(context, da, {
+    providers: { tencent: { enabled: true } },
+    network: mockTencent({
+      search: loadJsonFixture('tencent-search.json'),
+      episodes: loadJsonFixture('tencent-episodes.json'),
+      danmakuBase: loadJsonFixture('tencent-danmaku-base.json'),
+      danmakuSegments: {
+        // Segment 30000 is omitted: the mock 404s it, so one forEach
+        // iteration fails while the other yields segment 0's two comments.
+        '0': loadJsonFixture('tencent-danmaku-segment-0.json'),
+      },
+    }),
+  })
+
+  const popup = await Popup.open(page, extensionId)
+  await popup.search.submit('frieren')
+  await popup.search.openFirstResult('Tencent')
+  const episode =
+    await popup.seasonDetails.fetchDanmakuForFirstEpisode('Tencent')
+  await popup.seasonDetails.expectCommentCountToBe(episode, 2)
 })

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -60,7 +60,7 @@
     "@fontsource-variable/noto-sans-tc": "^5.2.10",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
-    "@mr-quin/dango": "^0.5.0",
+    "@mr-quin/dango": "^0.6.0",
     "@mui/icons-material": "^9.0.1",
     "@mui/lab": "9.0.0-beta.3",
     "@mui/material": "^9.0.1",
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "2.2.1",
-    "@mr-quin/dango-manifests": "^0.5.0",
+    "@mr-quin/dango-manifests": "^0.6.0",
     "@playwright/test": "^1.59.1",
     "@types/chrome": "^0.0.326",
     "@types/d3": "^7.4.3",

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { DanmakuFetchByMeta } from '@/common/danmaku/dto'
 import type { ILogger } from '@/common/Logger'
 import {
+  DANMAKU_RUN_OPTIONS,
   MANIFEST_RUN_OPTIONS,
   ManifestProviderService,
 } from './ManifestProviderService'
@@ -249,7 +250,15 @@ describe('ManifestProviderService.getDanmaku', () => {
     const result = await svc.getDanmaku(makeRequest({ episodeId: 42 }))
 
     expect(result).toBe(raw)
-    expect(runner.runDanmaku).toHaveBeenCalledWith({ episodeId: 42 }, RUN_OPTS)
+    expect(runner.runDanmaku).toHaveBeenCalledWith(
+      { episodeId: 42 },
+      DANMAKU_RUN_OPTIONS
+    )
+  })
+
+  it('only the danmaku run tolerates a failed segment', () => {
+    expect(DANMAKU_RUN_OPTIONS.continueOnError).toBe(true)
+    expect(MANIFEST_RUN_OPTIONS).not.toHaveProperty('continueOnError')
   })
 })
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
@@ -75,6 +75,13 @@ export interface ManifestProviderConfig {
 // self-hosted local server resolves instead of being blocked.
 export const MANIFEST_RUN_OPTIONS: RunOptions = { allowPrivateHosts: true }
 
+// A danmaku run fans out across segments; tolerate a failed segment so one
+// missing segment doesn't drop the whole overlay.
+export const DANMAKU_RUN_OPTIONS: RunOptions = {
+  ...MANIFEST_RUN_OPTIONS,
+  continueOnError: true,
+}
+
 export class ManifestProviderService implements IDanmakuProvider {
   readonly forProvider: DanmakuSourceType
 
@@ -181,7 +188,7 @@ export class ManifestProviderService implements IDanmakuProvider {
       ...meta.params,
       ...meta.providerIds,
     })
-    return runner.runDanmaku<CommentEntity[]>(inputs, MANIFEST_RUN_OPTIONS)
+    return runner.runDanmaku<CommentEntity[]>(inputs, DANMAKU_RUN_OPTIONS)
   }
 
   async findEpisode(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,8 +306,8 @@ importers:
         specifier: 0.10.18
         version: 0.10.18
       '@mr-quin/dango':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@mui/icons-material':
         specifier: ^9.0.1
         version: 9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.15)(react@19.2.0)
@@ -421,8 +421,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@mr-quin/dango-manifests':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.60.0
@@ -2880,11 +2880,11 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@mr-quin/dango-manifests@0.5.0':
-    resolution: {integrity: sha512-9jJvPBhFkxTyB163bZYe8+NqxqD2uH3z23M9Yr8T4pn/P+1PRgWLNaHmctvIP60adNCABjnqS2t3+GOJlVj8+g==}
+  '@mr-quin/dango-manifests@0.6.0':
+    resolution: {integrity: sha512-WnbuGEhYg9BQJzalOcSpUayL3hciaf8JvpjCrqrCvPQ2CCEa/dnL6PMn/HA8b3X/qWM888muQgf1HdpHWybJkA==}
 
-  '@mr-quin/dango@0.5.0':
-    resolution: {integrity: sha512-zrR5zmDYl/gaJTX7ugaNejrG8jhytngUpHQupSePR4yCwQM2ySlWEWvQIrQyCWrBlH1628OzWm0aYc2a8IgzaQ==}
+  '@mr-quin/dango@0.6.0':
+    resolution: {integrity: sha512-Hm1IBBqRi2MEUgVbCKCA+9RnIkts/wQY1tNpRqyvzVyUyooACJmb8nQE95ZuaTRH9O/hwQzegPBGVx4PdFQYSg==}
     engines: {node: '>=20'}
 
   '@mr-quin/danmu@0.20.0-rc.4':
@@ -10473,9 +10473,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mr-quin/dango-manifests@0.5.0': {}
+  '@mr-quin/dango-manifests@0.6.0': {}
 
-  '@mr-quin/dango@0.5.0':
+  '@mr-quin/dango@0.6.0':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
       fast-xml-parser: 4.5.6


### PR DESCRIPTION
## Summary
- Bump `@mr-quin/dango` and `@mr-quin/dango-manifests` from `^0.5.0` to `^0.6.0`.
- dango 0.6.0 makes concurrent `forEach` steps fail fast (one failed iteration dooms the step) and adds an opt-in `RunOptions.continueOnError`. A danmaku fetch fans out across segments, so add `DANMAKU_RUN_OPTIONS` (`continueOnError: true`) and pass it ONLY to `runDanmaku`. One missing segment no longer drops the whole overlay.
- search / season / episodes / parseUrl and the login probe keep `MANIFEST_RUN_OPTIONS` (no `continueOnError`), so they still fail hard.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` (unit: `ManifestProviderService.test.ts` pins `runDanmaku` to `DANMAKU_RUN_OPTIONS`, the other pipelines to `MANIFEST_RUN_OPTIONS`, and asserts the base options never gain `continueOnError`).
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- specs/sources/tencent.spec.ts`

## Notes
- e2e turned out to be feasible and was added: `specs/sources/tencent.spec.ts` gains a partial-failure case that 404s one of two danmaku segments and asserts the surviving segment's comments still render. Verified non-theatre by inverting the implementation back to `MANIFEST_RUN_OPTIONS`, which makes the new e2e (and the unit call-site assertion) fail while the happy path stays green.
- New POM helper `SeasonDetailsPage.expectCommentCountToBe` scopes to the count caption rather than the flattened episode-button text (which merges the episode number with the count).