### PR TITLE
(extension) show open-in-new-tab in popup app bar on mobile [DA-643]

### DIFF
--- a/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
@@ -58,14 +58,24 @@ export const AppToolBar = () => {
           onClick={() => {
             navigate('/options')
           }}
-          edge={isMobile ? 'end' : undefined}
           sx={{
             color: 'inherit',
           }}
         >
           <Settings />
         </IconButton>
-        {!isMobile && (
+        {isMobile ? (
+          <IconButton
+            onClick={openInTab}
+            edge="end"
+            data-testid="open-in-tab-button"
+            sx={{
+              color: 'inherit',
+            }}
+          >
+            <Tab />
+          </IconButton>
+        ) : (
           <DrilldownMenu
             icon={<OpenInNew />}
             buttonTestId="open-in-new-button"

--- a/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/home/AppToolBar.tsx
@@ -68,6 +68,7 @@ export const AppToolBar = () => {
           <IconButton
             onClick={openInTab}
             edge="end"
+            aria-label={t('common.openInNewTab', 'Open in new tab')}
             data-testid="open-in-tab-button"
             sx={{
               color: 'inherit',


### PR DESCRIPTION
## Summary
- On mobile (Android), the popup app bar now renders a single "open in new tab" `IconButton`; desktop keeps the existing new-window/new-tab dropdown unchanged.
- The new-window option is omitted on mobile because `chrome.windows.create` is unsupported on Android.

## Why
On Edge Canary mobile the Backup > Import button does not open the native file picker, likely because the MV3 popup is a constrained context. `openPopupInNewTab` uses `chrome.tabs.create`, opening the popup page as a real browser tab (a normal full-page web context) where `<input type=file>.click()` works. This gives Android users a working path: open in a tab, then Settings > Backup > Import.

## Test plan
- Verified: lint (tsc + biome) pass · e2e `e2e/specs/lifecycle/openInNew.spec.ts` 2/2 passed (desktop dropdown path intact after the `&&` -> ternary refactor)
- [ ] Reviewer: `pnpm --filter @mr-quin/danmaku-anywhere test:e2e e2e/specs/lifecycle/openInNew.spec.ts`
- Mobile button rendering is not e2e-covered: the branch is gated on `platformInfo.os === 'android'`, which reads `chrome.runtime.getPlatformInfo()` in the background SW; forcing it to `android` on desktop Chromium would require a production test-only seam. The underlying `openPopupInNewTab` action is already covered by the existing "open in new tab" menu-item test. No React component-test harness exists in this package to assert the conditional in isolation.

## Notes
- On-device verification still pending: load this build on Edge Canary mobile and confirm the import picker opens in the new tab.