### PR TITLE
(extension) force-refresh manifest catalog bypasses backend edge cache [DA-628]

### DIFF
--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -88,3 +88,31 @@ export function mockCatalog(
     },
   }
 }
+
+export interface CatalogRequest {
+  isFile: boolean
+  cacheControl: string
+}
+
+// Wraps mockCatalog, recording each request's path kind and Cache-Control so a
+// spec can assert the force-refresh path sends no-cache to the backend.
+export function recordingCatalog(
+  ids: readonly string[],
+  versionOverrides: Record<string, string>,
+  sink: CatalogRequest[]
+): NetworkMock {
+  const base = mockCatalog(ids, versionOverrides)
+  return {
+    pattern: base.pattern,
+    respond: async (route: Route) => {
+      const headers = await route.request().allHeaders()
+      sink.push({
+        isFile: new URL(route.request().url()).pathname.endsWith(
+          '/manifest/file'
+        ),
+        cacheControl: headers['cache-control'] ?? '',
+      })
+      await base.respond(route)
+    },
+  }
+}

--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -103,3 +103,31 @@ export function offlineCatalog(): NetworkMock {
     },
   }
 }
+
+export interface CatalogRequest {
+  isFile: boolean
+  cacheControl: string
+}
+
+// Wraps mockCatalog, recording each request's path kind and Cache-Control so a
+// spec can assert the force-refresh path sends no-cache to the backend.
+export function recordingCatalog(
+  ids: readonly string[],
+  versionOverrides: Record<string, string>,
+  sink: CatalogRequest[]
+): NetworkMock {
+  const base = mockCatalog(ids, versionOverrides)
+  return {
+    pattern: base.pattern,
+    respond: async (route: Route) => {
+      const headers = await route.request().allHeaders()
+      sink.push({
+        isFile: new URL(route.request().url()).pathname.endsWith(
+          '/manifest/file'
+        ),
+        cacheControl: headers['cache-control'] ?? '',
+      })
+      await base.respond(route)
+    },
+  }
+}

--- a/packages/danmaku-anywhere/e2e/specs/sources/catalog-refresh.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/catalog-refresh.spec.ts
@@ -1,38 +1,24 @@
-import type { Route } from '@playwright/test'
-import { manifestStoreSeed, mockCatalog } from '../../network/catalog'
+import {
+  type CatalogRequest,
+  manifestStoreSeed,
+  manifestVersion,
+  recordingCatalog,
+} from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
 import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
-import type { NetworkMock } from '../../setup/profile'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * A user-initiated catalog Refresh must bypass the backend edge cache. Drives
- * the Refresh button and asserts the user-visible signal (the bumped catalog
- * version appears), then asserts the catalog index request carried
- * Cache-Control: no-cache so the backend refetches instead of serving stale.
+ * User-initiated catalog actions must bypass the backend edge cache. Refresh
+ * and Apply both drive their button, assert the user-visible signal (the bumped
+ * version appears / the update row clears), and assert the catalog requests
+ * they triggered carried Cache-Control: no-cache so the backend refetches the
+ * latest manifests instead of serving up to an hour of stale edge cache.
  */
 
 const BUMPED = '9.9.9'
-
-function recordingCatalog(
-  ids: readonly string[],
-  versionOverrides: Record<string, string>,
-  indexCacheControls: string[]
-): NetworkMock {
-  const base = mockCatalog(ids, versionOverrides)
-  return {
-    pattern: base.pattern,
-    respond: async (route: Route) => {
-      const url = new URL(route.request().url())
-      if (!url.pathname.endsWith('/manifest/file')) {
-        const headers = await route.request().allHeaders()
-        indexCacheControls.push(headers['cache-control'] ?? '')
-      }
-      await base.respond(route)
-    },
-  }
-}
+const BUILT_IN_IDS = ['dandanplay', 'bilibili', 'tencent']
 
 test('refresh: a user refresh forces a no-cache catalog fetch', async ({
   context,
@@ -41,14 +27,14 @@ test('refresh: a user refresh forces a no-cache catalog fetch', async ({
 }) => {
   const da = await getDaClient(context)
   const ids = ['dandanplay', 'bilibili', 'tencent', 'iqiyi']
-  const indexCacheControls: string[] = []
+  const requests: CatalogRequest[] = []
 
   await applyProfile(context, da, {
     providers: {},
     rawStorage: [
       { area: 'local', key: 'manifests', value: manifestStoreSeed({}, ids) },
     ],
-    network: [recordingCatalog(ids, { iqiyi: BUMPED }, indexCacheControls)],
+    network: [recordingCatalog(ids, { iqiyi: BUMPED }, requests)],
   })
 
   const popup = await Popup.open(page, extensionId, '/providers')
@@ -60,5 +46,42 @@ test('refresh: a user refresh forces a no-cache catalog fetch', async ({
     `v${BUMPED}`
   )
 
-  expect(indexCacheControls).toContain('no-cache')
+  // Only the user refresh forces no-cache (background syncs stay cached), so
+  // the forced requests isolate the refresh regardless of any boot sync. The
+  // index is fetched once and shared, not once per sync step.
+  const forced = requests.filter((r) => r.cacheControl === 'no-cache')
+  expect(forced.filter((r) => !r.isFile)).toHaveLength(1)
+  expect(forced.some((r) => r.isFile)).toBe(true)
+})
+
+test('apply: updating an installed source forces a no-cache fetch', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  const current = manifestVersion('bilibili')
+  const requests: CatalogRequest[] = []
+
+  await applyProfile(context, da, {
+    providers: { bilibili: {} },
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed() },
+    ],
+    network: [recordingCatalog(BUILT_IN_IDS, { bilibili: BUMPED }, requests)],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeVisible()
+
+  await popup.providers.update()
+
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeHidden()
+
+  // The applied manifest file must come from a forced fetch, not the edge cache.
+  const forcedFiles = requests.filter(
+    (r) => r.isFile && r.cacheControl === 'no-cache'
+  )
+  expect(forcedFiles.length).toBeGreaterThan(0)
 })

--- a/packages/danmaku-anywhere/e2e/specs/sources/catalog-refresh.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/catalog-refresh.spec.ts
@@ -1,0 +1,64 @@
+import type { Route } from '@playwright/test'
+import { manifestStoreSeed, mockCatalog } from '../../network/catalog'
+import { Popup } from '../../pom/Popup'
+import { getDaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import type { NetworkMock } from '../../setup/profile'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * A user-initiated catalog Refresh must bypass the backend edge cache. Drives
+ * the Refresh button and asserts the user-visible signal (the bumped catalog
+ * version appears), then asserts the catalog index request carried
+ * Cache-Control: no-cache so the backend refetches instead of serving stale.
+ */
+
+const BUMPED = '9.9.9'
+
+function recordingCatalog(
+  ids: readonly string[],
+  versionOverrides: Record<string, string>,
+  indexCacheControls: string[]
+): NetworkMock {
+  const base = mockCatalog(ids, versionOverrides)
+  return {
+    pattern: base.pattern,
+    respond: async (route: Route) => {
+      const url = new URL(route.request().url())
+      if (!url.pathname.endsWith('/manifest/file')) {
+        const headers = await route.request().allHeaders()
+        indexCacheControls.push(headers['cache-control'] ?? '')
+      }
+      await base.respond(route)
+    },
+  }
+}
+
+test('refresh: a user refresh forces a no-cache catalog fetch', async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const da = await getDaClient(context)
+  const ids = ['dandanplay', 'bilibili', 'tencent', 'iqiyi']
+  const indexCacheControls: string[] = []
+
+  await applyProfile(context, da, {
+    providers: {},
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed({}, ids) },
+    ],
+    network: [recordingCatalog(ids, { iqiyi: BUMPED }, indexCacheControls)],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  const iqiyiName = /iQIYI|爱奇艺/
+
+  await popup.providers.refreshCatalog()
+
+  await expect(popup.providers.catalogRow(iqiyiName)).toContainText(
+    `v${BUMPED}`
+  )
+
+  expect(indexCacheControls).toContain('no-cache')
+})

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -137,7 +137,9 @@ export class RpcManager {
           return this.manifestRegistry.getPendingUpdates()
         },
         providerApplyUpdates: async ({ manifestIds }) => {
-          await this.manifestRegistry.applyUpdates(manifestIds)
+          // User-initiated, so force a no-cache fetch: the new manifest file
+          // must not come from the backend's stale edge cache.
+          await this.manifestRegistry.applyUpdates(manifestIds, undefined, true)
         },
         bilibiliSetCookies: async () => {
           // Credentialed homepage GET lets bilibili's Set-Cookie response

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -138,7 +138,9 @@ export class RpcManager {
           return this.manifestRegistry.getPendingUpdates()
         },
         providerApplyUpdates: async ({ manifestIds }) => {
-          await this.manifestRegistry.applyUpdates(manifestIds)
+          // User-initiated, so force a no-cache fetch: the new manifest file
+          // must not come from the backend's stale edge cache.
+          await this.manifestRegistry.applyUpdates(manifestIds, undefined, true)
         },
         providerValidateManifest: async ({ manifest }) => {
           return this.manifestSandbox.validate(manifest)

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -15,7 +15,8 @@ import type {
  * fetching files or applying; applyUpdates replaces only the named preinstalled
  * ids, never a user import or an unseeded id), skipping a bad/failed file,
  * index failures, that neither update() nor getPendingUpdates stamps
- * lastCheckedAt (only recordChecked does), and
+ * lastCheckedAt (only recordChecked does), forcing a no-cache fetch, reusing a
+ * passed-in index instead of refetching, and
  * register / unregister / hydrate-skip-invalid.
  */
 
@@ -71,7 +72,7 @@ function makeResponse(status: number, body: unknown) {
 function stubFetch(
   respond: (url: string) => { status: number; body: unknown }
 ) {
-  const fetchMock = vi.fn(async (input: unknown) => {
+  const fetchMock = vi.fn(async (input: unknown, _init?: unknown) => {
     const { status, body } = respond(String(input))
     return makeResponse(status, body)
   })
@@ -87,6 +88,20 @@ function fileFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
   return fetchMock.mock.calls
     .map(([url]) => String(url))
     .filter((url) => url.includes('/manifest/file'))
+}
+
+function indexFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
+  return fetchMock.mock.calls
+    .map(([url]) => String(url))
+    .filter(
+      (url) => url.includes('/manifest') && !url.includes('/manifest/file')
+    )
+}
+
+function cacheControl(init: unknown): string | undefined {
+  const headers = (init as { headers?: Record<string, string> } | undefined)
+    ?.headers
+  return headers?.['Cache-Control']
 }
 
 function stubCatalogFetch(
@@ -596,6 +611,82 @@ describe('ManifestRegistry', () => {
 
     expect(await store.has('test:one')).toBe(false)
     expect(() => registry.getRunner('test:one')).toThrow()
+  })
+
+  it('update forwards Cache-Control: no-cache to the index and file fetches when forced', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+    await registry.update(undefined, true)
+
+    expect(fetchMock).toHaveBeenCalled()
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(cacheControl(init)).toBe('no-cache')
+    }
+  })
+
+  it('update sends no cache header by default', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+    await registry.update()
+
+    expect(fetchMock).toHaveBeenCalled()
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(cacheControl(init)).toBeUndefined()
+    }
+  })
+
+  it('update reuses a passed-in index instead of fetching it', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+    await registry.update([catalogEntry('one')], true)
+
+    expect(indexFetches(fetchMock)).toEqual([])
+    expect(fileFetches(fetchMock)).toHaveLength(1)
+    expect(cacheControl(fetchMock.mock.calls[0][1])).toBe('no-cache')
+  })
+
+  it('getPendingUpdates reuses a passed-in index without any fetch', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {})
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    const pending = await registry.getPendingUpdates([
+      catalogEntry('one', '2.0.0'),
+    ])
+
+    expect(pending).toEqual([
+      { manifestId: 'one', fromVersion: '1.0.0', toVersion: '2.0.0' },
+    ])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('applyUpdates reuses a passed-in index and forces the file fetch', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {
+      [manifestPath('one')]: makeManifest('one', 1, '2.0.0'),
+    })
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    await registry.applyUpdates(['one'], [catalogEntry('one', '2.0.0')], true)
+
+    expect(indexFetches(fetchMock)).toEqual([])
+    expect(fileFetches(fetchMock)).toHaveLength(1)
+    expect(cacheControl(fetchMock.mock.calls[0][1])).toBe('no-cache')
+    expect((await store.get('one'))?.manifest).toMatchObject({
+      version: '2.0.0',
+    })
   })
 
   it('skips a manifest that fails safeParse without taking the registry down', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -17,8 +17,9 @@ import type {
  * ids, never a user import or an unseeded id), skipping a bad/failed file,
  * index failures (one retry after a delay, then give up), the offline bundle
  * fallback seeding built-ins only when the index is unreachable, that neither
- * update() nor getPendingUpdates stamps
- * lastCheckedAt (only recordChecked does), and
+ * update() nor getPendingUpdates stamps lastCheckedAt (only recordChecked
+ * does), forcing a no-cache fetch, reusing a passed-in index instead of
+ * refetching, and
  * register / unregister / hydrate-skip-invalid.
  */
 
@@ -75,7 +76,7 @@ function makeResponse(status: number, body: unknown) {
 function stubFetch(
   respond: (url: string) => { status: number; body: unknown }
 ) {
-  const fetchMock = vi.fn(async (input: unknown) => {
+  const fetchMock = vi.fn(async (input: unknown, _init?: unknown) => {
     const { status, body } = respond(String(input))
     return makeResponse(status, body)
   })
@@ -91,6 +92,20 @@ function fileFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
   return fetchMock.mock.calls
     .map(([url]) => String(url))
     .filter((url) => url.includes('/manifest/file'))
+}
+
+function indexFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
+  return fetchMock.mock.calls
+    .map(([url]) => String(url))
+    .filter(
+      (url) => url.includes('/manifest') && !url.includes('/manifest/file')
+    )
+}
+
+function cacheControl(init: unknown): string | undefined {
+  const headers = (init as { headers?: Record<string, string> } | undefined)
+    ?.headers
+  return headers?.['Cache-Control']
 }
 
 function stubCatalogFetch(
@@ -788,6 +803,82 @@ describe('ManifestRegistry', () => {
 
     expect(await store.has('test:one')).toBe(false)
     expect(() => registry.getRunner('test:one')).toThrow()
+  })
+
+  it('update forwards Cache-Control: no-cache to the index and file fetches when forced', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+    await registry.update(undefined, true)
+
+    expect(fetchMock).toHaveBeenCalled()
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(cacheControl(init)).toBe('no-cache')
+    }
+  })
+
+  it('update sends no cache header by default', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+    await registry.update()
+
+    expect(fetchMock).toHaveBeenCalled()
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(cacheControl(init)).toBeUndefined()
+    }
+  })
+
+  it('update reuses a passed-in index instead of fetching it', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+    await registry.update([catalogEntry('one')], true)
+
+    expect(indexFetches(fetchMock)).toEqual([])
+    expect(fileFetches(fetchMock)).toHaveLength(1)
+    expect(cacheControl(fetchMock.mock.calls[0][1])).toBe('no-cache')
+  })
+
+  it('getPendingUpdates reuses a passed-in index without any fetch', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {})
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    const pending = await registry.getPendingUpdates([
+      catalogEntry('one', '2.0.0'),
+    ])
+
+    expect(pending).toEqual([
+      { manifestId: 'one', fromVersion: '1.0.0', toVersion: '2.0.0' },
+    ])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('applyUpdates reuses a passed-in index and forces the file fetch', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {
+      [manifestPath('one')]: makeManifest('one', 1, '2.0.0'),
+    })
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    await registry.applyUpdates(['one'], [catalogEntry('one', '2.0.0')], true)
+
+    expect(indexFetches(fetchMock)).toEqual([])
+    expect(fileFetches(fetchMock)).toHaveLength(1)
+    expect(cacheControl(fetchMock.mock.calls[0][1])).toBe('no-cache')
+    expect((await store.get('one'))?.manifest).toMatchObject({
+      version: '2.0.0',
+    })
   })
 
   it('skips a manifest that fails safeParse without taking the registry down', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -32,7 +32,7 @@ const zCatalogIndex = z.object({
   manifests: z.array(zCatalogEntry),
 })
 
-type CatalogEntry = z.infer<typeof zCatalogEntry>
+export type CatalogEntry = z.infer<typeof zCatalogEntry>
 type CatalogManifest = { raw: unknown; parsed: Manifest }
 
 function storedVersion(manifest: unknown): unknown {
@@ -127,32 +127,41 @@ export class ManifestRegistry {
     }
   }
 
+  // Fetch the catalog index once so a single sync can share it across update,
+  // getPendingUpdates, and applyUpdates instead of refetching three times. force
+  // sends Cache-Control: no-cache so the backend skips its edge cache.
+  async loadCatalog(force = false): Promise<CatalogEntry[] | null> {
+    await this.ready
+    return this.loadIndex(force)
+  }
+
   // Add-only: seeds only manifests absent from the store; a changed preinstalled
   // manifest surfaces via getPendingUpdates instead of being replaced here.
-  // Returns false when the catalog index could not be fetched.
-  async update(): Promise<boolean> {
+  // Returns false when the catalog index could not be fetched. Pass a
+  // pre-fetched index to reuse one sync's fetch; force flows to the file fetches.
+  async update(entries?: CatalogEntry[], force = false): Promise<boolean> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = entries ?? (await this.loadIndex(force))
+    if (!catalog) {
       return false
     }
     const stored = await this.store.getAll()
-    const missing = entries.filter((entry) => !stored[entry.id])
-    await this.fetchAndStore(missing)
+    const missing = catalog.filter((entry) => !stored[entry.id])
+    await this.fetchAndStore(missing, force)
     return true
   }
 
   // Index-only: diff stored versions against the catalog without fetching files
   // or applying.
-  async getPendingUpdates(): Promise<ManifestUpdate[]> {
+  async getPendingUpdates(entries?: CatalogEntry[]): Promise<ManifestUpdate[]> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = entries ?? (await this.loadIndex())
+    if (!catalog) {
       return []
     }
     const stored = await this.store.getAll()
     const updates: ManifestUpdate[] = []
-    for (const entry of entries) {
+    for (const entry of catalog) {
       const existing = stored[entry.id]
       if (!existing || existing.kind === 'user') {
         continue
@@ -174,19 +183,23 @@ export class ManifestRegistry {
   // can never clobber a user manifest or install a brand-new source. Throws on
   // failure (unreachable catalog or a file that did not apply) so a user-driven
   // update surfaces the error instead of silently no-op'ing.
-  async applyUpdates(manifestIds: string[]): Promise<void> {
+  async applyUpdates(
+    manifestIds: string[],
+    entries?: CatalogEntry[],
+    force = false
+  ): Promise<void> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = entries ?? (await this.loadIndex(force))
+    if (!catalog) {
       throw new Error('Failed to fetch the manifest catalog')
     }
     const wanted = new Set(manifestIds)
     const stored = await this.store.getAll()
-    const targets = entries.filter((entry) => {
+    const targets = catalog.filter((entry) => {
       const existing = stored[entry.id]
       return wanted.has(entry.id) && existing?.kind === 'preinstalled'
     })
-    const applied = await this.fetchAndStore(targets)
+    const applied = await this.fetchAndStore(targets, force)
     if (applied.length < targets.length) {
       const failed = targets
         .map((entry) => entry.id)
@@ -205,10 +218,13 @@ export class ManifestRegistry {
 
   // Returns the ids actually stored; the caller can compare against what it
   // asked for to tell a partial failure from a complete one.
-  private async fetchAndStore(entries: CatalogEntry[]): Promise<string[]> {
+  private async fetchAndStore(
+    entries: CatalogEntry[],
+    force = false
+  ): Promise<string[]> {
     const fetched = (
       await Promise.all(
-        entries.map((entry) => this.fetchManifest(entry.file, entry.id))
+        entries.map((entry) => this.fetchManifest(entry.file, entry.id, force))
       )
     ).filter((manifest) => manifest !== null)
     if (fetched.length === 0) {
@@ -225,18 +241,18 @@ export class ManifestRegistry {
     return fetched.map(({ parsed }) => parsed.id)
   }
 
-  private async loadIndex(): Promise<CatalogEntry[] | null> {
+  private async loadIndex(force = false): Promise<CatalogEntry[] | null> {
     try {
-      return await this.fetchIndex()
+      return await this.fetchIndex(force)
     } catch (e) {
       this.log.error('Failed to fetch manifest catalog:', e)
       return null
     }
   }
 
-  private async fetchIndex(): Promise<CatalogEntry[]> {
+  private async fetchIndex(force = false): Promise<CatalogEntry[]> {
     const index = zCatalogIndex.parse(
-      await this.fetchJson(`${this.baseUrl}/manifest`)
+      await this.fetchJson(`${this.baseUrl}/manifest`, force)
     )
     return index.manifests.filter((entry) =>
       SUPPORTED_API_VERSIONS.has(entry.apiVersion)
@@ -247,12 +263,14 @@ export class ManifestRegistry {
   // rest; the next reconcile retries whatever is still missing.
   private async fetchManifest(
     file: string,
-    id: string
+    id: string,
+    force = false
   ): Promise<CatalogManifest | null> {
     let raw: unknown
     try {
       raw = await this.fetchJson(
-        `${this.baseUrl}/manifest/file?file=${encodeURIComponent(file)}`
+        `${this.baseUrl}/manifest/file?file=${encodeURIComponent(file)}`,
+        force
       )
     } catch (e) {
       this.log.error('Failed to fetch catalog manifest:', id, e)
@@ -280,9 +298,10 @@ export class ManifestRegistry {
     return { raw, parsed: parsed.data }
   }
 
-  private async fetchJson(url: string): Promise<unknown> {
+  private async fetchJson(url: string, force = false): Promise<unknown> {
     const res = await extensionFetchLike(url, {
       signal: AbortSignal.timeout(5000),
+      headers: force ? { 'Cache-Control': 'no-cache' } : undefined,
     })
     if (res.status !== 200) {
       throw new Error(`catalog fetch failed (${res.status}): ${url}`)

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -33,7 +33,7 @@ const zCatalogIndex = z.object({
   manifests: z.array(zCatalogEntry),
 })
 
-type CatalogEntry = z.infer<typeof zCatalogEntry>
+export type CatalogEntry = z.infer<typeof zCatalogEntry>
 type CatalogManifest = { raw: unknown; parsed: Manifest }
 
 // Shared by every catalog-gated path; tests and the popup toast match on it.
@@ -160,6 +160,14 @@ export class ManifestRegistry {
     }
   }
 
+  // Fetch the catalog index once so a single sync can share it across update,
+  // getPendingUpdates, and applyUpdates instead of refetching three times. force
+  // sends Cache-Control: no-cache so the backend skips its edge cache.
+  async loadCatalog(force = false): Promise<CatalogEntry[] | null> {
+    await this.ready
+    return this.loadIndex(force)
+  }
+
   // Add-only for everything except a bundle-seeded entry: a changed
   // preinstalled manifest surfaces via getPendingUpdates instead of being
   // replaced here, but a 'bundled' entry auto-upgrades to the catalog copy
@@ -171,35 +179,43 @@ export class ManifestRegistry {
   // offline. The bundle can be stale, so the first successful sync replaces
   // any still-listed bundled entry outright rather than waiting for a manual
   // update, since the user never chose to install the bundled version.
-  async update(): Promise<boolean> {
+  //
+  // Pass a pre-fetched index to reuse one sync's fetch, or null when that
+  // fetch already failed; force flows to the file fetches.
+  async update(
+    entries?: CatalogEntry[] | null,
+    force = false
+  ): Promise<boolean> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = await this.resolveCatalog(entries, force)
+    if (!catalog) {
       await this.seedFromBundle()
       return false
     }
     const stored = await this.store.getAll()
-    const missing = entries.filter((entry) => !stored[entry.id])
-    const bundledStale = entries.filter(
+    const missing = catalog.filter((entry) => !stored[entry.id])
+    const bundledStale = catalog.filter(
       (entry) => stored[entry.id]?.kind === 'bundled'
     )
-    await this.fetchAndStore([...missing, ...bundledStale])
+    await this.fetchAndStore([...missing, ...bundledStale], force)
     return true
   }
 
   // Index-only: diff stored versions against the catalog without fetching files
   // or applying. Throws on an unreachable catalog: "no updates" and "could not
   // check" must stay distinguishable, or a failed check would clear the
-  // popup's pending list.
-  async getPendingUpdates(): Promise<ManifestUpdate[]> {
+  // popup's pending list. Pass a pre-fetched index to reuse one sync's fetch.
+  async getPendingUpdates(
+    entries?: CatalogEntry[] | null
+  ): Promise<ManifestUpdate[]> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = await this.resolveCatalog(entries, false)
+    if (!catalog) {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     const stored = await this.store.getAll()
     const updates: ManifestUpdate[] = []
-    for (const entry of entries) {
+    for (const entry of catalog) {
       const existing = stored[entry.id]
       // 'user' is never replaced by the catalog. 'bundled' auto-upgrades in
       // update() as soon as the index is reachable, so it must not also
@@ -229,22 +245,26 @@ export class ManifestRegistry {
   // source. Throws on failure (unreachable catalog or a file that did not
   // apply) so a user-driven update surfaces the error instead of silently
   // no-op'ing.
-  async applyUpdates(manifestIds: string[]): Promise<void> {
+  async applyUpdates(
+    manifestIds: string[],
+    entries?: CatalogEntry[] | null,
+    force = false
+  ): Promise<void> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = await this.resolveCatalog(entries, force)
+    if (!catalog) {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     const wanted = new Set(manifestIds)
     const stored = await this.store.getAll()
-    const targets = entries.filter((entry) => {
+    const targets = catalog.filter((entry) => {
       const existing = stored[entry.id]
       return (
         wanted.has(entry.id) &&
         (existing?.kind === 'preinstalled' || existing?.kind === 'bundled')
       )
     })
-    const applied = await this.fetchAndStore(targets)
+    const applied = await this.fetchAndStore(targets, force)
     if (applied.length < targets.length) {
       const failed = targets
         .map((entry) => entry.id)
@@ -309,10 +329,13 @@ export class ManifestRegistry {
 
   // Returns the ids actually stored; the caller can compare against what it
   // asked for to tell a partial failure from a complete one.
-  private async fetchAndStore(entries: CatalogEntry[]): Promise<string[]> {
+  private async fetchAndStore(
+    entries: CatalogEntry[],
+    force = false
+  ): Promise<string[]> {
     const fetched = (
       await Promise.all(
-        entries.map((entry) => this.fetchManifest(entry.file, entry.id))
+        entries.map((entry) => this.fetchManifest(entry.file, entry.id, force))
       )
     ).filter((manifest) => manifest !== null)
     if (fetched.length === 0) {
@@ -372,24 +395,36 @@ export class ManifestRegistry {
     }
   }
 
-  private async loadIndex(): Promise<CatalogEntry[] | null> {
+  // undefined means the caller has no index and this call should fetch one;
+  // null means a shared fetch already ran and failed, so do not refetch.
+  private async resolveCatalog(
+    entries: CatalogEntry[] | null | undefined,
+    force: boolean
+  ): Promise<CatalogEntry[] | null> {
+    if (entries === undefined) {
+      return this.loadIndex(force)
+    }
+    return entries
+  }
+
+  private async loadIndex(force = false): Promise<CatalogEntry[] | null> {
     try {
-      return await this.fetchIndex()
+      return await this.fetchIndex(force)
     } catch (e) {
       this.log.warn('Catalog index fetch failed, retrying:', e)
     }
     await sleep(1000)
     try {
-      return await this.fetchIndex()
+      return await this.fetchIndex(force)
     } catch (e) {
       this.log.error('Failed to fetch manifest catalog:', e)
       return null
     }
   }
 
-  private async fetchIndex(): Promise<CatalogEntry[]> {
+  private async fetchIndex(force = false): Promise<CatalogEntry[]> {
     const index = zCatalogIndex.parse(
-      await this.fetchJson(`${this.baseUrl}/manifest`)
+      await this.fetchJson(`${this.baseUrl}/manifest`, force)
     )
     return index.manifests.filter((entry) =>
       SUPPORTED_API_VERSIONS.has(entry.apiVersion)
@@ -400,12 +435,14 @@ export class ManifestRegistry {
   // rest; the next reconcile retries whatever is still missing.
   private async fetchManifest(
     file: string,
-    id: string
+    id: string,
+    force = false
   ): Promise<CatalogManifest | null> {
     let raw: unknown
     try {
       raw = await this.fetchJson(
-        `${this.baseUrl}/manifest/file?file=${encodeURIComponent(file)}`
+        `${this.baseUrl}/manifest/file?file=${encodeURIComponent(file)}`,
+        force
       )
     } catch (e) {
       this.log.error('Failed to fetch catalog manifest:', id, e)
@@ -433,9 +470,10 @@ export class ManifestRegistry {
     return { raw, parsed: parsed.data }
   }
 
-  private async fetchJson(url: string): Promise<unknown> {
+  private async fetchJson(url: string, force = false): Promise<unknown> {
     const res = await extensionFetchLike(url, {
       signal: AbortSignal.timeout(5000),
+      headers: force ? { 'Cache-Control': 'no-cache' } : undefined,
     })
     if (res.status !== 200) {
       throw new Error(`catalog fetch failed (${res.status}): ${url}`)

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -338,16 +338,24 @@ describe('ProviderService.refreshCatalog', () => {
     vi.clearAllMocks()
   })
 
+  const catalogEntries = [
+    { id: 'one', apiVersion: 1, version: '1.0.0', file: 'one.json' },
+  ]
+
   function buildForRefresh(opts: {
     pending: { manifestId: string; fromVersion: string; toVersion: string }[]
     installedManifestIds: string[]
   }) {
+    const loadCatalog = vi.fn(async () => catalogEntries)
+    const update = vi.fn(async () => true)
+    const getPendingUpdates = vi.fn(async () => opts.pending)
     const applyUpdates = vi.fn(async () => {})
     const recordChecked = vi.fn(async () => {})
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => true),
-      getPendingUpdates: vi.fn(async () => opts.pending),
+      loadCatalog,
+      update,
+      getPendingUpdates,
       applyUpdates,
       recordChecked,
       listManifests: vi.fn(() => []),
@@ -373,7 +381,14 @@ describe('ProviderService.refreshCatalog', () => {
       silentExtensionOptions
     )
 
-    return { service, applyUpdates, recordChecked }
+    return {
+      service,
+      registry,
+      loadCatalog,
+      update,
+      applyUpdates,
+      recordChecked,
+    }
   }
 
   it('auto-applies updates for uninstalled manifests only', async () => {
@@ -387,7 +402,36 @@ describe('ProviderService.refreshCatalog', () => {
 
     await service.refreshCatalog()
 
-    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'])
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
+  })
+
+  it('forces a no-cache fetch and reuses one index across the sync', async () => {
+    const { service, loadCatalog, update, applyUpdates } = buildForRefresh({
+      pending: [
+        { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+      ],
+      installedManifestIds: [],
+    })
+
+    await service.refreshCatalog()
+
+    expect(loadCatalog).toHaveBeenCalledTimes(1)
+    expect(loadCatalog).toHaveBeenCalledWith(true)
+    expect(update).toHaveBeenCalledWith(catalogEntries, true)
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
+  })
+
+  it('a background sync stays cached and reuses one index', async () => {
+    const { service, loadCatalog, update } = buildForRefresh({
+      pending: [],
+      installedManifestIds: [],
+    })
+
+    await service.syncCatalog()
+
+    expect(loadCatalog).toHaveBeenCalledTimes(1)
+    expect(loadCatalog).toHaveBeenCalledWith(false)
+    expect(update).toHaveBeenCalledWith(catalogEntries, false)
   })
 
   it('does not apply anything when every pending update is installed', async () => {
@@ -416,10 +460,12 @@ describe('ProviderService.refreshCatalog', () => {
 
   it('does not record a check when the catalog index fetch fails', async () => {
     const recordChecked = vi.fn(async () => {})
+    const update = vi.fn(async () => true)
     const getPendingUpdates = vi.fn(async () => [])
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => false),
+      loadCatalog: vi.fn(async () => null),
+      update,
       getPendingUpdates,
       applyUpdates: vi.fn(async () => {}),
       recordChecked,
@@ -438,6 +484,7 @@ describe('ProviderService.refreshCatalog', () => {
 
     await service.refreshCatalog()
 
+    expect(update).not.toHaveBeenCalled()
     expect(getPendingUpdates).not.toHaveBeenCalled()
     expect(recordChecked).not.toHaveBeenCalled()
   })
@@ -500,6 +547,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     const listManifests = vi.fn(() => opts.manifests ?? DEFAULT_MANIFESTS)
     const registry = {
       ready: Promise.resolve(true),
+      loadCatalog: vi.fn(async () => []),
       update: vi.fn(async () => true),
       getPendingUpdates: vi.fn(async () => []),
       recordChecked: vi.fn(async () => {}),

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -466,7 +466,7 @@ describe('ProviderService.refreshCatalog', () => {
     expect(recordChecked).toHaveBeenCalledTimes(1)
   })
 
-  it('does not record a check when the catalog index fetch fails', async () => {
+  function buildForFailedIndex() {
     const recordChecked = vi.fn(async () => {})
     const update = vi.fn(async () => true)
     const getPendingUpdates = vi.fn(async () => [])
@@ -489,10 +489,27 @@ describe('ProviderService.refreshCatalog', () => {
       silentLogger,
       silentExtensionOptions
     )
+    return { service, update, getPendingUpdates, recordChecked }
+  }
 
-    await service.refreshCatalog()
+  it('a user refresh rejects when the catalog index fetch fails', async () => {
+    const { service, update, getPendingUpdates, recordChecked } =
+      buildForFailedIndex()
+
+    await expect(service.refreshCatalog()).rejects.toThrow(
+      'Failed to fetch the manifest catalog'
+    )
 
     expect(update).not.toHaveBeenCalled()
+    expect(getPendingUpdates).not.toHaveBeenCalled()
+    expect(recordChecked).not.toHaveBeenCalled()
+  })
+
+  it('a background sync stays silent when the catalog index fetch fails', async () => {
+    const { service, getPendingUpdates, recordChecked } = buildForFailedIndex()
+
+    await expect(service.syncCatalog()).resolves.toBeUndefined()
+
     expect(getPendingUpdates).not.toHaveBeenCalled()
     expect(recordChecked).not.toHaveBeenCalled()
   })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -386,6 +386,7 @@ describe('ProviderService.refreshCatalog', () => {
       registry,
       loadCatalog,
       update,
+      getPendingUpdates,
       applyUpdates,
       recordChecked,
     }
@@ -406,32 +407,39 @@ describe('ProviderService.refreshCatalog', () => {
   })
 
   it('forces a no-cache fetch and reuses one index across the sync', async () => {
-    const { service, loadCatalog, update, applyUpdates } = buildForRefresh({
-      pending: [
-        { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
-      ],
-      installedManifestIds: [],
-    })
+    const { service, loadCatalog, update, getPendingUpdates, applyUpdates } =
+      buildForRefresh({
+        pending: [
+          { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+        ],
+        installedManifestIds: [],
+      })
 
     await service.refreshCatalog()
 
     expect(loadCatalog).toHaveBeenCalledTimes(1)
     expect(loadCatalog).toHaveBeenCalledWith(true)
     expect(update).toHaveBeenCalledWith(catalogEntries, true)
+    expect(getPendingUpdates).toHaveBeenCalledWith(catalogEntries)
     expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
   })
 
   it('a background sync stays cached and reuses one index', async () => {
-    const { service, loadCatalog, update } = buildForRefresh({
-      pending: [],
-      installedManifestIds: [],
-    })
+    const { service, loadCatalog, update, getPendingUpdates, applyUpdates } =
+      buildForRefresh({
+        pending: [
+          { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+        ],
+        installedManifestIds: [],
+      })
 
     await service.syncCatalog()
 
     expect(loadCatalog).toHaveBeenCalledTimes(1)
     expect(loadCatalog).toHaveBeenCalledWith(false)
     expect(update).toHaveBeenCalledWith(catalogEntries, false)
+    expect(getPendingUpdates).toHaveBeenCalledWith(catalogEntries)
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, false)
   })
 
   it('does not apply anything when every pending update is installed', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -461,32 +461,39 @@ describe('ProviderService.refreshCatalog', () => {
   })
 
   it('forces a no-cache fetch and reuses one index across the sync', async () => {
-    const { service, loadCatalog, update, applyUpdates } = buildForRefresh({
-      pending: [
-        { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
-      ],
-      installedManifestIds: [],
-    })
+    const { service, loadCatalog, update, getPendingUpdates, applyUpdates } =
+      buildForRefresh({
+        pending: [
+          { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+        ],
+        installedManifestIds: [],
+      })
 
     await service.refreshCatalog()
 
     expect(loadCatalog).toHaveBeenCalledTimes(1)
     expect(loadCatalog).toHaveBeenCalledWith(true)
     expect(update).toHaveBeenCalledWith(catalogEntries, true)
+    expect(getPendingUpdates).toHaveBeenCalledWith(catalogEntries)
     expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
   })
 
   it('a background sync stays cached and reuses one index', async () => {
-    const { service, loadCatalog, update } = buildForRefresh({
-      pending: [],
-      installedManifestIds: [],
-    })
+    const { service, loadCatalog, update, getPendingUpdates, applyUpdates } =
+      buildForRefresh({
+        pending: [
+          { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+        ],
+        installedManifestIds: [],
+      })
 
     await service.syncCatalog()
 
     expect(loadCatalog).toHaveBeenCalledTimes(1)
     expect(loadCatalog).toHaveBeenCalledWith(false)
     expect(update).toHaveBeenCalledWith(catalogEntries, false)
+    expect(getPendingUpdates).toHaveBeenCalledWith(catalogEntries)
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, false)
   })
 
   it('does not apply anything when every pending update is installed', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -394,16 +394,23 @@ describe('ProviderService.refreshCatalog', () => {
     vi.clearAllMocks()
   })
 
+  const catalogEntries = [
+    { id: 'one', apiVersion: 1, version: '1.0.0', file: 'one.json' },
+  ]
+
   function buildForRefresh(opts: {
     pending: { manifestId: string; fromVersion: string; toVersion: string }[]
     installedManifestIds: string[]
   }) {
+    const loadCatalog = vi.fn(async () => catalogEntries)
+    const update = vi.fn(async () => true)
+    const getPendingUpdates = vi.fn(async () => opts.pending)
     const applyUpdates = vi.fn(async () => {})
     const recordChecked = vi.fn(async () => {})
-    const getPendingUpdates = vi.fn(async () => opts.pending)
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => true),
+      loadCatalog,
+      update,
       getPendingUpdates,
       applyUpdates,
       recordChecked,
@@ -429,7 +436,14 @@ describe('ProviderService.refreshCatalog', () => {
       silentExtensionOptions
     )
 
-    return { service, applyUpdates, recordChecked, getPendingUpdates }
+    return {
+      service,
+      loadCatalog,
+      update,
+      getPendingUpdates,
+      applyUpdates,
+      recordChecked,
+    }
   }
 
   it('auto-applies updates for uninstalled manifests only', async () => {
@@ -443,7 +457,36 @@ describe('ProviderService.refreshCatalog', () => {
 
     await service.refreshCatalog()
 
-    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'])
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
+  })
+
+  it('forces a no-cache fetch and reuses one index across the sync', async () => {
+    const { service, loadCatalog, update, applyUpdates } = buildForRefresh({
+      pending: [
+        { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+      ],
+      installedManifestIds: [],
+    })
+
+    await service.refreshCatalog()
+
+    expect(loadCatalog).toHaveBeenCalledTimes(1)
+    expect(loadCatalog).toHaveBeenCalledWith(true)
+    expect(update).toHaveBeenCalledWith(catalogEntries, true)
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
+  })
+
+  it('a background sync stays cached and reuses one index', async () => {
+    const { service, loadCatalog, update } = buildForRefresh({
+      pending: [],
+      installedManifestIds: [],
+    })
+
+    await service.syncCatalog()
+
+    expect(loadCatalog).toHaveBeenCalledTimes(1)
+    expect(loadCatalog).toHaveBeenCalledWith(false)
+    expect(update).toHaveBeenCalledWith(catalogEntries, false)
   })
 
   it('does not apply anything when every pending update is installed', async () => {
@@ -486,10 +529,12 @@ describe('ProviderService.refreshCatalog', () => {
 
   it('throws and does not record a check when the catalog index fetch fails', async () => {
     const recordChecked = vi.fn(async () => {})
+    const update = vi.fn(async () => false)
     const getPendingUpdates = vi.fn(async () => [])
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => false),
+      loadCatalog: vi.fn(async () => null),
+      update,
       getPendingUpdates,
       applyUpdates: vi.fn(async () => {}),
       recordChecked,
@@ -511,6 +556,8 @@ describe('ProviderService.refreshCatalog', () => {
       /Failed to fetch the manifest catalog/
     )
 
+    // update still runs on a null index so the offline bundle fallback seeds.
+    expect(update).toHaveBeenCalledWith(null, true)
     expect(getPendingUpdates).not.toHaveBeenCalled()
     expect(recordChecked).not.toHaveBeenCalled()
   })
@@ -577,6 +624,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     const listManifests = vi.fn(() => opts.manifests ?? DEFAULT_MANIFESTS)
     const registry = {
       ready: Promise.resolve(true),
+      loadCatalog: vi.fn(async () => []),
       update: vi.fn(async () => true),
       getPendingUpdates: vi.fn(async () => []),
       recordChecked: vi.fn(async () => {}),

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -300,20 +300,24 @@ export class ProviderService {
   }
 
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
-    await this.syncCatalog()
+    await this.syncCatalog(true)
     return this.listManifests(locale)
   }
 
   // Bring the catalog current: updates for uninstalled sources (no config or
   // user data to disturb) are applied here, while installed-source updates stay
   // manual via the Updates list. Records the check only on a real sync, so
-  // "checked Nm ago" never advances on a bare detection.
-  async syncCatalog(): Promise<void> {
-    const fetched = await this.manifestRegistry.update()
-    if (!fetched) {
+  // "checked Nm ago" never advances on a bare detection. force sends
+  // Cache-Control: no-cache on a user-initiated refresh so the backend skips its
+  // edge cache; background and install syncs stay cached. The index is fetched
+  // once and shared across the three steps.
+  async syncCatalog(force = false): Promise<void> {
+    const entries = await this.manifestRegistry.loadCatalog(force)
+    if (!entries) {
       return
     }
-    const pending = await this.manifestRegistry.getPendingUpdates()
+    await this.manifestRegistry.update(entries, force)
+    const pending = await this.manifestRegistry.getPendingUpdates(entries)
     const configs = await this.providerConfigService.getAll()
     const installed = new Set(configs.map((config) => config.manifestId))
     const uninstalled = pending
@@ -321,7 +325,7 @@ export class ProviderService {
       .map((update) => update.manifestId)
     if (uninstalled.length > 0) {
       try {
-        await this.manifestRegistry.applyUpdates(uninstalled)
+        await this.manifestRegistry.applyUpdates(uninstalled, entries, force)
       } catch (e) {
         // Best-effort: a failed background apply retries next sync and must not
         // block recording the check or the rest of the refresh.

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -313,6 +313,11 @@ export class ProviderService {
   async syncCatalog(force = false): Promise<void> {
     const entries = await this.manifestRegistry.loadCatalog(force)
     if (!entries) {
+      // A user-initiated refresh surfaces the failure so the UI can toast it; a
+      // background sync stays best-effort and silently retries next cycle.
+      if (force) {
+        throw new Error('Failed to fetch the manifest catalog')
+      }
       return
     }
     await this.manifestRegistry.update(entries, force)

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -309,8 +309,7 @@ export class ProviderService {
   // manual via the Updates list. Records the check only on a real sync, so
   // "checked Nm ago" never advances on a bare detection. force sends
   // Cache-Control: no-cache on a user-initiated refresh so the backend skips its
-  // edge cache; background and install syncs stay cached. The index is fetched
-  // once and shared across the three steps.
+  // edge cache; background and install syncs stay cached.
   async syncCatalog(force = false): Promise<void> {
     const entries = await this.manifestRegistry.loadCatalog(force)
     if (!entries) {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -405,7 +405,7 @@ export class ProviderService {
   // Throws on an unreachable catalog so a user-driven refresh surfaces the
   // failure instead of silently returning the stale list.
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
-    const synced = await this.syncCatalog()
+    const synced = await this.syncCatalog(true)
     if (!synced) {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
@@ -416,16 +416,21 @@ export class ProviderService {
   // user data to disturb) are applied here, while installed-source updates stay
   // manual via the Updates list. Records the check only on a real sync, so
   // "checked Nm ago" never advances on a bare detection. Returns whether the
-  // catalog index was reachable.
-  async syncCatalog(): Promise<boolean> {
-    const fetched = await this.manifestRegistry.update()
+  // catalog index was reachable. force sends Cache-Control: no-cache on a
+  // user-initiated refresh so the backend skips its edge cache; background and
+  // install syncs stay cached. The index is fetched once and shared across the
+  // three steps.
+  async syncCatalog(force = false): Promise<boolean> {
+    const entries = await this.manifestRegistry.loadCatalog(force)
+    const fetched = await this.manifestRegistry.update(entries, force)
     if (!fetched) {
       return false
     }
-    // update() just reached the index, so a failure here means it died
-    // mid-sync; skip the best-effort auto-apply rather than fail the sync.
+    // The index is already in hand, so this only reads the store; stay
+    // best-effort so a store failure skips the auto-apply instead of failing
+    // the whole sync.
     const pending = await this.manifestRegistry
-      .getPendingUpdates()
+      .getPendingUpdates(entries)
       .catch((e) => {
         this.logger.warn('Failed to detect pending updates mid-sync:', e)
         return []
@@ -437,7 +442,7 @@ export class ProviderService {
       .map((update) => update.manifestId)
     if (uninstalled.length > 0) {
       try {
-        await this.manifestRegistry.applyUpdates(uninstalled)
+        await this.manifestRegistry.applyUpdates(uninstalled, entries, force)
       } catch (e) {
         // Best-effort: a failed background apply retries next sync and must not
         // block recording the check or the rest of the refresh.


### PR DESCRIPTION
## Summary
- User-initiated catalog actions now send `Cache-Control: no-cache` so the backend skips its 1-hour Cloudflare edge cache and refetches the latest manifests from GitHub raw. A `force` flag threads from `refreshCatalog` and the `providerApplyUpdates` RPC down through `syncCatalog -> loadCatalog/update/getPendingUpdates/applyUpdates -> fetchJson`. Background and install syncs stay cached.
- Coalesced the triple index fetch: `syncCatalog` now loads the catalog index once via `loadCatalog` and shares it across the three steps instead of refetching it in each.
- The Updates list "Update" button (`providerApplyUpdates`) forces too. It is the only path to refresh an already-installed source, so without no-cache it could store a stale edge-cached body and silently no-op.

## Test plan
- Verified: lint (tsc + biome) pass · tests `vitest run` on `background/alarm` + `background/services/providers` -> 91 passed · e2e `specs/sources/catalog-refresh.spec.ts` (refresh + apply force no-cache) and `specs/sources/updates.spec.ts` -> 4 passed
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- specs/sources/catalog-refresh.spec.ts specs/sources/updates.spec.ts`
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` (unit)

## Notes
- Passive pending-updates detection (`providerGetPendingUpdates`) stays cached on purpose: a Refresh re-primes the edge cache, and forcing every providers-page open would hammer `raw.githubusercontent.com` against the throttling caution in the task.
- No CORS preflight concern: these fetches run in the background service worker against a host covered by `host_permissions` (`https://*/*`), which is not subject to CORS, so the non-safelisted `Cache-Control` request header does not trigger an OPTIONS preflight. The e2e exercises the real built extension and confirms the header reaches the request.
- Left the backend 1-hour TTL and the `raw.githubusercontent.com` origin as-is per the task; GitHub Pages / R2 migration remains a separate follow-up.