### PR TITLE
(extension) drop unknown comment modes instead of throwing [DA-644]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/integration/unknown-mode-drop.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/unknown-mode-drop.spec.ts
@@ -1,0 +1,86 @@
+import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
+import { IntegrationPage } from '../../pom/IntegrationPage'
+import type { DaClient } from '../../setup/da-client'
+import { expect, test } from '../../setup/fixtures'
+import {
+  buildFixtureIntegrationPolicy,
+  seedXPathIntegration,
+} from '../../setup/integration'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * A seeded batch carrying one comment with an unknown mode renders its valid
+ * comments and silently drops the malformed one. Guards the parser throwing on
+ * an unrecognized mode, which would break rendering of the whole batch. The
+ * console-error baseline asserts no error surfaces from the dropped comment.
+ */
+
+const ORIGIN = 'https://da-test.invalid'
+const NATIVE_URL = `${ORIGIN}/native/`
+const MOUNT_PATTERN = `${ORIGIN}/*`
+
+const EPISODE_TITLE = 'DA Integration Test'
+const VALID_TEXT = 'valid-comment'
+const INVALID_TEXT = 'unknown-mode-comment'
+// Both sit at the same timestamp, so a dropped-vs-rendered comparison is fair.
+const COMMENTS = [
+  { p: '12,99,16777215,bad', m: INVALID_TEXT },
+  { p: '12,1,16777215,e2e-1', m: VALID_TEXT },
+]
+const SEEK_TIME_S = 15
+
+async function seedFixtureProfile(
+  context: import('@playwright/test').BrowserContext,
+  da: DaClient
+): Promise<{ episodeId: number }> {
+  await applyProfile(context, da, {
+    extensionOptions: { matchLocalDanmaku: true },
+  })
+
+  const customEpisode = await da.episode.addCustom({
+    provider: DanmakuSourceType.MacCMS,
+    title: EPISODE_TITLE,
+    comments: COMMENTS,
+    commentCount: COMMENTS.length,
+    schemaVersion: 4,
+  })
+
+  await seedXPathIntegration(da, {
+    patterns: [MOUNT_PATTERN],
+    name: 'da-e2e',
+    policy: buildFixtureIntegrationPolicy(),
+  })
+
+  await da.mount.waitForRegistration(MOUNT_PATTERN, 5_000)
+
+  return { episodeId: customEpisode.id }
+}
+
+test('unknown comment mode is dropped without breaking the batch', async ({
+  context,
+  page,
+  da,
+}) => {
+  const { episodeId } = await seedFixtureProfile(context, da)
+
+  const integrationPage = new IntegrationPage(page)
+  await page.bringToFront()
+  await integrationPage.open(NATIVE_URL, 'native-video.html')
+
+  const mirror = await da.mount.waitForMount(undefined, 15_000)
+  expect(mirror.isMounted).toBe(true)
+  expect(mirror.episodeIds).toEqual([episodeId])
+
+  await integrationPage.playVideo()
+
+  await expect(async () => {
+    await integrationPage.setVideoTime(SEEK_TIME_S)
+    await expect(
+      integrationPage.commentElements().filter({ hasText: VALID_TEXT })
+    ).toBeVisible({ timeout: 1_000 })
+  }).toPass({ timeout: 15_000 })
+
+  await expect(
+    integrationPage.commentElements().filter({ hasText: INVALID_TEXT })
+  ).toHaveCount(0)
+})

--- a/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
+++ b/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
@@ -145,17 +145,23 @@ export const CommentsTable = ({
   const [hoverRow, setHoverRow] = useState<number>()
   const [filter, setFilter] = useState('')
 
-  const timeOf = useMemo(() => {
-    const map = new Map<CommentEntity, number>()
+  const { validComments, timeOf } = useMemo(() => {
+    const timeByComment = new Map<CommentEntity, number>()
+    const valid: CommentEntity[] = []
     for (const c of comments) {
       const options = parseCommentEntityP(c.p)
-      if (options) map.set(c, options.time)
+      if (!options) continue
+      timeByComment.set(c, options.time)
+      valid.push(c)
     }
-    return (c: CommentEntity) => map.get(c) ?? 0
+    return {
+      validComments: valid,
+      timeOf: (c: CommentEntity) => timeByComment.get(c) ?? 0,
+    }
   }, [comments])
 
   const { decisionByComment, headLabelByIndex } = useMemo(() => {
-    const inTimeOrder = comments.toSorted((a, b) => timeOf(a) - timeOf(b))
+    const inTimeOrder = validComments.toSorted((a, b) => timeOf(a) - timeOf(b))
     const { decisions } = compile(
       inTimeOrder.map((c) => ({ text: c.m, time: timeOf(c) })),
       {
@@ -174,7 +180,7 @@ export const CommentsTable = ({
     })
     return { decisionByComment, headLabelByIndex }
   }, [
-    comments,
+    validComments,
     timeOf,
     danmakuOptions.filters,
     danmakuOptions.collapse,
@@ -183,7 +189,7 @@ export const CommentsTable = ({
 
   const filteredComments = useMemo(() => {
     const keyword = filter.trim().toLowerCase()
-    const withDecision = comments.map((c) => ({
+    const withDecision = validComments.map((c) => ({
       comment: c,
       decision: decisionByComment.get(c) ?? ({ kind: 'normal' } as Decision),
     }))
@@ -191,7 +197,7 @@ export const CommentsTable = ({
     return withDecision.filter(({ comment }) =>
       comment.m.toLowerCase().includes(keyword)
     )
-  }, [comments, decisionByComment, filter])
+  }, [validComments, decisionByComment, filter])
 
   const sortedComments = useMemo(() => {
     return match(orderBy)

--- a/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
+++ b/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
@@ -147,7 +147,10 @@ export const CommentsTable = ({
 
   const timeOf = useMemo(() => {
     const map = new Map<CommentEntity, number>()
-    for (const c of comments) map.set(c, parseCommentEntityP(c.p).time)
+    for (const c of comments) {
+      const options = parseCommentEntityP(c.p)
+      if (options) map.set(c, options.time)
+    }
     return (c: CommentEntity) => map.get(c) ?? 0
   }, [comments])
 

--- a/packages/danmaku-converter/src/canonical/comment/utils.test.ts
+++ b/packages/danmaku-converter/src/canonical/comment/utils.test.ts
@@ -26,4 +26,8 @@ describe('comment entity conversion', () => {
 
     expect(p).toEqual(commentEntity.p)
   })
+
+  it('should return null for an unknown mode', () => {
+    expect(parseCommentEntityP('658.73,99,16777215,0')).toBeNull()
+  })
 })

--- a/packages/danmaku-converter/src/canonical/comment/utils.ts
+++ b/packages/danmaku-converter/src/canonical/comment/utils.ts
@@ -16,11 +16,12 @@ export const parseCommentGradient = (s: string) => {
 }
 
 // convert string to object
-export const parseCommentEntityP = (p: string): CommentOptions => {
+// returns null on an unrecognized mode so callers can drop the comment instead of throwing
+export const parseCommentEntityP = (p: string): CommentOptions | null => {
   const [time, mode, color, uid = ''] = p.split(',')
 
   if (!CommentMode[Number.parseInt(mode)]) {
-    throw new Error(`Invalid mode: ${mode}`)
+    return null
   }
 
   return {

--- a/packages/danmaku-engine/src/DanmakuRenderer.ts
+++ b/packages/danmaku-engine/src/DanmakuRenderer.ts
@@ -69,6 +69,7 @@ export class DanmakuRenderer {
     )
     const sampledGenerator = sampleByTime(
       Array.from(commentGenerator)
+        .filter((comment) => comment !== null)
         .toSorted((a, b) => a.time - b.time)
         .values(),
       Number.POSITIVE_INFINITY,

--- a/packages/danmaku-engine/src/parser.test.ts
+++ b/packages/danmaku-engine/src/parser.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { applyFilter, filterComments } from './parser'
+import { applyFilter, filterComments, transformComment } from './parser'
 
 /**
- * Exercises the pure filter primitives the engine and renderer share.
- * Asserts text-includes vs regex semantics, the enabled flag, and that
- * filterComments drops everything matched by any enabled filter.
+ * Exercises the pure filter primitives the engine and renderer share,
+ * plus transformComment. Asserts text-includes vs regex semantics, the
+ * enabled flag, that filterComments drops everything matched by any
+ * enabled filter, and that a comment with an unknown mode is dropped
+ * (null) rather than throwing.
  */
+
+describe('transformComment', () => {
+  it('parses a valid comment', () => {
+    const parsed = transformComment({ p: '10,1,16777215,0', m: 'hi' }, 0)
+    expect(parsed).toMatchObject({ text: 'hi', mode: 'rtl', time: 10 })
+  })
+
+  it('returns null for an unknown mode', () => {
+    expect(transformComment({ p: '10,99,16777215,0', m: 'hi' }, 0)).toBeNull()
+  })
+})
 
 describe('applyFilter', () => {
   it('matches text via includes', () => {

--- a/packages/danmaku-engine/src/parser.ts
+++ b/packages/danmaku-engine/src/parser.ts
@@ -56,9 +56,15 @@ export interface DanmakuOption {
 export const transformComment = (
   comment: CommentEntity,
   offset: number
-): ParsedComment => {
+): ParsedComment | null => {
   const { p, m, s } = comment
-  const { time, mode, color } = parseCommentEntityP(p)
+  const options = parseCommentEntityP(p)
+
+  if (!options) {
+    return null
+  }
+
+  const { time, mode, color } = options
   const offsetTime = time + offset / 1000
 
   const parsed: ParsedComment = {

--- a/packages/danmaku-provider/src/providers/ddp/api.ts
+++ b/packages/danmaku-provider/src/providers/ddp/api.ts
@@ -268,8 +268,10 @@ export const commentGetCommentManualWithRelated = async (
               // if the shift is not 0, we need to adjust the time of the comments
               if (entry.shift !== 0) {
                 const options = parseCommentEntityP(comment.p)
-                options.time += entry.shift
-                comment.p = commentOptionsToString(options)
+                if (options) {
+                  options.time += entry.shift
+                  comment.p = commentOptionsToString(options)
+                }
               }
 
               comments.push(comment)


### PR DESCRIPTION
## Summary
- `parseCommentEntityP` now returns `null` for a comment whose `p` mode is not in `CommentMode` (ltr/rtl/top/bottom) instead of throwing `Invalid mode`. A single malformed comment no longer breaks parsing/rendering of the rest of the batch.
- Callers updated to handle the nullable result: `transformComment` returns `null`, the `DanmakuRenderer` pipeline filters dropped comments before sorting, the ddp time-shift path keeps the comment unchanged when it can't parse, and `CommentsTable` skips the time entry.
- Unknown modes are silently dropped (excluded), not defaulted to rtl.

## Test plan
- Verified: lint (tsc + biome) pass · tests `pnpm --filter` converter/engine/provider -> 124 passed · e2e `specs/integration/unknown-mode-drop.spec.ts` -> 1 passed
- [ ] `pnpm --filter @danmaku-anywhere/danmaku-converter --filter @danmaku-anywhere/danmaku-engine --filter @danmaku-anywhere/danmaku-provider test`
- [ ] `cd packages/danmaku-anywhere && pnpm test:e2e -- specs/integration/unknown-mode-drop.spec.ts`

## Notes
- The new e2e seeds a batch with one unknown-mode comment alongside valid ones and asserts the valid comment renders while the malformed one never does; the suite's console-error baseline covers "no console error for unknown modes".