### PR TITLE
(extension) popup app bar open-in-new window/tab dropdown [DA-629]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/AppBarPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/AppBarPage.ts
@@ -1,0 +1,25 @@
+import type { Locator, Page } from '@playwright/test'
+
+export class AppBarPage {
+  constructor(private readonly page: Page) {}
+
+  // The mount tab has its own drilldown toolbar, so scope to the app bar banner
+  // to keep this button unambiguous.
+  private openInNewButton(): Locator {
+    return this.page
+      .getByRole('banner')
+      .locator('[data-testid="drilldown-menu-button"]')
+  }
+
+  async openOpenInNewMenu(): Promise<void> {
+    await this.openInNewButton().click()
+  }
+
+  openInNewWindowItem(): Locator {
+    return this.page.getByTestId('drilldown-menu-item-open-in-window')
+  }
+
+  openInNewTabItem(): Locator {
+    return this.page.getByTestId('drilldown-menu-item-open-in-tab')
+  }
+}

--- a/packages/danmaku-anywhere/e2e/pom/AppBarPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/AppBarPage.ts
@@ -3,12 +3,8 @@ import type { Locator, Page } from '@playwright/test'
 export class AppBarPage {
   constructor(private readonly page: Page) {}
 
-  // The mount tab has its own drilldown toolbar, so scope to the app bar banner
-  // to keep this button unambiguous.
   private openInNewButton(): Locator {
-    return this.page
-      .getByRole('banner')
-      .locator('[data-testid="drilldown-menu-button"]')
+    return this.page.getByTestId('open-in-new-button')
   }
 
   async openOpenInNewMenu(): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test'
+import { AppBarPage } from './AppBarPage'
 import { BackupPage } from './BackupPage'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ImportResultDialog } from './ImportResultDialog'
@@ -11,6 +12,7 @@ import { Toast } from './Toast'
 import { UrlImportDialog } from './UrlImportDialog'
 
 export class Popup {
+  readonly appBar: AppBarPage
   readonly mount: MountPage
   readonly search: SearchPage
   readonly seasonDetails: SeasonDetailsPage
@@ -23,6 +25,7 @@ export class Popup {
   readonly importResult: ImportResultDialog
 
   private constructor(page: Page) {
+    this.appBar = new AppBarPage(page)
     this.mount = new MountPage(page)
     this.search = new SearchPage(page)
     this.seasonDetails = new SeasonDetailsPage(page)

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/openInNew.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/openInNew.spec.ts
@@ -10,8 +10,9 @@ import { expect, test } from '../../setup/fixtures'
  * choice adds a window.
  */
 
-function getWindowCount(context: BrowserContext): Promise<number> {
-  const [worker] = context.serviceWorkers()
+async function getWindowCount(context: BrowserContext): Promise<number> {
+  const [sw] = context.serviceWorkers()
+  const worker = sw ?? (await context.waitForEvent('serviceworker'))
   return worker.evaluate(() => chrome.windows.getAll().then((w) => w.length))
 }
 

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/openInNew.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/openInNew.spec.ts
@@ -1,0 +1,55 @@
+import type { BrowserContext } from '@playwright/test'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+
+/**
+ * Verifies the app bar "open in new" dropdown. The menu offers two choices,
+ * "open in new window" spawns a popup-type browser window, and "open in new
+ * tab" spawns a tab in the existing window. Both load the detached popup page.
+ * The browser window count discriminates the two actions: only the window
+ * choice adds a window.
+ */
+
+function getWindowCount(context: BrowserContext): Promise<number> {
+  const [worker] = context.serviceWorkers()
+  return worker.evaluate(() => chrome.windows.getAll().then((w) => w.length))
+}
+
+test('open in new window spawns a detached popup window', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const popup = await Popup.open(page, extensionId, '/mount')
+
+  await popup.appBar.openOpenInNewMenu()
+  await expect(popup.appBar.openInNewWindowItem()).toBeVisible()
+  await expect(popup.appBar.openInNewTabItem()).toBeVisible()
+
+  const windowsBefore = await getWindowCount(context)
+  const detachedPagePromise = context.waitForEvent('page')
+  await popup.appBar.openInNewWindowItem().click()
+
+  const detached = await detachedPagePromise
+  await expect(detached).toHaveURL(/pages\/popup\.html\?detached=1/)
+  await expect.poll(() => getWindowCount(context)).toBe(windowsBefore + 1)
+})
+
+test('open in new tab spawns a detached tab without a new window', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const popup = await Popup.open(page, extensionId, '/mount')
+
+  await popup.appBar.openOpenInNewMenu()
+  const windowsBefore = await getWindowCount(context)
+  const pagesBefore = context.pages().length
+  const detachedPagePromise = context.waitForEvent('page')
+  await popup.appBar.openInNewTabItem().click()
+
+  const detached = await detachedPagePromise
+  await expect(detached).toHaveURL(/pages\/popup\.html\?detached=1/)
+  expect(context.pages().length).toBe(pagesBefore + 1)
+  await expect.poll(() => getWindowCount(context)).toBe(windowsBefore)
+})

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -339,6 +339,11 @@ export class RpcManager {
             height: height ?? 650,
           })
         },
+        openPopupInNewTab: async ({ path }) => {
+          void chrome.tabs.create({
+            url: chrome.runtime.getURL(`pages/popup.html?detached=1#/${path}`),
+          })
+        },
         getConfigMacCms: async (input) => {
           const res = await getMaccmsConfig(input?.force)
           if (!res.success) {

--- a/packages/danmaku-anywhere/src/common/components/Menu/DrilldownMenu.tsx
+++ b/packages/danmaku-anywhere/src/common/components/Menu/DrilldownMenu.tsx
@@ -19,6 +19,7 @@ import { DrilldownMenuList } from './DrilldownMenuList'
 
 type DrilldownMenuProps = PropsWithChildren & {
   icon?: ReactNode
+  buttonTestId?: string
   ButtonProps?: IconButtonProps
   BoxProps?: BoxProps
   MenuProps?: Partial<MenuProps>
@@ -37,6 +38,7 @@ export const DrilldownMenu = ({
   MenuProps,
   items,
   icon,
+  buttonTestId = 'drilldown-menu-button',
   dense = false,
   renderButton: renderButtonProp,
 }: DrilldownMenuProps): ReactElement => {
@@ -62,7 +64,7 @@ export const DrilldownMenu = ({
       <IconButton
         id={buttonId}
         onClick={handleClick}
-        data-testid="drilldown-menu-button"
+        data-testid={buttonTestId}
         {...ButtonProps}
       >
         {icon ?? <MoreVert fontSize={ButtonProps?.size} />}

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -94,6 +94,8 @@
     "multiselect": "Multiselect",
     "name": "Name",
     "next": "Next",
+    "openInNewTab": "Open in new tab",
+    "openInNewWindow": "Open in new window",
     "pip": "Picture-in-Picture",
     "refresh": "Refresh",
     "regexShort": "Regex",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -93,6 +93,8 @@
     "multiselect": "多选",
     "name": "名称",
     "next": "下一步",
+    "openInNewTab": "在新标签页中打开",
+    "openInNewWindow": "在新窗口中打开",
     "pip": "画中画",
     "refresh": "刷新",
     "regexShort": "正则",

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -208,6 +208,7 @@ export type BackgroundMethods = {
     { path: string; width?: number; height?: number },
     void
   >
+  openPopupInNewTab: RPCDef<{ path: string }, void>
   getConfigMacCms: RPCDef<{ force?: boolean } | void, BaseUrlConfig>
   getConfigDanmuIcu: RPCDef<{ force?: boolean } | void, BaseUrlConfig>
   providerConfigDelete: RPCDef<string, void>

--- a/packages/danmaku-anywhere/src/common/standalone/standaloneHandlers.ts
+++ b/packages/danmaku-anywhere/src/common/standalone/standaloneHandlers.ts
@@ -134,6 +134,7 @@ export const standaloneBackgroundHandlers: StandaloneRpcHandlers<BackgroundMetho
       }
     },
     openPopupInNewWindow: () => undefined,
+    openPopupInNewTab: () => undefined,
     getConfigMacCms: () => standaloneBaseUrlConfig,
     getConfigDanmuIcu: () => standaloneBaseUrlConfig,
     providerConfigDelete: () => undefined,

--- a/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
@@ -1,4 +1,4 @@
-import { OpenInNew, Settings } from '@mui/icons-material'
+import { OpenInNew, Settings, Tab } from '@mui/icons-material'
 import {
   AppBar,
   Box,
@@ -11,6 +11,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 
+import { DrilldownMenu } from '@/common/components/Menu/DrilldownMenu'
 import { useAnyLoading } from '@/common/hooks/useAnyLoading'
 import { usePlatformInfo } from '@/common/hooks/usePlatformInfo'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
@@ -25,8 +26,12 @@ export const AppToolBar = () => {
 
   const { t } = useTranslation()
 
-  const openInWindow = async () => {
+  const openInWindow = () => {
     void chromeRpcClient.openPopupInNewWindow({ path: '' })
+  }
+
+  const openInTab = () => {
+    void chromeRpcClient.openPopupInNewTab({ path: '' })
   }
 
   return (
@@ -61,15 +66,24 @@ export const AppToolBar = () => {
           <Settings />
         </IconButton>
         {!isMobile && (
-          <IconButton
-            onClick={openInWindow}
-            edge="end"
-            sx={{
-              color: 'inherit',
-            }}
-          >
-            <OpenInNew />
-          </IconButton>
+          <DrilldownMenu
+            icon={<OpenInNew />}
+            ButtonProps={{ edge: 'end', sx: { color: 'inherit' } }}
+            items={[
+              {
+                id: 'open-in-window',
+                label: t('common.openInNewWindow', 'Open in new window'),
+                icon: <OpenInNew />,
+                onClick: openInWindow,
+              },
+              {
+                id: 'open-in-tab',
+                label: t('common.openInNewTab', 'Open in new tab'),
+                icon: <Tab />,
+                onClick: openInTab,
+              },
+            ]}
+          />
         )}
       </Toolbar>
     </AppBar>

--- a/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
@@ -68,6 +68,7 @@ export const AppToolBar = () => {
         {!isMobile && (
           <DrilldownMenu
             icon={<OpenInNew />}
+            buttonTestId="open-in-new-button"
             ButtonProps={{ edge: 'end', sx: { color: 'inherit' } }}
             items={[
               {


### PR DESCRIPTION
## Summary
- Replace the popup app bar's single "open in new" IconButton with a `DrilldownMenu` offering "open in new window" (existing behavior) and a new "open in new tab" choice.
- Add an `openPopupInNewTab` RPC (`chrome.tabs.create`) mirroring `openPopupInNewWindow`; both load the detached popup page. Standalone runtime gets the matching no-op stub.

## Test plan
- Verified: lint (tsc + biome) pass · tests: e2e only (additive UI + RPC, contract enforced by tsc) · e2e `specs/lifecycle/openInNew.spec.ts` 2 passed
- [ ] `cd packages/danmaku-anywhere && pnpm test:e2e specs/lifecycle/openInNew.spec.ts`
- browser-verify: dropdown shows both items; "open in new tab" opens a detached tab (window count unchanged), "open in new window" opens a popup-type window (window count +1); no console errors.

## Notes
- The new-tab URL reuses `?detached=1`, same as the window path: both want the viewport-filling layout and want to skip popup route persistence so they don't clobber the main popup's stored route.