### PR TITLE
(extension) keep orphaned seasons when deleting a provider config [DA-642]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/MountPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/MountPage.ts
@@ -72,6 +72,22 @@ export class MountPage {
     await expect(menuItem).toBeHidden()
   }
 
+  // Right-click to reveal the context menu without acting on an entry, so a
+  // spec can assert an entry's enabled/disabled state. Targets the row header
+  // near the top: an expanded season's box covers its child rows, so a centered
+  // click would open a child's menu instead.
+  async openContextMenu(item: Locator): Promise<void> {
+    await item.click({ button: 'right', position: { x: 16, y: 16 } })
+  }
+
+  contextMenuItem(actionId: string): Locator {
+    return this.page.locator(SELECTORS.menuItem(actionId))
+  }
+
+  seasonOrphanedBadge(seasonId: number): Locator {
+    return this.seasonItem(seasonId).getByTestId('season-orphaned-badge')
+  }
+
   async expandSeason(seasonId: number): Promise<void> {
     const item = this.seasonItem(seasonId)
     if ((await item.getAttribute('aria-expanded')) === 'true') {

--- a/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
@@ -16,8 +16,7 @@ export class ProvidersPage {
     await this.row(name).first().click()
   }
 
-  // Opens the installed row's overflow menu and clicks Delete. Leaves the
-  // confirm Dialog open for the caller to confirm via `popup.dialog`.
+  // Stops before confirming; the caller confirms via `popup.dialog`.
   async deleteProvider(name: string | RegExp): Promise<void> {
     const installedRow = this.page
       .getByRole('listitem')

--- a/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
@@ -16,6 +16,16 @@ export class ProvidersPage {
     await this.row(name).first().click()
   }
 
+  // Opens the installed row's overflow menu and clicks Delete. Leaves the
+  // confirm Dialog open for the caller to confirm via `popup.dialog`.
+  async deleteProvider(name: string | RegExp): Promise<void> {
+    const installedRow = this.page
+      .getByRole('listitem')
+      .filter({ hasText: name })
+    await installedRow.getByTestId('drilldown-menu-button').click()
+    await this.page.getByTestId('drilldown-menu-item-delete').click()
+  }
+
   filter(query: string): Promise<void> {
     return this.page.getByPlaceholder(/Filter sources|筛选/).fill(query)
   }

--- a/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
@@ -4,16 +4,19 @@ import {
   type EpisodeInsert,
   type SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
+import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
+import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
 
 /**
- * Deleting a provider config keeps its seasons/episodes instead of cascading.
- * Seeds a Bilibili season with a cached episode, deletes the Bilibili provider
- * from /providers, then asserts on /mount that the season survives in the DB
- * and tree, still renders its cached comment count, shows a "source removed"
- * badge, and that Refresh Metadata is disabled.
+ * Deleting a provider config orphans its seasons instead of cascading.
+ * Seeds a bookmarked Bilibili season with a cached episode, deletes the
+ * Bilibili provider, then asserts the season/episode survive (DB + tree),
+ * cached comments still render, the bookmark and its stubs are gone, a
+ * "source removed" badge shows, Refresh Metadata is disabled, Follow is
+ * disabled, and the episode menu no longer offers Refresh Danmaku.
  */
 
 const SEASON: SeasonInsert = {
@@ -36,6 +39,8 @@ const COMMENTS: CommentEntity[] = [
 ]
 
 function makeEpisode(seasonId: number): EpisodeInsert {
+  // indexedId matches the fixture's first episode so the bookmark dedups to
+  // one stub.
   return {
     provider: DanmakuSourceType.Bilibili,
     providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
@@ -58,38 +63,49 @@ test('deleting a provider orphans its season but keeps it viewable', async ({
 }) => {
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
-    // The providers list probes Bilibili login status (/nav) on render.
-    network: [
-      {
-        pattern: /api\.bilibili\.com\/x\/web-interface\/nav/,
-        respond: (route) =>
-          route.fulfill({ json: { code: 0, data: { isLogin: false } } }),
-      },
-    ],
+    network: mockBilibiliXml({
+      searchBangumi: loadJsonFixture('bilibili-search-bangumi.json'),
+      searchFt: loadJsonFixture('bilibili-search-ft.json'),
+      season: loadJsonFixture('bilibili-season.json'),
+      xml: loadTextFixture('bilibili-xml.xml'),
+    }),
   })
 
   const season = await da.season.add(SEASON)
   const ep = await da.episode.add(makeEpisode(season.id))
 
-  const popup = await Popup.open(page, extensionId, '/providers')
+  const popup = await Popup.open(page, extensionId, '/mount')
+  let seasonItem = await popup.mount.waitForSeason(season.id)
+  await popup.mount.openItemMenu(seasonItem, 'bookmarkAdd')
+  await expect(seasonItem).toContainText(/\+1/)
+
+  await Popup.open(page, extensionId, '/providers')
   await popup.providers.deleteProvider('Bilibili')
   await popup.dialog.confirm()
   await popup.toast.expectSuccess(/Provider deleted|弹幕源已删除/)
 
   expect((await da.season.get(season.id))?.id).toBe(season.id)
   expect((await da.episode.get(ep.id))?.commentCount).toBe(COMMENTS.length)
+  await expect.poll(() => da.bookmark.bySeason(season.id)).toBeUndefined()
 
   await Popup.open(page, extensionId, '/mount')
-  const seasonItem = await popup.mount.waitForSeason(season.id)
+  seasonItem = await popup.mount.waitForSeason(season.id)
   await expect(popup.mount.seasonOrphanedBadge(season.id)).toBeVisible()
+  await expect(seasonItem).not.toContainText(/\+\d+/)
 
   await popup.mount.expandSeason(season.id)
   await expect(popup.mount.episodeCommentCount(ep.id)).toHaveText(
     String(COMMENTS.length)
   )
 
+  const epItem = popup.mount.episodeItem(ep.id)
+  await popup.mount.openContextMenu(epItem)
+  await expect(popup.mount.contextMenuItem('view')).toBeVisible()
+  await expect(popup.mount.contextMenuItem('refresh')).toBeHidden()
+
   await popup.mount.openContextMenu(seasonItem)
   const refresh = popup.mount.contextMenuItem('refresh')
   await expect(refresh).toBeVisible()
   await expect(refresh).toBeDisabled()
+  await expect(popup.mount.contextMenuItem('bookmarkAdd')).toBeDisabled()
 })

--- a/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
@@ -1,0 +1,95 @@
+import {
+  type CommentEntity,
+  DanmakuSourceType,
+  type EpisodeInsert,
+  type SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Deleting a provider config keeps its seasons/episodes instead of cascading.
+ * Seeds a Bilibili season with a cached episode, deletes the Bilibili provider
+ * from /providers, then asserts on /mount that the season survives in the DB
+ * and tree, still renders its cached comment count, shows a "source removed"
+ * badge, and that Refresh Metadata is disabled.
+ */
+
+const SEASON: SeasonInsert = {
+  provider: DanmakuSourceType.Bilibili,
+  providerIds: { seasonId: 41410, mediaId: 28219412 },
+  providerConfigId: 'bilibili',
+  indexedId: '41410',
+  title: '葬送的芙莉莲',
+  type: '番剧',
+  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
+  episodeCount: 28,
+  year: 2023,
+  schemaVersion: 1,
+}
+
+const COMMENTS: CommentEntity[] = [
+  { p: '1,1,16777215', m: 'first' },
+  { p: '2,1,16777215', m: 'second' },
+  { p: '3,1,16777215', m: 'third' },
+]
+
+function makeEpisode(seasonId: number): EpisodeInsert {
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
+    indexedId: '1300001',
+    title: 'Ep1',
+    episodeNumber: '1',
+    seasonId,
+    comments: COMMENTS,
+    commentCount: COMMENTS.length,
+    schemaVersion: 4,
+    lastChecked: 0,
+  }
+}
+
+test('deleting a provider orphans its season but keeps it viewable', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  await applyProfile(context, da, {
+    providers: { bilibili: { enabled: true } },
+    // The providers list probes Bilibili login status (/nav) on render.
+    network: [
+      {
+        pattern: /api\.bilibili\.com\/x\/web-interface\/nav/,
+        respond: (route) =>
+          route.fulfill({ json: { code: 0, data: { isLogin: false } } }),
+      },
+    ],
+  })
+
+  const season = await da.season.add(SEASON)
+  const ep = await da.episode.add(makeEpisode(season.id))
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  await popup.providers.deleteProvider('Bilibili')
+  await popup.dialog.confirm()
+  await popup.toast.expectSuccess(/Provider deleted|弹幕源已删除/)
+
+  expect((await da.season.get(season.id))?.id).toBe(season.id)
+  expect((await da.episode.get(ep.id))?.commentCount).toBe(COMMENTS.length)
+
+  await Popup.open(page, extensionId, '/mount')
+  const seasonItem = await popup.mount.waitForSeason(season.id)
+  await expect(popup.mount.seasonOrphanedBadge(season.id)).toBeVisible()
+
+  await popup.mount.expandSeason(season.id)
+  await expect(popup.mount.episodeCommentCount(ep.id)).toHaveText(
+    String(COMMENTS.length)
+  )
+
+  await popup.mount.openContextMenu(seasonItem)
+  const refresh = popup.mount.contextMenuItem('refresh')
+  await expect(refresh).toBeVisible()
+  await expect(refresh).toBeDisabled()
+})

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -361,8 +361,10 @@ export class RpcManager {
           // providerConfigId) so downloaded danmaku stays viewable. Bookmarks
           // are removed: they only exist to fetch new episodes, which an
           // orphaned season can no longer do.
-          await this.bookmarkService.deleteByProviderConfigId(id)
+          // deleteFromStorage throws if the config does not exist, so it runs
+          // first to keep a failed delete free of side effects.
           await this.providerConfigService.deleteFromStorage(id)
+          await this.bookmarkService.deleteByProviderConfigId(id)
 
           void invalidateContentScriptData(sender.tab?.id)
         },

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -357,9 +357,11 @@ export class RpcManager {
           return res.data
         },
         providerConfigDelete: async (id, sender) => {
-          // Deleting a config keeps its seasons, episodes, and bookmarks. They
-          // become orphaned (no config matches their providerConfigId) so the
-          // downloaded danmaku stays viewable; refresh is blocked downstream.
+          // Seasons and episodes are kept (orphaned: no config matches their
+          // providerConfigId) so downloaded danmaku stays viewable. Bookmarks
+          // are removed: they only exist to fetch new episodes, which an
+          // orphaned season can no longer do.
+          await this.bookmarkService.deleteByProviderConfigId(id)
           await this.providerConfigService.deleteFromStorage(id)
 
           void invalidateContentScriptData(sender.tab?.id)

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -24,7 +24,6 @@ import { ManifestRegistry } from '@/background/services/providers/ManifestRegist
 import { invalidateContentScriptData } from '@/background/utils/invalidateContentScriptData'
 import { AuthClientService } from '@/common/auth/AuthClientService'
 import type { EpisodeFetchBySeasonParams } from '@/common/danmaku/dto'
-import { DanmakuAnywhereDb } from '@/common/db/db'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import { MountConfigService } from '@/common/options/mountConfig/service'
@@ -67,7 +66,6 @@ export class RpcManager {
     @inject(EpisodeMatchingService)
     private episodeMatchingService: EpisodeMatchingService,
     @inject(LogService) private logService: LogService,
-    @inject(DanmakuAnywhereDb) private db: DanmakuAnywhereDb,
     @inject(LoggerSymbol) logger: ILogger,
     @inject(DebugFileService) private debugFileService: DebugFileService,
     @inject(ImageCacheService) private imageCacheService: ImageCacheService,
@@ -359,29 +357,9 @@ export class RpcManager {
           return res.data
         },
         providerConfigDelete: async (id, sender) => {
-          await this.db.transaction(
-            'rw',
-            this.db.season,
-            this.db.episode,
-            this.db.bookmark,
-            async () => {
-              const seasons = await this.db.season
-                .where({ providerConfigId: id })
-                .toArray()
-              const seasonIds = seasons.map((s) => s.id)
-
-              if (seasonIds.length > 0) {
-                await this.db.episode
-                  .where('seasonId')
-                  .anyOf(seasonIds)
-                  .delete()
-                await this.bookmarkService.deleteBySeasonIds(seasonIds)
-              }
-
-              await this.db.season.where({ providerConfigId: id }).delete()
-            }
-          )
-
+          // Deleting a config keeps its seasons, episodes, and bookmarks. They
+          // become orphaned (no config matches their providerConfigId) so the
+          // downloaded danmaku stays viewable; refresh is blocked downstream.
           await this.providerConfigService.deleteFromStorage(id)
 
           void invalidateContentScriptData(sender.tab?.id)

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
@@ -80,13 +80,6 @@ export class BookmarkService {
     await this.db.bookmark.where({ seasonId }).delete()
   }
 
-  async deleteBySeasonIds(seasonIds: number[]): Promise<void> {
-    if (seasonIds.length === 0) {
-      return
-    }
-    await this.db.bookmark.where('seasonId').anyOf(seasonIds).delete()
-  }
-
   async getAll(): Promise<Bookmark[]> {
     return this.db.bookmark.toArray()
   }

--- a/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/BookmarkService.ts
@@ -80,6 +80,10 @@ export class BookmarkService {
     await this.db.bookmark.where({ seasonId }).delete()
   }
 
+  async deleteByProviderConfigId(providerConfigId: string): Promise<void> {
+    await this.db.bookmark.where({ providerConfigId }).delete()
+  }
+
   async getAll(): Promise<Bookmark[]> {
     return this.db.bookmark.toArray()
   }

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -66,7 +66,11 @@ function makeProvider(
 function build(
   config: ProviderConfig,
   provider: IDanmakuProvider,
-  opts: { findExisting?: unknown; existingDanmaku?: unknown[] } = {}
+  opts: {
+    findExisting?: unknown
+    existingDanmaku?: unknown[]
+    configMissing?: boolean
+  } = {}
 ) {
   const danmakuService = {
     filter: vi.fn(async () => opts.existingDanmaku ?? []),
@@ -88,6 +92,7 @@ function build(
 
   const providerConfigService = {
     mustGet: vi.fn(async () => config),
+    get: vi.fn(async () => (opts.configMissing ? undefined : config)),
   } as unknown as ProviderConfigService
 
   const factory = vi.fn(() => provider)
@@ -221,6 +226,20 @@ describe('ProviderService legacy-maccms decoupling', () => {
       )
       expect(provider.getEpisodes).not.toHaveBeenCalled()
     })
+
+    it('throws a source-removed error when the season is orphaned', async () => {
+      const provider = makeProvider()
+      const { service } = build(
+        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
+        provider,
+        { configMissing: true }
+      )
+
+      await expect(service.fetchEpisodesBySeason(1)).rejects.toThrow(
+        'This source has been removed'
+      )
+      expect(provider.getEpisodes).not.toHaveBeenCalled()
+    })
   })
 
   describe('searchSeason', () => {
@@ -328,6 +347,24 @@ describe('ProviderService legacy-maccms decoupling', () => {
       await expect(
         service.getDanmaku({ type: 'by-meta', meta: maccmsMeta, options: {} })
       ).rejects.toThrow('MacCMS episodes are not refetchable')
+      expect(provider.getDanmaku).not.toHaveBeenCalled()
+    })
+
+    it('throws a source-removed error when forcing an orphaned season', async () => {
+      const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
+      const { service } = build(
+        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
+        provider,
+        { configMissing: true }
+      )
+
+      await expect(
+        service.getDanmaku({
+          type: 'by-meta',
+          meta,
+          options: { forceUpdate: true },
+        })
+      ).rejects.toThrow('This source has been removed')
       expect(provider.getDanmaku).not.toHaveBeenCalled()
     })
   })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -104,13 +104,29 @@ export class ProviderService {
     return this.seasonService.upsert(data)
   }
 
+  // Resolves the config a season was saved under, raising a clear "source
+  // removed" error when the config has been deleted (the season is orphaned).
+  // The UI blocks refresh affordances for orphaned seasons, so this is the
+  // fallback for any path that still reaches a provider call.
+  private async getConfigForSeason(
+    providerConfigId: string
+  ): Promise<ProviderConfig> {
+    const config = await this.providerConfigService.get(providerConfigId)
+    if (!config) {
+      throw new Error(
+        'This source has been removed. Re-add it to refresh or fetch new danmaku.'
+      )
+    }
+    return config
+  }
+
   async fetchEpisodesBySeason(
     seasonId: number
   ): Promise<WithSeason<EpisodeMeta>[]> {
     await this.manifestRegistry.ready
     const season = await this.seasonService.mustGetById(seasonId)
 
-    const providerConfig = await this.providerConfigService.mustGet(
+    const providerConfig = await this.getConfigForSeason(
       season.providerConfigId
     )
 
@@ -127,7 +143,7 @@ export class ProviderService {
     await this.manifestRegistry.ready
     const [season] = await this.seasonService.filter(filter)
 
-    const providerConfig = await this.providerConfigService.mustGet(
+    const providerConfig = await this.getConfigForSeason(
       season.providerConfigId
     )
 
@@ -186,9 +202,7 @@ export class ProviderService {
       this.logger.debug('Danmaku not found in db, fetching from server')
     }
 
-    const config = await this.providerConfigService.mustGet(
-      meta.season.providerConfigId
-    )
+    const config = await this.getConfigForSeason(meta.season.providerConfigId)
 
     if (config.manifestId === LEGACY_MACCMS_ID) {
       throw new Error('MacCMS episodes are not refetchable')

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -114,7 +114,7 @@ export class ProviderService {
     const config = await this.providerConfigService.get(providerConfigId)
     if (!config) {
       throw new Error(
-        'This source has been removed. Re-add it to refresh or fetch new danmaku.'
+        'This source has been removed, so new danmaku cannot be fetched.'
       )
     }
     return config

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -142,6 +142,9 @@ export class ProviderService {
   async refreshSeason(filter: SeasonQueryFilter) {
     await this.manifestRegistry.ready
     const [season] = await this.seasonService.filter(filter)
+    if (!season) {
+      throw new Error('No season found for refresh filter')
+    }
 
     const providerConfig = await this.getConfigForSeason(
       season.providerConfigId

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/ExtendedTreeItem.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/ExtendedTreeItem.ts
@@ -11,6 +11,9 @@ interface SeasonTreeItem extends TreeViewDefaultItemModelProperties {
   kind: 'season'
   data: Season | CustomSeason
   provider?: ProviderConfig
+  // True when the season's provider config has been deleted: the season stays
+  // viewable, but refresh is blocked since there is no source to re-fetch from.
+  orphaned?: boolean
   bookmarked?: boolean
   children?: ExtendedTreeItem[]
 }

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/ExtendedTreeItem.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/ExtendedTreeItem.ts
@@ -21,6 +21,7 @@ interface SeasonTreeItem extends TreeViewDefaultItemModelProperties {
 interface EpisodeTreeItem extends TreeViewDefaultItemModelProperties {
   kind: 'episode'
   data: GenericEpisodeLite
+  orphaned?: boolean
   children?: ExtendedTreeItem[]
 }
 

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/DanmakuTreeItem.tsx
@@ -113,6 +113,7 @@ export const DanmakuTreeItem = forwardRef(function CustomTreeItem(
         <SeasonTreeItem
           season={item.data}
           provider={item.provider}
+          orphaned={item.orphaned}
           fetchedCount={fetchedCount}
           stubCount={stubCount}
           bookmarked={item.bookmarked}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/SeasonTreeItem.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/items/SeasonTreeItem.tsx
@@ -2,6 +2,7 @@ import type { CustomSeason, Season } from '@danmaku-anywhere/danmaku-converter'
 import { Favorite, Folder } from '@mui/icons-material'
 import { Chip, Skeleton, Stack, styled, Typography } from '@mui/material'
 import { type ReactElement, Suspense } from 'react'
+import { useTranslation } from 'react-i18next'
 import { isNotCustom } from '@/common/danmaku/utils'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import { SuspenseImage } from '../../../image/SuspenseImage'
@@ -41,6 +42,7 @@ const SeasonThumbnail = ({
 interface SeasonTreeItemProps {
   season: Season | CustomSeason
   provider?: ProviderConfig
+  orphaned?: boolean
   fetchedCount?: number
   stubCount?: number
   bookmarked?: boolean
@@ -49,10 +51,12 @@ interface SeasonTreeItemProps {
 export const SeasonTreeItem = ({
   season,
   provider,
+  orphaned,
   fetchedCount,
   stubCount,
   bookmarked,
 }: SeasonTreeItemProps): ReactElement => {
+  const { t } = useTranslation()
   const isCustom = !isNotCustom(season)
 
   const renderCounts = () => {
@@ -129,6 +133,15 @@ export const SeasonTreeItem = ({
               label={provider.name}
               size="small"
               variant="outlined"
+            />
+          )}
+          {orphaned && (
+            <ProviderChip
+              label={t('anime.sourceRemoved', 'Source removed')}
+              size="small"
+              variant="outlined"
+              color="warning"
+              data-testid="season-orphaned-badge"
             />
           )}
           {renderCounts()}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/DanmakuContextMenu.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/DanmakuContextMenu.tsx
@@ -35,7 +35,11 @@ export const DanmakuContextMenu = ({
 
   const element =
     item.kind === 'season' ? (
-      <SeasonContextMenuContainer season={item.data} itemId={item.id} />
+      <SeasonContextMenuContainer
+        season={item.data}
+        itemId={item.id}
+        orphaned={item.orphaned}
+      />
     ) : (
       <EpisodeContextMenuContainer episode={item.data} itemId={item.id} />
     )

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/DanmakuContextMenu.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/DanmakuContextMenu.tsx
@@ -41,7 +41,11 @@ export const DanmakuContextMenu = ({
         orphaned={item.orphaned}
       />
     ) : (
-      <EpisodeContextMenuContainer episode={item.data} itemId={item.id} />
+      <EpisodeContextMenuContainer
+        episode={item.data}
+        itemId={item.id}
+        orphaned={item.orphaned}
+      />
     )
 
   return <StyledBox>{element}</StyledBox>

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/EpisodeContextMenuContainer.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/EpisodeContextMenuContainer.tsx
@@ -13,11 +13,13 @@ import { EpisodeContextMenuPure } from './EpisodeContextMenuPure'
 interface EpisodeContextMenuContainerProps {
   episode: GenericEpisodeLite
   itemId: string
+  orphaned?: boolean
 }
 
 export const EpisodeContextMenuContainer = ({
   episode,
   itemId,
+  orphaned,
 }: EpisodeContextMenuContainerProps): ReactElement => {
   const { t } = useTranslation()
   const { mutateAsync: load, isPending } = useFetchDanmaku()
@@ -95,7 +97,7 @@ export const EpisodeContextMenuContainer = ({
 
   return (
     <EpisodeContextMenuPure
-      canRefresh={isNotCustom(episode)}
+      canRefresh={isNotCustom(episode) && !orphaned}
       isRefreshing={isPending}
       onViewDanmaku={() => setViewingDanmaku(episode)}
       onRefresh={handleFetchDanmaku}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/SeasonContextMenuContainer.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/SeasonContextMenuContainer.tsx
@@ -18,11 +18,13 @@ import { SeasonContextMenuPure } from './SeasonContextMenuPure'
 interface SeasonContextMenuContainerProps {
   season: Season | CustomSeason
   itemId: string
+  orphaned?: boolean
 }
 
 export const SeasonContextMenuContainer = ({
   season,
   itemId,
+  orphaned,
 }: SeasonContextMenuContainerProps): ReactElement => {
   const { t } = useTranslation()
   const { contextMenu, setContextMenu } = useDanmakuTreeContext()
@@ -115,6 +117,7 @@ export const SeasonContextMenuContainer = ({
       isExporting={exportXml.isPending || exportBackup.isPending}
       onRefresh={() => refreshSeason.mutate(season.id)}
       isRefreshing={refreshSeason.isPending}
+      orphaned={orphaned}
       bookmarked={isBookmarked}
       onBookmarkToggle={handleBookmarkToggle}
       onBookmarkRefresh={handleBookmarkRefresh}

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/SeasonContextMenuPure.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/SeasonContextMenuPure.tsx
@@ -78,10 +78,7 @@ export const SeasonContextMenuPure = ({
 
   if (isNotCustom(season)) {
     const sourceRemovedTooltip = orphaned
-      ? t(
-          'anime.sourceRemovedTooltip',
-          'This source was deleted. Re-add it to refresh.'
-        )
+      ? t('anime.sourceRemovedTooltip', 'This source has been deleted.')
       : undefined
 
     items.unshift({
@@ -124,6 +121,8 @@ export const SeasonContextMenuPure = ({
         icon: <FavoriteBorder fontSize="small" />,
         onClick: onBookmarkToggle,
         loading: isBookmarkLoading,
+        disabled: orphaned,
+        tooltip: sourceRemovedTooltip,
       })
     }
   }

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/SeasonContextMenuPure.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/menus/SeasonContextMenuPure.tsx
@@ -21,6 +21,7 @@ export interface SeasonContextMenuPureProps {
   onRefresh: () => void
   isRefreshing: boolean
   isExporting: boolean
+  orphaned?: boolean
   bookmarked: boolean
   onBookmarkToggle: () => void
   onBookmarkRefresh: () => void
@@ -37,6 +38,7 @@ export const SeasonContextMenuPure = ({
   onRefresh,
   isRefreshing,
   isExporting,
+  orphaned,
   bookmarked,
   onBookmarkToggle,
   onBookmarkRefresh,
@@ -75,6 +77,13 @@ export const SeasonContextMenuPure = ({
   ]
 
   if (isNotCustom(season)) {
+    const sourceRemovedTooltip = orphaned
+      ? t(
+          'anime.sourceRemovedTooltip',
+          'This source was deleted. Re-add it to refresh.'
+        )
+      : undefined
+
     items.unshift({
       kind: 'item',
       id: 'refresh',
@@ -82,6 +91,8 @@ export const SeasonContextMenuPure = ({
       icon: <Sync />,
       onClick: onRefresh,
       loading: isRefreshing,
+      disabled: orphaned,
+      tooltip: sourceRemovedTooltip,
     })
 
     if (bookmarked) {
@@ -93,6 +104,8 @@ export const SeasonContextMenuPure = ({
           icon: <Sync fontSize="small" />,
           onClick: onBookmarkRefresh,
           loading: isBookmarkLoading,
+          disabled: orphaned,
+          tooltip: sourceRemovedTooltip,
         },
         {
           kind: 'item',

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/useDanmakuTree.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/useDanmakuTree.ts
@@ -234,18 +234,20 @@ export const useDanmakuTree = (
         return
       }
 
+      const provider = getProviderById(season.providerConfigId)
+      const orphaned = !provider
+
       const children = groupEpisodes.map((ep) =>
         register({
           id: `episode-${ep.id}`,
           label: ep.title,
           kind: 'episode',
           data: ep,
+          orphaned,
         })
       )
 
       children.sort(compareEpisodes)
-
-      const provider = getProviderById(season.providerConfigId)
 
       treeItems.push(
         register({
@@ -254,7 +256,7 @@ export const useDanmakuTree = (
           kind: 'season',
           data: season,
           provider,
-          orphaned: !provider,
+          orphaned,
           children,
         })
       )

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/useDanmakuTree.ts
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/tree/useDanmakuTree.ts
@@ -245,13 +245,16 @@ export const useDanmakuTree = (
 
       children.sort(compareEpisodes)
 
+      const provider = getProviderById(season.providerConfigId)
+
       treeItems.push(
         register({
           id: `season-${season.id}`,
           label: season.title,
           kind: 'season',
           data: season,
-          provider: getProviderById(season.providerConfigId),
+          provider,
+          orphaned: !provider,
           children,
         })
       )
@@ -307,13 +310,15 @@ export const useDanmakuTree = (
         existingNode.children.sort(compareEpisodes)
         existingNode.bookmarked = true
       } else {
-        // Season has no fetched episodes — create node from stubs only
+        // Season has no fetched episodes, create node from stubs only
+        const provider = getProviderById(season.providerConfigId)
         const seasonNode = register({
           id: `season-${season.id}`,
           label: season.title,
           kind: 'season' as const,
           data: season,
-          provider: getProviderById(season.providerConfigId),
+          provider,
+          orphaned: !provider,
           bookmarked: true,
           children: stubNodes.sort(compareEpisodes),
         })

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -54,6 +54,8 @@
     "numericEpisode": "Episode {{episode}}",
     "numericSeason": "Season {{season}}",
     "refreshMetadata": "Refresh Metadata",
+    "sourceRemoved": "Source removed",
+    "sourceRemovedTooltip": "This source was deleted. Re-add it to refresh.",
     "title": "Title"
   },
   "bookmark": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -55,7 +55,7 @@
     "numericSeason": "Season {{season}}",
     "refreshMetadata": "Refresh Metadata",
     "sourceRemoved": "Source removed",
-    "sourceRemovedTooltip": "This source was deleted. Re-add it to refresh.",
+    "sourceRemovedTooltip": "This source has been deleted.",
     "title": "Title"
   },
   "bookmark": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -55,7 +55,7 @@
     "numericSeason": "第{{season}}季",
     "refreshMetadata": "刷新元数据",
     "sourceRemoved": "来源已删除",
-    "sourceRemovedTooltip": "该来源已被删除，重新添加后才能刷新。",
+    "sourceRemovedTooltip": "该来源已被删除。",
     "title": "标题"
   },
   "bookmark": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -54,6 +54,8 @@
     "numericEpisode": "第{{episode}}集",
     "numericSeason": "第{{season}}季",
     "refreshMetadata": "刷新元数据",
+    "sourceRemoved": "来源已删除",
+    "sourceRemovedTooltip": "该来源已被删除，重新添加后才能刷新。",
     "title": "标题"
   },
   "bookmark": {

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -185,8 +185,8 @@ export class ProviderConfigService implements IStoreService {
   }
 
   async delete(id: string) {
-    // Deletion involves deleting seasons and episodes, which must be done in the background script
-    // So this method just calls the background script to do the deletion
+    // Routed through the background script so the deletion runs where the DB
+    // lives and content scripts get invalidated. Seasons/episodes are kept.
     await chromeRpcClient.providerConfigDelete(id)
   }
 

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -185,8 +185,6 @@ export class ProviderConfigService implements IStoreService {
   }
 
   async delete(id: string) {
-    // Routed through the background script so the deletion runs where the DB
-    // lives and content scripts get invalidated. Seasons/episodes are kept.
     await chromeRpcClient.providerConfigDelete(id)
   }
 

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/useProviderConfig.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/useProviderConfig.ts
@@ -2,7 +2,7 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useInjectService } from '@/common/hooks/useInjectService'
-import { storageQueryKeys } from '@/common/queries/queryKeys'
+import { bookmarkQueryKeys, storageQueryKeys } from '@/common/queries/queryKeys'
 import { useSuspenseExtStorageQuery } from '@/common/storage/hooks/useSuspenseExtStorageQuery'
 import type { ProviderConfig, ProviderConfigOptions } from './schema'
 import { ProviderConfigService } from './service'
@@ -64,7 +64,9 @@ export const useEditProviderConfig = () => {
 
   const deleteMutation = useMutation({
     mutationFn: providerConfigService.delete.bind(providerConfigService),
-    meta,
+    // Deleting a config also deletes its bookmarks in the background, so the
+    // bookmark cache must refetch or the tree keeps showing dead stubs.
+    meta: { invalidates: [queryKey, bookmarkQueryKeys.all()] },
   })
 
   const toggleMutation = useMutation({


### PR DESCRIPTION
## Summary
- Deleting a provider config now removes only the config and its bookmarks. Its seasons and episodes are kept (drop the cascade in `RpcManager.providerConfigDelete`).
- Such seasons become **orphaned** (no config owns their `providerConfigId`). Orphan state is derived in the library tree, not stored: no flag, no migration.
- Orphaned seasons stay fully viewable (cached danmaku renders) but cannot fetch anything new:
  - season menu: Refresh Metadata and Follow disabled (with a "source deleted" tooltip), "Source removed" badge on the row
  - episode menu: Refresh Danmaku entry is removed
  - bookmarks are deleted with the config (they only exist to fetch new episodes, which an orphaned season can no longer do), so no dead stub rows survive; the delete mutation invalidates the bookmark cache
- `ProviderService` (episode re-fetch / danmaku force-update / season refresh) raises a clear "source has been removed" error instead of `mustGet`'s raw throw, as a fallback for any path that still reaches a provider call.

## Test plan
- Verified: lint (tsc + biome + i18n check) pass · unit tests `pnpm vitest run` 551 passed · e2e `e2e/specs/mount` + `e2e/specs/providers` 20 passed (incl. the new spec)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- e2e/specs/mount/orphaned-season.spec.ts` — bookmark a season, delete its provider: season survives + renders cached comments, badge shows, bookmark + stubs gone, season refresh + Follow disabled, episode menu has no refresh.
- [ ] Sanity: `e2e/specs/mount/refresh-metadata.spec.ts`, `e2e/specs/mount/bookmark.spec.ts`, `e2e/specs/mount/delete.spec.ts` (shared tree/menu components changed).

## Notes
- The error/tooltip copy deliberately does not suggest re-adding the source: re-imported configs get fresh random ids, so seasons would not reattach. Linking orphaned seasons back to a re-added source needs a season-to-manifest link (seasons do not store `manifestId` today) and is a follow-up.
- Known interactions left for follow-ups: opt-in retention purge can delete orphaned episodes that cannot be refetched; orphaned seasons with no cached episodes are unreachable in the UI (no GC path); `EpisodeResolutionService` still throws the old `mustGet` message on the match-by-seasonId path.