### PR TITLE
(extension) e2e: doctrine fixes, assertion hardening, proxy env defaults [DA-611]

### DIFF
--- a/.github/workflows/quality-e2e.yml
+++ b/.github/workflows/quality-e2e.yml
@@ -90,16 +90,6 @@ jobs:
           restore-keys: |
             prior-releases-${{ runner.os }}-
 
-      # .env is gitignored, so write a synthetic one for the build. The
-      # hosts are intercepted by Playwright routes; nothing reaches them.
-      - name: Write .env for build
-        working-directory: packages/danmaku-anywhere
-        run: |
-          cat > .env <<'EOF'
-          VITE_PROXY_URL=https://api.danmaku.test
-          VITE_PROXY_ORIGIN=https://danmaku.test
-          EOF
-
       - name: Build extension (e2e — dev API on, open shadow root)
         working-directory: packages/danmaku-anywhere
         env:

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cache-scope.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-cache-scope.spec.ts
@@ -2,6 +2,9 @@ import type { BrowserContext, Frame, Page } from '@playwright/test'
 import { expect, test } from '../../setup/fixtures'
 
 /**
+ * Sanctioned browser-capability probe, exempt from the user-visible-signal rule
+ * in e2e/AGENTS.md: OPFS scope has no DOM signal, so it asserts storage state.
+ *
  * Guards a load-bearing assumption of the occlusion model cache: OPFS inside the
  * extension-origin segmenter iframe must be shared across top-level sites, so a
  * large model is downloaded once globally rather than re-fetched per host site.

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -2,6 +2,7 @@ import {
   DanmakuSourceType,
   PROVIDER_TO_BUILTIN_ID,
 } from '@danmaku-anywhere/danmaku-converter'
+import { Popup } from '../../pom/Popup'
 import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
@@ -10,7 +11,8 @@ import { expect, test } from '../../setup/fixtures'
  * extensionOptions, and the three preloaded provider configs are seeded after
  * the manifest catalog loads with names derived from the manifest (so they
  * localize): the default UI language is Chinese, so the seeded names are the
- * manifests' zh strings, not hardcoded English. No console errors.
+ * manifests' zh strings, not hardcoded English. Then opens the popup providers
+ * list and asserts those localized names render. No console errors.
  *
  * A runtime.reload() variant was dropped: under --load-extension, the
  * extension does not respawn after reload, so the case isn't exercisable.
@@ -31,6 +33,7 @@ const LOCALIZED_NAMES_BY_ID: Record<string, string> = {
 
 test('fresh install: default options seeded, no console errors', async ({
   context,
+  page,
   extensionId,
 }) => {
   // Chrome extension IDs are a 32-char base-16 alphabet of a-p.
@@ -55,5 +58,22 @@ test('fresh install: default options seeded, no console errors', async ({
   const providers = await da.providerConfig.list()
   for (const provider of providers) {
     expect(provider.name).toBe(LOCALIZED_NAMES_BY_ID[provider.id])
+  }
+
+  // The providers list runs each configured provider's connectivity probe on
+  // render; mock them so network strict-mode and the console gate stay clean.
+  await context.route(/api\.bilibili\.com\/x\/web-interface\/nav/, (route) =>
+    route.fulfill({ json: { code: 0, message: '0', data: { isLogin: true } } })
+  )
+  await context.route(
+    /pbaccess\.video\.qq\.com\/.*page_server_rpc\.PageServer\/GetPageData/,
+    (route) => route.fulfill({ json: { ret: 0, msg: '', data: {} } })
+  )
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  for (const id of BUILTIN_PROVIDER_IDS) {
+    await expect(
+      popup.providers.row(LOCALIZED_NAMES_BY_ID[id]).first()
+    ).toBeVisible()
   }
 })

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -18,7 +18,7 @@ import { expect, test } from '../../setup/fixtures'
  * extension does not respawn after reload, so the case isn't exercisable.
  */
 
-const BUILTIN_PROVIDER_IDS = [
+const PRELOADED_PROVIDER_IDS = [
   PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
   PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
   PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
@@ -53,7 +53,7 @@ test('fresh install: default options seeded, no console errors', async ({
       const providers = await da.providerConfig.list()
       return providers.map((p) => p.id).sort()
     })
-    .toEqual([...BUILTIN_PROVIDER_IDS].sort())
+    .toEqual([...PRELOADED_PROVIDER_IDS].sort())
 
   const providers = await da.providerConfig.list()
   for (const provider of providers) {
@@ -71,7 +71,7 @@ test('fresh install: default options seeded, no console errors', async ({
   )
 
   const popup = await Popup.open(page, extensionId, '/providers')
-  for (const id of BUILTIN_PROVIDER_IDS) {
+  for (const id of PRELOADED_PROVIDER_IDS) {
     await expect(
       popup.providers.row(LOCALIZED_NAMES_BY_ID[id]).first()
     ).toBeVisible()

--- a/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
@@ -191,12 +191,11 @@ async function openProbePage(context: BrowserContext): Promise<Page> {
     { waitUntil: 'domcontentloaded', timeout: POPUP_TIMEOUT_MS }
   )
   await expect(page.locator('#root')).toBeVisible({ timeout: POPUP_TIMEOUT_MS })
-  // A render-time error (zod parse, a field SeasonTreeItem reads going missing)
-  // shows neither the season tree nor the empty-library state, so this is the
-  // gate that surfaces it instead of the probe moving on half-rendered.
-  const renderedTree = page.locator('[role="treeitem"]')
-  const emptyLibrary = page.getByText(/library/i)
-  await expect(renderedTree.or(emptyLibrary).first()).toBeVisible({
+  // The fixture always seeds seasons, so a healthy popup renders the season
+  // tree. A render-time error (zod parse, a field SeasonTreeItem reads going
+  // missing) leaves no tree item; this gate fails the test instead of letting
+  // the probe move on half-rendered.
+  await expect(page.locator('[role="treeitem"]').first()).toBeVisible({
     timeout: POPUP_TIMEOUT_MS,
   })
   return page

--- a/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
@@ -191,19 +191,14 @@ async function openProbePage(context: BrowserContext): Promise<Page> {
     { waitUntil: 'domcontentloaded', timeout: POPUP_TIMEOUT_MS }
   )
   await expect(page.locator('#root')).toBeVisible({ timeout: POPUP_TIMEOUT_MS })
-  // Wait for the season tree to either render an entry or show the
-  // empty-library state. Without this, render-time errors (zod parse,
-  // missing fields read by SeasonTreeItem) land after we've already moved on.
-  await page
-    .waitForFunction(
-      () =>
-        Boolean(
-          document.querySelector('[role="treeitem"]') ||
-            document.body.textContent?.toLowerCase().includes('library')
-        ),
-      { timeout: POPUP_TIMEOUT_MS }
-    )
-    .catch(() => undefined)
+  // A render-time error (zod parse, a field SeasonTreeItem reads going missing)
+  // shows neither the season tree nor the empty-library state, so this is the
+  // gate that surfaces it instead of the probe moving on half-rendered.
+  const renderedTree = page.locator('[role="treeitem"]')
+  const emptyLibrary = page.getByText(/library/i)
+  await expect(renderedTree.or(emptyLibrary).first()).toBeVisible({
+    timeout: POPUP_TIMEOUT_MS,
+  })
   return page
 }
 

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-detach.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-detach.spec.ts
@@ -74,12 +74,7 @@ test('/import route renders standalone and runs a full file import', async ({
 
   const importResult = new ImportResultDialog(page)
   await importResult.confirm()
-
-  await expect(
-    page.locator('[role="alert"]').filter({
-      hasText: /Successfully imported|成功导入/,
-    })
-  ).toBeVisible()
+  await importResult.expectSuccess()
 
   const customs = await da.episode.listCustom()
   expect(customs).toHaveLength(1)
@@ -114,11 +109,7 @@ test('an open /mount popup refreshes when the /import window writes', async ({
 
   const importResult = new ImportResultDialog(importTab)
   await importResult.confirm()
-  await expect(
-    importTab.locator('[role="alert"]').filter({
-      hasText: /Successfully imported|成功导入/,
-    })
-  ).toBeVisible()
+  await importResult.expectSuccess()
 
   const customs = await da.episode.listCustom()
   expect(customs).toHaveLength(1)

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
@@ -44,12 +44,7 @@ test('mount toolbar: import from URL fetches a mocked xml and stages a custom ep
 
   await popup.urlImport.expectHidden()
   await popup.importResult.confirm()
-
-  await expect(
-    page.locator('[role="alert"]').filter({
-      hasText: /Successfully imported|成功导入/,
-    })
-  ).toBeVisible()
+  await popup.importResult.expectSuccess()
 
   const customs = await da.episode.listCustom()
   expect(customs).toHaveLength(1)

--- a/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
@@ -106,11 +106,12 @@ test('mount tree: bookmark-driven preload caches the next episode', async ({
   )
   const nextEpisodeId = episodeIds.find((id) => id !== episode.id) as number
 
-  await expect(popup.mount.episodeCommentCount(nextEpisodeId)).not.toHaveText(
-    '0'
-  )
-
   await expect
     .poll(async () => (await da.episode.get(nextEpisodeId))?.commentCount)
     .toBeGreaterThan(0)
+
+  const preloaded = await da.episode.get(nextEpisodeId)
+  await expect(popup.mount.episodeCommentCount(nextEpisodeId)).toHaveText(
+    String(preloaded?.commentCount)
+  )
 })

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
@@ -75,9 +75,12 @@ test('mount tree: refresh danmaku fetches new comments for an episode', async ({
 
   await popup.mount.openItemMenu(episodeItem, 'refresh')
 
-  await expect(popup.mount.episodeCommentCount(episode.id)).not.toHaveText('0')
-
   await expect
     .poll(async () => (await da.episode.get(episode.id))?.commentCount)
     .toBeGreaterThan(0)
+
+  const refreshed = await da.episode.get(episode.id)
+  await expect(popup.mount.episodeCommentCount(episode.id)).toHaveText(
+    String(refreshed?.commentCount)
+  )
 })

--- a/packages/danmaku-anywhere/vite.config.ts
+++ b/packages/danmaku-anywhere/vite.config.ts
@@ -30,6 +30,22 @@ console.log('Building for', {
   gitBranch,
 })
 
+// E2E builds run without a developer .env (CI and fresh checkouts), but the DNR
+// rule that stamps the proxy Origin header rejects undefined values. Inject
+// placeholder hosts that Playwright routes intercept; an exported env var (not a
+// .env file, which this define overrides) still points an e2e build at a backend.
+const e2eProxyDefines =
+  daEnv === 'e2e'
+    ? {
+        'import.meta.env.VITE_PROXY_URL': JSON.stringify(
+          process.env.VITE_PROXY_URL || 'https://api.danmaku.test'
+        ),
+        'import.meta.env.VITE_PROXY_ORIGIN': JSON.stringify(
+          process.env.VITE_PROXY_ORIGIN || 'https://danmaku.test'
+        ),
+      }
+    : {}
+
 export default defineConfig({
   // @ts-ignore
   plugins: [
@@ -83,6 +99,7 @@ export default defineConfig({
     'import.meta.env.VITE_DA_BRANCH': JSON.stringify(
       daEnv === 'prod' ? '' : gitBranch
     ),
+    ...e2eProxyDefines,
   },
   build: {
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- **migration-smoke render gate:** replaced the swallowed `waitForFunction(...).catch(() => undefined)` with a real `expect(page.locator('[role="treeitem"]').first()).toBeVisible()`, so a post-migration render error fails the test instead of passing silently. Verified on both the legacy seeded probe and the post-swap probe.
- **UI-anchored `install.spec.ts`:** it asserted only `da.*` state; now also opens the popup providers list and asserts the three seeded providers render under their localized names.
- **Sanctioned `occlusion-cache-scope.spec.ts`:** documented in its header as a browser-capability probe (OPFS scope has no DOM signal), per `e2e/AGENTS.md`.
- **Mount assertion hardening:** the copy-pasted raw `[role="alert"]` import-success assertion in `import-detach` / `import-from-url` now uses the existing `ImportResultDialog.expectSuccess()` (testid-scoped, locale-proof); the loose `not.toHaveText('0')` comment-count checks in `preload-next` / `refresh-danmaku` now pin the UI count to the exact stored `commentCount`.
- **E2E proxy env defaults at build time:** a fresh clone with no `.env` produced a broken e2e build (no DNR proxy rule + degraded catalog seed). Inject placeholder `VITE_PROXY_URL`/`VITE_PROXY_ORIGIN` in `vite.config.ts` gated on the e2e env, and drop the CI step that wrote a synthetic `.env`. An exported env var still wins.

## Test plan
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` (full suite; CI runs this)
- Ran locally and passing: the 3 doctrine specs (install, occlusion-cache-scope, migration-smoke), the 4 mount specs (import-detach, import-from-url, preload-next, refresh-danmaku), and the proxy/DDP/auth-sensitive source specs (dandanplay, dandanplay-custom, dandanplay-local-origin, login-probe, catalog-import).
- Verified the e2e build inlines the placeholder proxy host and a developer `.env.local` staging host does not leak into the e2e build.

## Notes
- The proxy env-defaults change makes local and CI e2e builds reproducible from a clean clone; it deterministically uses placeholder hosts for e2e (the mocks are path-based, so the host value is irrelevant to the tests).
- Scope grew from the original two doctrine fixes to fold in the highest-value bounded audit follow-ups. The `da`/`seed` fixture refactor (touches ~37 specs) and feature-coverage gaps remain tracked separately.