### PR TITLE
(extension) e2e: lift da/seed wiring into Playwright fixtures [DA-624]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { mockCatalog } from '../network/catalog'
 import { attachConsoleWatcher, type ConsoleWatcher } from './console-watcher'
+import { type DaClient, getDaClient } from './da-client'
 import {
   type AllowedNetworkPattern,
   attachNetworkWatcher,
@@ -29,6 +30,7 @@ export type { AllowedNetworkPattern } from './network-watcher'
 export const test = base.extend<{
   context: BrowserContext
   extensionId: string
+  da: DaClient
   consoleErrors: () => string[]
   expectedConsoleErrors: ExpectedConsoleErrorPattern[]
   allowedNetworkOrigins: AllowedNetworkPattern[]
@@ -70,6 +72,9 @@ export const test = base.extend<{
     }
     const extensionId = serviceWorker.url().split('/')[2]
     await use(extensionId)
+  },
+  da: async ({ context }, use) => {
+    await use(await getDaClient(context))
   },
   consoleErrors: async ({ context }, use) => {
     const watchers = watchersByContext.get(context)

--- a/packages/danmaku-anywhere/e2e/specs/baseline/fonts.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/baseline/fonts.spec.ts
@@ -1,6 +1,5 @@
 import { CONTROLLER_ROOT_ID } from '../../../src/content/controller/common/constants/rootId'
 import { IntegrationPage } from '../../pom/IntegrationPage'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import {
   buildFixtureIntegrationPolicy,
@@ -29,8 +28,8 @@ const FONT_PROBES = [
 test('content-script controller paints text using bundled variable fonts', async ({
   context,
   page,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await seedXPathIntegration(da, {
     patterns: [MOUNT_PATTERN],
     name: 'da-e2e-fonts',

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -1,6 +1,6 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { IntegrationPage } from '../../pom/IntegrationPage'
-import type { getDaClient } from '../../setup/da-client'
+import type { DaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import {
   buildFixtureIntegrationPolicy,
@@ -31,7 +31,7 @@ const SEEK_TIME_S = 15
 
 async function seedFixtureProfile(
   context: import('@playwright/test').BrowserContext,
-  da: Awaited<ReturnType<typeof getDaClient>>
+  da: DaClient
 ): Promise<{ episodeId: number }> {
   await applyProfile(context, da, {
     extensionOptions: { matchLocalDanmaku: true },

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -1,6 +1,6 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { IntegrationPage } from '../../pom/IntegrationPage'
-import { getDaClient } from '../../setup/da-client'
+import type { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import {
   buildFixtureIntegrationPolicy,
@@ -62,8 +62,8 @@ async function seedFixtureProfile(
 test('integration auto-mount: native <video> happy path', async ({
   context,
   page,
+  da,
 }) => {
-  const da = await getDaClient(context)
   const { episodeId } = await seedFixtureProfile(context, da)
 
   const integrationPage = new IntegrationPage(page)
@@ -88,8 +88,8 @@ test('integration auto-mount: native <video> happy path', async ({
 test('integration auto-mount: same-origin iframe <video> happy path', async ({
   context,
   page,
+  da,
 }) => {
-  const da = await getDaClient(context)
   const { episodeId } = await seedFixtureProfile(context, da)
 
   const integrationPage = new IntegrationPage(page)

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-models.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-models.spec.ts
@@ -1,7 +1,7 @@
 import type { BrowserContext } from '@playwright/test'
 import { defaultDanmakuOptions } from '../../../src/common/options/danmakuOptions/constant'
 import { Popup } from '../../pom/Popup'
-import type { getDaClient } from '../../setup/da-client'
+import type { DaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -48,7 +48,7 @@ function modelFileSize(
   }, id)
 }
 
-function activeModel(da: Awaited<ReturnType<typeof getDaClient>>) {
+function activeModel(da: DaClient) {
   return da.storage.get('sync', 'danmakuOptions').then((stored) => {
     return (stored as { data: { occlusionModel: string } }).data.occlusionModel
   })

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion-models.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion-models.spec.ts
@@ -1,7 +1,7 @@
 import type { BrowserContext } from '@playwright/test'
 import { defaultDanmakuOptions } from '../../../src/common/options/danmakuOptions/constant'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
+import type { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -57,8 +57,8 @@ function activeModel(da: Awaited<ReturnType<typeof getDaClient>>) {
 test('occlusion models: lists, reflects OPFS state, switches active, and evicts on delete', async ({
   context,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     rawStorage: [
       {

--- a/packages/danmaku-anywhere/e2e/specs/integration/occlusion.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/occlusion.spec.ts
@@ -2,7 +2,6 @@ import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { defaultDanmakuOptions } from '../../../src/common/options/danmakuOptions/constant'
 import { IntegrationPage } from '../../pom/IntegrationPage'
 import { Toast } from '../../pom/Toast'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import {
   buildFixtureIntegrationPolicy,
@@ -47,8 +46,8 @@ function maskImageOf(locator: import('@playwright/test').Locator) {
 test('occlusion: mask applied to danmu container when enabled', async ({
   context,
   page,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     extensionOptions: { matchLocalDanmaku: true },
     rawStorage: [
@@ -97,8 +96,7 @@ test('occlusion: mask applied to danmu container when enabled', async ({
     .toMatch(/^url\(/)
 })
 
-test('occlusion: no mask when disabled', async ({ context, page }) => {
-  const da = await getDaClient(context)
+test('occlusion: no mask when disabled', async ({ context, page, da }) => {
   await applyProfile(context, da, {
     extensionOptions: { matchLocalDanmaku: true },
   })
@@ -134,8 +132,8 @@ test('occlusion: no mask when disabled', async ({ context, page }) => {
 test('occlusion: anime model without WebGPU surfaces an error and applies no mask', async ({
   context,
   page,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     extensionOptions: { matchLocalDanmaku: true },
     rawStorage: [
@@ -192,8 +190,8 @@ test('occlusion: anime model without WebGPU surfaces an error and applies no mas
 test('occlusion: debug mode shows the mask debug overlay', async ({
   context,
   page,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     extensionOptions: { matchLocalDanmaku: true, debug: true },
     rawStorage: [

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -3,7 +3,6 @@ import {
   PROVIDER_TO_BUILTIN_ID,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
 /**
@@ -35,11 +34,10 @@ test('fresh install: default options seeded, no console errors', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
   // Chrome extension IDs are a 32-char base-16 alphabet of a-p.
   expect(extensionId).toMatch(/^[a-p]{32}$/)
-
-  const da = await getDaClient(context)
 
   const options = await da.extensionOptions.get()
   expect(options.enabled).toBe(true)

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/popupRoute.spec.ts
@@ -1,4 +1,3 @@
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
 /**
@@ -20,9 +19,8 @@ test('reopened popup lands on the last-visited route within the session', async 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
-
   await openPopup(page, extensionId)
   await expect(page).toHaveURL(/#\/mount$/)
 
@@ -45,8 +43,8 @@ test('reopened popup at a nested route rebuilds back stack to ancestors', async 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await da.storage.setRaw('session', 'popup:lastRoute', '/config/add')
 
   await openPopup(page, extensionId)
@@ -63,9 +61,8 @@ test('invalid stored route is cleared and popup falls back to /mount', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
-
   await da.storage.setRaw('session', 'popup:lastRoute', '/this/does/not/exist')
 
   await openPopup(page, extensionId)

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 import { ImportPage } from '../../pom/ImportPage'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
 /**
@@ -44,6 +43,7 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
   context,
   page,
   extensionId,
+  da,
 }) => {
   const popup = await Popup.open(page, extensionId, '/options/backup')
 
@@ -59,8 +59,6 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
   await importPage.selectFiles(DANMAKU_ZIP)
   await importPage.result.confirm()
   await importPage.result.expectSuccess()
-
-  const da = await getDaClient(context)
 
   const providers = await da.providerConfig.list()
   expect(providers.length).toBeGreaterThan(0)

--- a/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -52,8 +51,8 @@ test('mount tree: bookmark adds stubs, remove clears them', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: mockBilibiliXml({

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -4,7 +4,6 @@ import {
   type SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -52,8 +51,8 @@ test('mount tree: delete season removes it + cascades episodes', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
   })
@@ -77,8 +76,8 @@ test('mount tree: delete single episode keeps season + siblings', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
   })

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '@danmaku-anywhere/danmaku-converter'
 import { readFile } from 'fs/promises'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -52,8 +51,8 @@ test('mount tree: season export downloads an XML payload', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
   })
@@ -85,8 +84,8 @@ test('mount tree: season exportBackup downloads a JSON payload', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
   })

--- a/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
@@ -1,6 +1,5 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -17,8 +16,8 @@ test('mount tree: custom episodes with shared path render under a folder node', 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {})
 
   const ep1 = await da.episode.addCustom({

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-detach.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-detach.spec.ts
@@ -1,6 +1,5 @@
 import { ImportResultDialog } from '../../pom/ImportResultDialog'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -23,8 +22,8 @@ test('popup opened as a tab runs the picker in place, no detach window', async (
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {})
 
   const popup = await Popup.open(page, extensionId, '/mount')
@@ -49,8 +48,8 @@ test('/import route renders standalone and runs a full file import', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {})
 
   await page.goto(
@@ -85,8 +84,8 @@ test('an open /mount popup refreshes when the /import window writes', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {})
 
   const popup = await Popup.open(page, extensionId, '/mount')

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-from-url.spec.ts
@@ -1,5 +1,4 @@
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -19,8 +18,8 @@ test('mount toolbar: import from URL fetches a mocked xml and stages a custom ep
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     network: [
       {
@@ -56,8 +55,8 @@ test('mount toolbar: URL dialog surfaces a validation error in the helperText', 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {})
 
   const popup = await Popup.open(page, extensionId, '/mount')

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -4,7 +4,6 @@ import {
   type SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -51,8 +50,8 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
   })

--- a/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -52,8 +51,8 @@ test('mount tree: bookmark-driven preload caches the next episode', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: mockBilibiliXml({

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -50,8 +49,8 @@ test('mount tree: refresh danmaku fetches new comments for an episode', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: mockBilibiliXml({

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-metadata.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-metadata.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -53,8 +52,8 @@ test('mount tree: refresh metadata replaces stale season info', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: mockBilibiliXml({

--- a/packages/danmaku-anywhere/e2e/specs/options/settings.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/options/settings.spec.ts
@@ -1,6 +1,5 @@
 import { Language } from '../../../src/common/localization/language'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 
 /**
@@ -26,8 +25,8 @@ test('settings menu shows the account card and live status subtitles', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   const current = await da.extensionOptions.get()
   await da.extensionOptions.update({
     lang: Language.en,
@@ -49,8 +48,8 @@ test('toggling a player option persists the option', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   const current = await da.extensionOptions.get()
   await da.extensionOptions.update({
     lang: Language.en,

--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -1,7 +1,6 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -35,8 +34,8 @@ test('renders configSchema fields and saves a custom DanDanPlay server', async (
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, { customProviders: [customDdp] })
 
   const popup = await Popup.open(page, extensionId, '/providers')
@@ -63,8 +62,8 @@ test('enforces the schema required constraint on auth headers', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, { customProviders: [customDdp] })
 
   const popup = await Popup.open(page, extensionId, '/providers')
@@ -94,8 +93,8 @@ test('edits the built-in Bilibili provider via the generic form', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: [

--- a/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
@@ -3,7 +3,6 @@ import { Language } from '../../../src/common/localization/language'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockCatalog } from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -35,8 +34,8 @@ test('catalog and config editor render localized manifest strings', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     extensionOptions: { lang: Language.zh },
     customProviders: [localDdp],

--- a/packages/danmaku-anywhere/e2e/specs/sources/bilibili-parse-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/bilibili-parse-url.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -18,8 +17,8 @@ test('bilibili url paste: detect URL → parse → download danmaku', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: mockBilibiliXml({

--- a/packages/danmaku-anywhere/e2e/specs/sources/bilibili.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/bilibili.spec.ts
@@ -1,7 +1,6 @@
 import type { Page } from '@playwright/test'
 import { mockBilibiliProto, mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import {
   loadBinaryFixture,
@@ -36,8 +35,8 @@ test('bilibili xml: search → season → episode → fetch xml danmaku', async 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
     network: mockBilibiliXml({
@@ -53,8 +52,8 @@ test('bilibili proto: same flow, danmaku via /seg.so protobuf', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       bilibili: {

--- a/packages/danmaku-anywhere/e2e/specs/sources/catalog-import.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/catalog-import.spec.ts
@@ -1,6 +1,5 @@
 import { mockCatalog } from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -23,8 +22,8 @@ test('catalog: refresh surfaces an uninstalled source and import installs it', a
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {},
     network: [

--- a/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-custom.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-custom.spec.ts
@@ -2,7 +2,6 @@ import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockDandanplayCustom } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -33,8 +32,8 @@ test('dandanplay: custom baseUrl flow', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     customProviders: [customConfig],
     network: mockDandanplayCustom({

--- a/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-local-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-local-origin.spec.ts
@@ -2,7 +2,6 @@ import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockDandanplayCustom } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -33,8 +32,8 @@ test('dandanplay: loopback baseUrl resolves with the private-host opt-in', async
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     customProviders: [localConfig],
     network: mockDandanplayCustom({

--- a/packages/danmaku-anywhere/e2e/specs/sources/dandanplay.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/dandanplay.spec.ts
@@ -1,6 +1,5 @@
 import { mockDandanplay } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -17,8 +16,8 @@ test('dandanplay: search → season → episode → fetch danmaku', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { dandanplay: { enabled: true } },
     network: [

--- a/packages/danmaku-anywhere/e2e/specs/sources/instances.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/instances.spec.ts
@@ -1,7 +1,6 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -27,8 +26,8 @@ test('installed: multiple dandanplay configs group into instances', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { dandanplay: { enabled: true } },
     customProviders: [homeServer],

--- a/packages/danmaku-anywhere/e2e/specs/sources/lazy-chip-fetch.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/lazy-chip-fetch.spec.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { mockDandanplay } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -19,6 +18,7 @@ test('search chips: only active provider fetches; clicking inactive chip dispatc
   context,
   page,
   extensionId,
+  da,
 }) => {
   const bilibiliSearchUrls: string[] = []
   context.on('request', (request) => {
@@ -31,7 +31,6 @@ test('search chips: only active provider fetches; clicking inactive chip dispatc
     }
   })
 
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: true },

--- a/packages/danmaku-anywhere/e2e/specs/sources/login-probe.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/login-probe.spec.ts
@@ -1,5 +1,4 @@
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -22,9 +21,9 @@ test('hides warnings when both probes return logged-in / cookies-present', async
   context,
   page,
   extensionId,
+  da,
 }) => {
   const calls = { nav: 0, tencent: 0 }
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       bilibili: { enabled: true },
@@ -62,8 +61,8 @@ test('surfaces warning icons when probes report logged-out / no cookies', async 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       bilibili: { enabled: true },

--- a/packages/danmaku-anywhere/e2e/specs/sources/no-providers.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/no-providers.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -16,8 +15,8 @@ test('search: noProviders error renders when all sources are disabled', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: false },

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-history-open.spec.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { mockDandanplay } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -18,8 +17,8 @@ test('returning from season details keeps the history dropdown off the source ch
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: true },
@@ -69,8 +68,8 @@ test('history auto-opens on focus for a fresh search', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: true },

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-loading-skeleton.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-loading-skeleton.spec.ts
@@ -1,5 +1,4 @@
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -23,10 +22,10 @@ test('loading shows a result-count skeleton, then the result count', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
   const gate = deferredGate()
 
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { dandanplay: { enabled: true } },
     network: [
@@ -64,11 +63,11 @@ test.describe(() => {
     context,
     page,
     extensionId,
+    da,
   }) => {
     let calls = 0
     const retryGate = deferredGate()
 
-    const da = await getDaClient(context)
     await applyProfile(context, da, {
       providers: { dandanplay: { enabled: true } },
       network: [

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-source-chips.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-source-chips.spec.ts
@@ -3,7 +3,6 @@ import { mockBilibiliXml } from '../../network/bilibili'
 import { mockDandanplay } from '../../network/dandanplay'
 import { mockTencent } from '../../network/tencent'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -20,8 +19,8 @@ test('source chips: selection persists across season details navigation', async 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: true },
@@ -67,10 +66,10 @@ test('source chips: overflow collapses into a +N menu that activates hidden sour
   context,
   page,
   extensionId,
+  da,
 }) => {
   await page.setViewportSize({ width: 240, height: 640 })
 
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: true },

--- a/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-styling.spec.ts
@@ -2,7 +2,6 @@ import { ColorMode } from '../../../src/common/theme/enums'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { mockDandanplay } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -47,8 +46,8 @@ test('source filter chip text is painted by the bundled theme font, not a serif 
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: {
       dandanplay: { enabled: true },
@@ -103,8 +102,8 @@ test('search history dropdown text stays readable when ambient color is stripped
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     extensionOptions: { theme: { colorMode: ColorMode.Dark } },
     providers: {

--- a/packages/danmaku-anywhere/e2e/specs/sources/tencent.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/tencent.spec.ts
@@ -1,6 +1,5 @@
 import { mockTencent } from '../../network/tencent'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { test } from '../../setup/fixtures'
 import { loadJsonFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -17,8 +16,8 @@ test('tencent: search → season → episode → fetch danmaku', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { tencent: { enabled: true } },
     network: mockTencent({
@@ -44,8 +43,8 @@ test('tencent: a failed danmaku segment does not drop the overlay', async ({
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   await applyProfile(context, da, {
     providers: { tencent: { enabled: true } },
     network: mockTencent({

--- a/packages/danmaku-anywhere/e2e/specs/sources/updates.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/updates.spec.ts
@@ -4,7 +4,6 @@ import {
   mockCatalog,
 } from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
-import { getDaClient } from '../../setup/da-client'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -24,8 +23,8 @@ test('updates: a stale installed source surfaces and applying it clears the row'
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   const current = manifestVersion('bilibili')
 
   await applyProfile(context, da, {
@@ -52,8 +51,8 @@ test('updates: an uninstalled catalog source updates in place on refresh, not as
   context,
   page,
   extensionId,
+  da,
 }) => {
-  const da = await getDaClient(context)
   // iqiyi is not a built-in, so it never gets a config: a catalog-only source.
   const ids = ['dandanplay', 'bilibili', 'tencent', 'iqiyi']
 


### PR DESCRIPTION
## Summary
- Add a lazy `da` fixture to `e2e/setup/fixtures.ts` (`da: async ({ context }, use) => { await use(await getDaClient(context)) }`). Playwright instantiates fixtures lazily, so the ~4 specs that don't use it pay nothing.
- Convert the 36 specs that called `const da = await getDaClient(context)` inline to destructure `da` from the test fixtures instead, and drop the now-unused `getDaClient` import. `applyProfile(context, da, ...)` stays per-spec (the profile differs per test).
- `seed` wrapper NOT adopted: three specs call `applyProfile` from module-level helpers that can't reach a test-scoped fixture, so a `seed` fixture would force mixed `seed`/`applyProfile` usage and cascade into dropping now-unused `context` from destructures. That trades a tractable mechanical diff for per-spec divergence, so per the brief's YAGNI tiebreaker this PR ships just `da`.

This is a pure wiring refactor: no assertion changes, no behavioral changes. Every changed line is one of three patterns (remove `getDaClient` import, append `da` to a destructure, delete the `const da` line); audited programmatically.

## Scope notes
- `getDaClient` import is intentionally kept in `integration-auto-mount.spec.ts` and `occlusion-models.spec.ts` (still referenced in a `typeof getDaClient` type position).
- `occlusion-cross-origin.spec.ts` is untouched: it uses `getDaClient` only inside a module-level helper, never in a test body, so the test-scoped fixture doesn't apply.

## Test plan
- Verified: lint (tsc + biome) pass · e2e full suite `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` -> 67 passed across 41 files. Full suite is the load-bearing check here because this changes the shared harness (`fixtures.ts`) plus 36 specs, so affected-only is insufficient.
- [ ] Re-run the full e2e suite: `cd packages/danmaku-anywhere && pnpm test:e2e`