### PR TITLE
(extension) e2e: cover mount-config CRUD editor [DA-626]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/MountConfigPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountConfigPage.ts
@@ -10,7 +10,7 @@ const NEXT = /^(Next|下一步)$/
 const SAVE = /^(Save|保存)$/
 const ADD_PATTERN = /^(Add Pattern|添加模式)$/
 const NAME_LABEL = /Name|名称/
-const patternLabel = (index: number) => new RegExp(`(Pattern|模式) ${index}`)
+const PATTERN_LABEL = /(Pattern|模式) 1/
 
 // POM for the mount-config list (#/config) and the stepper-based config editor
 // (#/config/add, #/config/edit). List rows carry no testid, so they are
@@ -43,11 +43,7 @@ export class MountConfigPage {
 
   async addPattern(value: string): Promise<void> {
     await this.page.getByRole('button', { name: ADD_PATTERN }).click()
-    await this.page.getByLabel(patternLabel(1)).fill(value)
-  }
-
-  async fillPattern(index: number, value: string): Promise<void> {
-    await this.page.getByLabel(patternLabel(index)).fill(value)
+    await this.page.getByLabel(PATTERN_LABEL).fill(value)
   }
 
   async next(): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/MountConfigPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountConfigPage.ts
@@ -21,8 +21,12 @@ export class MountConfigPage {
 
   // The row is a MUI ListItem (<li>) whose clickable body nests a button, so
   // the implicit listitem role is lost; match the <li> tag directly instead.
+  // Exact text match keeps a name that is a substring of another from
+  // resolving two rows.
   row(name: string): Locator {
-    return this.page.locator('li').filter({ hasText: name })
+    return this.page
+      .locator('li')
+      .filter({ has: this.page.getByText(name, { exact: true }) })
   }
 
   async expectRow(name: string): Promise<void> {

--- a/packages/danmaku-anywhere/e2e/pom/MountConfigPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountConfigPage.ts
@@ -1,0 +1,65 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+const SELECTORS = {
+  drilldownButton: '[data-testid="drilldown-menu-button"]',
+  menuItem: (id: string) => `[data-testid="drilldown-menu-item-${id}"]`,
+}
+
+const ADD = /^(Add|添加)$/
+const NEXT = /^(Next|下一步)$/
+const SAVE = /^(Save|保存)$/
+const ADD_PATTERN = /^(Add Pattern|添加模式)$/
+const NAME_LABEL = /Name|名称/
+const patternLabel = (index: number) => new RegExp(`(Pattern|模式) ${index}`)
+
+// POM for the mount-config list (#/config) and the stepper-based config editor
+// (#/config/add, #/config/edit). List rows carry no testid, so they are
+// addressed by the config name they render; the per-row action menu and the
+// editor's stepper buttons are stable across locales via role + name.
+export class MountConfigPage {
+  constructor(private readonly page: Page) {}
+
+  // The row is a MUI ListItem (<li>) whose clickable body nests a button, so
+  // the implicit listitem role is lost; match the <li> tag directly instead.
+  row(name: string): Locator {
+    return this.page.locator('li').filter({ hasText: name })
+  }
+
+  async expectRow(name: string): Promise<void> {
+    await expect(this.row(name)).toBeVisible()
+  }
+
+  async startAdd(): Promise<void> {
+    await this.page.getByRole('button', { name: ADD }).click()
+  }
+
+  async openEditor(name: string): Promise<void> {
+    await this.row(name).getByText(name, { exact: true }).click()
+  }
+
+  async fillName(name: string): Promise<void> {
+    await this.page.getByLabel(NAME_LABEL).fill(name)
+  }
+
+  async addPattern(value: string): Promise<void> {
+    await this.page.getByRole('button', { name: ADD_PATTERN }).click()
+    await this.page.getByLabel(patternLabel(1)).fill(value)
+  }
+
+  async fillPattern(index: number, value: string): Promise<void> {
+    await this.page.getByLabel(patternLabel(index)).fill(value)
+  }
+
+  async next(): Promise<void> {
+    await this.page.getByRole('button', { name: NEXT }).click()
+  }
+
+  async save(): Promise<void> {
+    await this.page.getByRole('button', { name: SAVE }).click()
+  }
+
+  async openRowMenu(name: string, actionId: string): Promise<void> {
+    await this.row(name).locator(SELECTORS.drilldownButton).click()
+    await this.page.locator(SELECTORS.menuItem(actionId)).click()
+  }
+}

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -3,6 +3,7 @@ import { AppBarPage } from './AppBarPage'
 import { BackupPage } from './BackupPage'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ImportResultDialog } from './ImportResultDialog'
+import { MountConfigPage } from './MountConfigPage'
 import { MountPage } from './MountPage'
 import { OptionsPage } from './OptionsPage'
 import { ProvidersPage } from './ProvidersPage'
@@ -14,6 +15,7 @@ import { UrlImportDialog } from './UrlImportDialog'
 export class Popup {
   readonly appBar: AppBarPage
   readonly mount: MountPage
+  readonly config: MountConfigPage
   readonly search: SearchPage
   readonly seasonDetails: SeasonDetailsPage
   readonly providers: ProvidersPage
@@ -27,6 +29,7 @@ export class Popup {
   private constructor(page: Page) {
     this.appBar = new AppBarPage(page)
     this.mount = new MountPage(page)
+    this.config = new MountConfigPage(page)
     this.search = new SearchPage(page)
     this.seasonDetails = new SeasonDetailsPage(page)
     this.providers = new ProvidersPage(page)

--- a/packages/danmaku-anywhere/e2e/specs/integration/mount-config-crud.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/mount-config-crud.spec.ts
@@ -1,0 +1,58 @@
+import type { MountConfig } from '../../../src/common/options/mountConfig/schema'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Full CRUD lifecycle for a mount config driven entirely through the editor UI
+ * (#/config -> /add -> /edit), the path that makes auto-mounting possible but
+ * was previously only exercised via a pre-seeded config. Creates a manual-mode
+ * config through the stepper, edits its name, then deletes it via the row menu.
+ * Asserts the success toast and list row at each step, with the stored
+ * `mountConfig` array as ground truth.
+ */
+
+test('mount config: create, edit, then delete through the editor UI', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  await applyProfile(context, da, {})
+
+  const storedNames = async (): Promise<string[]> => {
+    const raw = (await da.storage.get('sync', 'mountConfig')) as
+      | { data: MountConfig[] }
+      | undefined
+    return (raw?.data ?? []).map((config) => config.name)
+  }
+
+  const popup = await Popup.open(page, extensionId, '/config')
+
+  await popup.config.startAdd()
+  await popup.config.fillName('Alpha Config')
+  await popup.config.addPattern('https://crud.e2e.invalid/*')
+  await popup.config.next()
+  await popup.config.save()
+
+  await popup.toast.expectSuccess(/Config Created|配置已创建/)
+  await popup.config.expectRow('Alpha Config')
+  await expect.poll(storedNames).toContain('Alpha Config')
+
+  await popup.config.openEditor('Alpha Config')
+  await popup.config.fillName('Beta Config')
+  await popup.config.next()
+  await popup.config.save()
+
+  await popup.toast.expectSuccess(/Config Updated|配置已更新/)
+  await popup.config.expectRow('Beta Config')
+  await expect(popup.config.row('Alpha Config')).toBeHidden()
+  await expect.poll(storedNames).toEqual(['Beta Config'])
+
+  await popup.config.openRowMenu('Beta Config', 'delete')
+  await popup.dialog.confirm()
+
+  await popup.toast.expectSuccess(/Config Deleted|配置已删除/)
+  await expect(popup.config.row('Beta Config')).toBeHidden()
+  await expect.poll(storedNames).toEqual([])
+})


### PR DESCRIPTION
## Summary
- Add `e2e/specs/integration/mount-config-crud.spec.ts`: a full create -> edit -> delete lifecycle for a mount config driven entirely through the editor UI (`#/config` -> `/add` -> `/edit`). Previously only a pre-seeded config was exercised, so a broken editor could ship undetected.
- Add `MountConfigPage` POM (`e2e/pom/MountConfigPage.ts`), wired into the `Popup` root as `popup.config`. Rows are addressed by the config name they render (no testid on rows) and the stepper/menu controls by locale-stable role + name.

## Test plan
- Verified: lint (tsc + biome) pass · tests: new spec only (`pnpm test:e2e e2e/specs/integration/mount-config-crud.spec.ts` -> 1 passed) · full e2e sweep left to CI
- [ ] `cd packages/danmaku-anywhere && pnpm test:e2e e2e/specs/integration/mount-config-crud.spec.ts`

## Notes
- Each step asserts a user-visible signal (success toast scoped by severity + the list row) with the stored `mountConfig` array as complementary ground truth.
- Matchers are bi-locale (default UI language is Chinese): toast text via `popup.toast.expectSuccess` and button/label regexes covering both `en` and `zh`.
- Uses an allow-listed `*.invalid` match pattern, so no per-spec network mock is needed.