### PR TITLE
(extension) e2e: housekeeping [DA-627]

### DIFF
--- a/packages/danmaku-anywhere/e2e/network/dandanplay.ts
+++ b/packages/danmaku-anywhere/e2e/network/dandanplay.ts
@@ -7,7 +7,13 @@ export interface DandanplayFixtures {
   comments: unknown
 }
 
-// Path-only match — VITE_PROXY_URL host varies between local, CI, and prod.
+const DDP_ROUTES = [
+  { path: '/api/v2/search/anime', key: 'search' },
+  { path: '/api/v2/bangumi/', key: 'bangumi' },
+  { path: '/api/v2/comment/', key: 'comments' },
+] as const
+
+// Path-only match: VITE_PROXY_URL host varies between local, CI, and prod.
 // The built-in provider points baseUrl at {proxy}/ddp and the manifest hits
 // /api/v2/* on it, so the proxy passes the path through transparently.
 const PROXY_PATH = /\/ddp\/api\/v2\//
@@ -17,22 +23,15 @@ export function mockDandanplay(fixtures: DandanplayFixtures): NetworkMock {
     pattern: PROXY_PATH,
     respond: async (route: Route) => {
       const innerPath = new URL(route.request().url()).pathname
-      if (innerPath.includes('/api/v2/search/anime')) {
-        await route.fulfill({ json: fixtures.search })
+      const matched = DDP_ROUTES.find((r) => innerPath.includes(r.path))
+      if (!matched) {
+        await route.fulfill({
+          status: 404,
+          body: `unhandled DDP path: ${innerPath}`,
+        })
         return
       }
-      if (innerPath.includes('/api/v2/bangumi/')) {
-        await route.fulfill({ json: fixtures.bangumi })
-        return
-      }
-      if (innerPath.includes('/api/v2/comment/')) {
-        await route.fulfill({ json: fixtures.comments })
-        return
-      }
-      await route.fulfill({
-        status: 404,
-        body: `unhandled DDP path: ${innerPath}`,
-      })
+      await route.fulfill({ json: fixtures[matched.key] })
     },
   }
 }
@@ -48,18 +47,8 @@ export function mockDandanplayCustom(
   fixtures: DandanplayCustomFixtures
 ): NetworkMock[] {
   const escaped = fixtures.baseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return [
-    {
-      pattern: new RegExp(`${escaped}/api/v2/search/anime`),
-      respond: (route) => route.fulfill({ json: fixtures.search }),
-    },
-    {
-      pattern: new RegExp(`${escaped}/api/v2/bangumi/`),
-      respond: (route) => route.fulfill({ json: fixtures.bangumi }),
-    },
-    {
-      pattern: new RegExp(`${escaped}/api/v2/comment/`),
-      respond: (route) => route.fulfill({ json: fixtures.comments }),
-    },
-  ]
+  return DDP_ROUTES.map((r) => ({
+    pattern: new RegExp(`${escaped}${r.path}`),
+    respond: (route) => route.fulfill({ json: fixtures[r.key] }),
+  }))
 }

--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -14,6 +14,10 @@ const SELECTORS = {
 export class MountPage {
   constructor(private readonly page: Page) {}
 
+  treeItem(id: string): Locator {
+    return this.page.locator(SELECTORS.treeItem(id))
+  }
+
   seasonItem(seasonId: number): Locator {
     return this.page.locator(SELECTORS.treeItem(`season-${seasonId}`))
   }

--- a/packages/danmaku-anywhere/e2e/setup/integration.ts
+++ b/packages/danmaku-anywhere/e2e/setup/integration.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import type { Integration } from '@danmaku-anywhere/integration-policy'
 import { BUILT_IN_AI_PROVIDER_ID } from '../../src/common/options/aiProviderConfig/constant'
+import {
+  zIntegration,
+  zIntegrationPolicy,
+} from '../../src/common/options/integrationPolicyStore/schema'
 import { LATEST_INTEGRATION_POLICY_VERSION } from '../../src/common/options/integrationPolicyStore/version'
 import { LATEST_MOUNT_CONFIG_VERSION } from '../../src/common/options/mountConfig/version'
 import type { DaClient } from './da-client'
@@ -28,7 +32,7 @@ export async function seedXPathIntegration(
   const mountConfigId = randomUUID()
 
   const integration: Integration = {
-    version: 3,
+    version: zIntegration.shape.version.value,
     id: integrationId,
     name: input.name ?? 'e2e integration',
     policy: input.policy,
@@ -61,7 +65,7 @@ export async function seedXPathIntegration(
 // Generic policy keyed to data-testid hooks on the fixture pages.
 export function buildFixtureIntegrationPolicy(): Integration['policy'] {
   return {
-    version: 3,
+    version: zIntegrationPolicy.shape.version.value,
     title: {
       selector: [{ value: '//*[@data-testid="da-title"]', quick: true }],
       regex: [],

--- a/packages/danmaku-anywhere/e2e/specs/baseline/fonts.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/baseline/fonts.spec.ts
@@ -9,8 +9,8 @@ import {
 /**
  * Mounts the controller on a host-origin page and asserts every variable
  * font is the one actually painting text inside the controller's shadow
- * DOM. Reads CDP CSS.getPlatformFontsForNode — the same source DevTools'
- * Rendered Fonts panel uses — so the assertion fails iff the woff2 isn't
+ * DOM. Reads CDP CSS.getPlatformFontsForNode (the same source DevTools'
+ * Rendered Fonts panel uses), so the assertion fails iff the woff2 isn't
  * registered AND the host page is using a fallback.
  */
 
@@ -53,7 +53,7 @@ test('content-script controller paints text using bundled variable fonts', async
       }
       const probeRoot = document.createElement('div')
       probeRoot.id = '__font_probes__'
-      // Offscreen but rendered — CSS.getPlatformFontsForNode needs a layout box.
+      // Offscreen but rendered: CSS.getPlatformFontsForNode needs a layout box.
       probeRoot.style.cssText = 'position:fixed;top:-9999px;left:-9999px;'
       for (const { family, sample } of probes) {
         const span = document.createElement('span')

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -12,7 +12,7 @@ import { applyProfile } from '../../setup/profile'
  * Auto-mount happy path: URL match → XPath policy → media-info → mount →
  * render at the right timestamp. Two video setups: top-frame and
  * same-origin iframe. Both resolve via LocalMatchingStrategy against a
- * seeded custom episode — no provider network is exercised here.
+ * seeded custom episode. No provider network is exercised here.
  */
 
 const ORIGIN = 'https://da-test.invalid'
@@ -98,7 +98,7 @@ test('integration auto-mount: same-origin iframe <video> happy path', async ({
     extraFixtures: { 'iframe-inner.html': 'iframe-inner.html' },
   })
 
-  // <video> in a child frame — controller (top) extracts media info,
+  // <video> in a child frame: controller (top) extracts media info,
   // player content script (allFrames) inside the iframe mounts the renderer.
   await integrationPage.useIframeVideo('iframe[data-testid="da-iframe"]')
 

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -9,8 +9,8 @@ import { applyProfile } from '../../setup/profile'
 
 /**
  * Per-item delete on the DanmakuTree (/mount) via the context menu:
- *   - Season delete cascades to its episodes — row vanishes, DB cleared.
- *   - Episode delete removes one row — parent + sibling stay intact.
+ *   - Season delete cascades to its episodes: row vanishes, DB cleared.
+ *   - Episode delete removes one row: parent + sibling stay intact.
  *
  * Both paths route through the shared confirm Dialog (`popup.dialog`).
  */
@@ -100,7 +100,7 @@ test('mount tree: delete single episode keeps season + siblings', async ({
 
   await expect.poll(() => da.episode.get(ep1.id)).toBeUndefined()
 
-  // Sibling + parent intact — checked in both UI and DB so a wider-than-
+  // Sibling + parent intact, checked in both UI and DB so a wider-than-
   // intended delete (or one that updates only one layer) is caught.
   await expect(popup.mount.episodeItem(ep2.id)).toBeVisible()
   await expect(popup.mount.seasonItem(season.id)).toBeVisible()

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -10,8 +10,8 @@ import { applyProfile } from '../../setup/profile'
 
 /**
  * Export actions on the DanmakuTree (/mount), via the season context menu:
- *   - `export` — downloads a `.xml` payload with the `<i>` root + comments.
- *   - `exportBackup` — downloads a `.json` payload with title + commentCount.
+ *   - `export`: downloads a `.xml` payload with the `<i>` root + comments.
+ *   - `exportBackup`: downloads a `.json` payload with title + commentCount.
  *
  * Single-episode seasons only; multi-episode exports zip (out of scope).
  */
@@ -63,7 +63,7 @@ test('mount tree: season export downloads an XML payload', async ({
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)
 
-  // Arm before the click. Wider timeout — RPC + serialize + programmatic
+  // Arm before the click. Wider timeout: RPC + serialize + programmatic
   // <a download> click is slow on CI.
   const downloadPromise = page.waitForEvent('download', { timeout: 20_000 })
   await popup.mount.openItemMenu(seasonItem, 'export')

--- a/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/folder.spec.ts
@@ -37,7 +37,7 @@ test('mount tree: custom episodes with shared path render under a folder node', 
 
   const popup = await Popup.open(page, extensionId, '/mount')
 
-  // `season-custom` is a synthetic id — there's no DB season for customs.
+  // `season-custom` is a synthetic id; there's no DB season for customs.
   await popup.mount.expandItem('season-custom')
 
   const folder = popup.mount.folderItem(FOLDER)

--- a/packages/danmaku-anywhere/e2e/specs/mount/import-detach.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/import-detach.spec.ts
@@ -90,7 +90,7 @@ test('an open /mount popup refreshes when the /import window writes', async ({
 
   const popup = await Popup.open(page, extensionId, '/mount')
 
-  const seasonCustom = page.locator('[data-testid="tree-item-season-custom"]')
+  const seasonCustom = popup.mount.treeItem('season-custom')
   await expect(seasonCustom).toBeHidden()
 
   const importTab = await context.newPage()

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -67,7 +67,7 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
   await popup.mount.waitForSeason(season.id)
   await popup.mount.expandSeason(season.id)
 
-  // Episodes must be rendered before selectAll — it walks the visible tree.
+  // Episodes must be rendered before selectAll: it walks the visible tree.
   for (const ep of seeded) {
     await expect(popup.mount.episodeItem(ep.id)).toBeVisible()
   }

--- a/packages/danmaku-anywhere/e2e/specs/options/settings.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/options/settings.spec.ts
@@ -64,6 +64,7 @@ test('toggling a player option persists the option', async ({
 
   await popup.options.openSubPage(/Player Settings/)
   await expect(page).toHaveURL(/#\/options\/player$/)
+  // One-off section heading on the player sub-page, asserted only here.
   await expect(page.getByText('In-player controls')).toBeVisible()
 
   const skipButton = popup.options.toggle(0)

--- a/packages/danmaku-anywhere/e2e/specs/sources/bilibili-parse-url.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/bilibili-parse-url.spec.ts
@@ -37,6 +37,7 @@ test('bilibili url paste: detect URL → parse → download danmaku', async ({
 
   await popup.search.parseButton.click()
 
+  // One-off action label; only this spec downloads from a parsed URL result.
   const downloadDanmaku = page.getByRole('button', {
     name: /download danmaku|获取弹幕/i,
   })

--- a/packages/danmaku-anywhere/e2e/specs/sources/login-probe.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/login-probe.spec.ts
@@ -10,6 +10,8 @@ import { applyProfile } from '../../setup/profile'
  * and the callout is absent when every probe reports logged-in.
  */
 
+// Probe-warning matchers used only here; the providers list has no POM for the
+// "needs attention" state and a single spec doesn't warrant one.
 const ATTENTION = /Needs attention|存在问题/
 const SIGN_IN = /^(Sign in|登录)$/
 

--- a/packages/danmaku-anywhere/e2e/specs/sources/no-providers.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/no-providers.spec.ts
@@ -28,6 +28,7 @@ test('search: noProviders error renders when all sources are disabled', async ({
   const popup = await Popup.open(page, extensionId)
   await popup.search.submit('frieren')
 
+  // One-off guard testid asserted only in this spec; not worth a POM method.
   const guard = page.locator('[data-testid="search-no-providers"]')
   await expect(guard).toBeVisible()
   await expect(guard).toContainText(


### PR DESCRIPTION
## Summary
- Add `MountPage.treeItem(id)` and route `import-detach.spec.ts` through it instead of a raw tree-item selector.
- Replace em dashes with periods/colons/parens in the headers and comments of `baseline/fonts`, `mount/export`, `mount/delete`, `integration/integration-auto-mount`, `mount/folder`, `mount/multi-select`.
- Add the doctrine-mandated one-line "why no POM" comment to the un-commented one-off raw selectors in `sources/no-providers`, `sources/bilibili-parse-url`, `sources/login-probe`, and `options/settings`.
- Derive the integration/policy `version` literal in `e2e/setup/integration.ts` from the source schema's `z.literal(...)` instead of hardcoding `3`, so a schema bump can't silently desync.
- Share a single DDP route table between `mockDandanplay` and `mockDandanplayCustom` so the three endpoint paths live in one place.

No behavioral changes; these are cleanups from the e2e suite audit.

## Test plan
- Verified: lint (tsc + biome) pass · e2e targeted: `import-detach`, `baseline/fonts`, `integration/integration-auto-mount`, `sources/dandanplay`, `sources/dandanplay-custom`, `sources/dandanplay-local-origin` -> 9 passed. These cover all three logic-touching changes (treeItem POM, integration policy literal, DDP route table). Full `test:e2e` sweep left to CI per repo convention.
- [ ] Reviewer: CI runs the full e2e suite; no extra manual steps needed.

## Notes
- Skipped optional audit item 5 (converge `migration-smoke.spec.ts` onto the harness console/network baseline): migration uses its own `launchExtension` persistent context and imports `test` from `@playwright/test`, not the shared fixtures, so the fixture-enforced baseline does not apply. Forcing it would couple the swap harness to the standard fixtures for no gain.
- Did the DDP-dispatch half of optional item 6 but skipped the `bytes=` half: the two range parsers live in different runtimes (a dependency-free Node http server in `harness/serve.mjs` vs a Playwright `route.fulfill` handler in `setup/media-route.ts`) with different semantics (suffix ranges + 416 vs buffered subarray). Unifying them couples two runtimes for little gain.