### PR TITLE
(extension) e2e: bookmark seeding, build freshness guard, shared bilibili fixtures [DA-646]

### DIFF
--- a/packages/danmaku-anywhere/e2e/network/loginProbes.ts
+++ b/packages/danmaku-anywhere/e2e/network/loginProbes.ts
@@ -4,16 +4,13 @@ import type { NetworkMock } from '../setup/profile'
 // Specs that visit /providers mock the probes so network strict-mode and the
 // console gate stay clean. The tencent mock is inert when tencent is not in
 // the profile.
-export function mockLoginProbes(
-  opts: { bilibiliLoggedIn?: boolean } = {}
-): NetworkMock[] {
-  const { bilibiliLoggedIn = true } = opts
+export function mockLoginProbes(): NetworkMock[] {
   return [
     {
       pattern: /api\.bilibili\.com\/x\/web-interface\/nav/,
       respond: (route) =>
         route.fulfill({
-          json: { code: 0, message: '0', data: { isLogin: bilibiliLoggedIn } },
+          json: { code: 0, message: '0', data: { isLogin: true } },
         }),
     },
     {

--- a/packages/danmaku-anywhere/e2e/network/loginProbes.ts
+++ b/packages/danmaku-anywhere/e2e/network/loginProbes.ts
@@ -1,0 +1,26 @@
+import type { NetworkMock } from '../setup/profile'
+
+// The providers list runs each configured provider's login probe on render.
+// Specs that visit /providers mock the probes so network strict-mode and the
+// console gate stay clean. The tencent mock is inert when tencent is not in
+// the profile.
+export function mockLoginProbes(
+  opts: { bilibiliLoggedIn?: boolean } = {}
+): NetworkMock[] {
+  const { bilibiliLoggedIn = true } = opts
+  return [
+    {
+      pattern: /api\.bilibili\.com\/x\/web-interface\/nav/,
+      respond: (route) =>
+        route.fulfill({
+          json: { code: 0, message: '0', data: { isLogin: bilibiliLoggedIn } },
+        }),
+    },
+    {
+      pattern:
+        /pbaccess\.video\.qq\.com\/.*page_server_rpc\.PageServer\/GetPageData/,
+      respond: (route) =>
+        route.fulfill({ json: { ret: 0, msg: '', data: {} } }),
+    },
+  ]
+}

--- a/packages/danmaku-anywhere/e2e/pom/Popup.ts
+++ b/packages/danmaku-anywhere/e2e/pom/Popup.ts
@@ -46,6 +46,11 @@ export class Popup {
   ): Promise<Popup> {
     // detached=1 makes the popup fill the viewport instead of its fixed 500px
     // box, so a narrow viewport can exercise width-dependent layout.
+    //
+    // Calling open() again with a different hashRoute is a same-document
+    // navigation: the SPA and its React Query cache survive, exactly like a
+    // user switching tabs inside the popup. Stale-cache bugs are reachable
+    // this way; use page.reload() if a spec needs a cold popup instead.
     const query = opts.detached ? '?detached=1' : ''
     await page.goto(
       `chrome-extension://${extensionId}/pages/popup.html${query}#${hashRoute}`

--- a/packages/danmaku-anywhere/e2e/setup/bilibiliSeed.ts
+++ b/packages/danmaku-anywhere/e2e/setup/bilibiliSeed.ts
@@ -29,7 +29,6 @@ export function makeBilibiliSeason(
 interface BilibiliEpisodeOpts {
   cid?: number
   episodeNumber?: string
-  title?: string
   comments?: CommentEntity[]
 }
 
@@ -40,17 +39,12 @@ export function makeBilibiliEpisode(
   seasonId: number,
   opts: BilibiliEpisodeOpts = {}
 ): EpisodeInsert {
-  const {
-    cid = 1300001,
-    episodeNumber = '1',
-    title = `Ep${episodeNumber}`,
-    comments = [],
-  } = opts
+  const { cid = 1300001, episodeNumber = '1', comments = [] } = opts
   return {
     provider: DanmakuSourceType.Bilibili,
     providerIds: { cid, aid: 100000 + cid, bvid: `BV${cid}` },
     indexedId: String(cid),
-    title,
+    title: `Ep${episodeNumber}`,
     episodeNumber,
     seasonId,
     comments,

--- a/packages/danmaku-anywhere/e2e/setup/bilibiliSeed.ts
+++ b/packages/danmaku-anywhere/e2e/setup/bilibiliSeed.ts
@@ -1,0 +1,61 @@
+import {
+  type CommentEntity,
+  DanmakuSourceType,
+  type EpisodeInsert,
+  type SeasonInsert,
+} from '@danmaku-anywhere/danmaku-converter'
+
+// Canonical Bilibili season for mount-tree specs. providerIds/indexedId line
+// up with e2e/fixtures/bilibili-season.json so upstream calls mocked with that
+// fixture resolve against this season.
+export function makeBilibiliSeason(
+  overrides: Partial<SeasonInsert> = {}
+): SeasonInsert {
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { seasonId: 41410, mediaId: 28219412 },
+    providerConfigId: 'bilibili',
+    indexedId: '41410',
+    title: '葬送的芙莉莲',
+    type: '番剧',
+    imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
+    episodeCount: 28,
+    year: 2023,
+    schemaVersion: 1,
+    ...overrides,
+  }
+}
+
+interface BilibiliEpisodeOpts {
+  cid?: number
+  episodeNumber?: string
+  title?: string
+  comments?: CommentEntity[]
+}
+
+// The default cid matches the season fixture's first episode, so a bookmark
+// snapshot dedups it and leaves the fixture's second episode as the only
+// unfetched stub.
+export function makeBilibiliEpisode(
+  seasonId: number,
+  opts: BilibiliEpisodeOpts = {}
+): EpisodeInsert {
+  const {
+    cid = 1300001,
+    episodeNumber = '1',
+    title = `Ep${episodeNumber}`,
+    comments = [],
+  } = opts
+  return {
+    provider: DanmakuSourceType.Bilibili,
+    providerIds: { cid, aid: 100000 + cid, bvid: `BV${cid}` },
+    indexedId: String(cid),
+    title,
+    episodeNumber,
+    seasonId,
+    comments,
+    commentCount: comments.length,
+    schemaVersion: 4,
+    lastChecked: 0,
+  }
+}

--- a/packages/danmaku-anywhere/e2e/setup/da-client.ts
+++ b/packages/danmaku-anywhere/e2e/setup/da-client.ts
@@ -4,6 +4,7 @@ import type {
   CustomEpisodeInsert,
   Episode,
   EpisodeInsert,
+  EpisodeStub,
   Season,
   SeasonInsert,
 } from '@danmaku-anywhere/danmaku-converter'
@@ -113,6 +114,11 @@ export class DaClient {
       this.sw.evaluate(() => self.__da.bookmark.list()),
     bySeason: (seasonId: number): Promise<Bookmark | undefined> =>
       this.sw.evaluate((id) => self.__da.bookmark.bySeason(id), seasonId),
+    add: (seasonId: number, episodes?: EpisodeStub[]): Promise<Bookmark> =>
+      this.sw.evaluate(([id, eps]) => self.__da.bookmark.add(id, eps), [
+        seasonId,
+        episodes,
+      ] as const),
     deleteBySeason: (seasonId: number): Promise<void> =>
       this.sw.evaluate((id) => self.__da.bookmark.deleteBySeason(id), seasonId),
   }

--- a/packages/danmaku-anywhere/e2e/setup/globalSetup.ts
+++ b/packages/danmaku-anywhere/e2e/setup/globalSetup.ts
@@ -1,0 +1,92 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Refuses to run the suite against a stale or wrong-env build/. The pretest
+// hook only fires via `pnpm test:e2e`; a direct `playwright test <spec>`
+// silently loads whatever build/ holds, which looks like phantom test results.
+// Compares the newest build-input mtime against the timestamp the da:build-info
+// vite plugin stamped into build/build-info.json.
+
+const PKG_ROOT = path.join(__dirname, '..', '..')
+const BUILD_DIR = path.join(PKG_ROOT, 'build')
+
+// Build inputs only: e2e/ changes never require a rebuild.
+const WATCHED = [
+  'src',
+  'public',
+  'manifest.ts',
+  'vite.config.ts',
+  'package.json',
+  'scripts',
+]
+
+const REBUILD_HINT =
+  'Rebuild with: VITE_DA_ENV=e2e pnpm run build (or run the full suite via pnpm test:e2e). ' +
+  'Set DA_E2E_ALLOW_STALE_BUILD=1 to skip this check.'
+
+interface NewestFile {
+  filePath: string
+  mtimeMs: number
+}
+
+function newestMtime(target: string): NewestFile | undefined {
+  let stat: ReturnType<typeof statSync>
+  try {
+    stat = statSync(target)
+  } catch {
+    return undefined
+  }
+  if (stat.isFile()) {
+    return { filePath: target, mtimeMs: stat.mtimeMs }
+  }
+  let newest: NewestFile | undefined
+  for (const entry of readdirSync(target)) {
+    const candidate = newestMtime(path.join(target, entry))
+    if (candidate && (!newest || candidate.mtimeMs > newest.mtimeMs)) {
+      newest = candidate
+    }
+  }
+  return newest
+}
+
+export default function globalSetup(): void {
+  if (process.env.DA_E2E_ALLOW_STALE_BUILD) {
+    console.warn('[e2e] DA_E2E_ALLOW_STALE_BUILD set, skipping freshness check')
+    return
+  }
+
+  let info: { daEnv?: string; builtAt?: number }
+  try {
+    info = JSON.parse(
+      readFileSync(path.join(BUILD_DIR, 'build-info.json'), 'utf8')
+    )
+  } catch {
+    throw new Error(
+      `[e2e] build/ has no readable build-info.json. ${REBUILD_HINT}`
+    )
+  }
+
+  if (info.daEnv !== 'e2e') {
+    throw new Error(
+      `[e2e] build/ was built with VITE_DA_ENV=${info.daEnv}, not e2e. ${REBUILD_HINT}`
+    )
+  }
+
+  let newest: NewestFile | undefined
+  for (const target of WATCHED) {
+    const candidate = newestMtime(path.join(PKG_ROOT, target))
+    if (candidate && (!newest || candidate.mtimeMs > newest.mtimeMs)) {
+      newest = candidate
+    }
+  }
+
+  if (newest && info.builtAt !== undefined && newest.mtimeMs > info.builtAt) {
+    const rel = path.relative(PKG_ROOT, newest.filePath)
+    throw new Error(
+      `[e2e] build/ is stale: ${rel} changed after the build. ${REBUILD_HINT}`
+    )
+  }
+}

--- a/packages/danmaku-anywhere/e2e/setup/globalSetup.ts
+++ b/packages/danmaku-anywhere/e2e/setup/globalSetup.ts
@@ -42,8 +42,17 @@ function newestMtime(target: string): NewestFile | undefined {
   if (stat.isFile()) {
     return { filePath: target, mtimeMs: stat.mtimeMs }
   }
+  if (!stat.isDirectory()) {
+    return undefined
+  }
+  let entries: string[]
+  try {
+    entries = readdirSync(target)
+  } catch {
+    return undefined
+  }
   let newest: NewestFile | undefined
-  for (const entry of readdirSync(target)) {
+  for (const entry of entries) {
     const candidate = newestMtime(path.join(target, entry))
     if (candidate && (!newest || candidate.mtimeMs > newest.mtimeMs)) {
       newest = candidate

--- a/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/lifecycle/install.spec.ts
@@ -2,6 +2,7 @@ import {
   DanmakuSourceType,
   PROVIDER_TO_BUILTIN_ID,
 } from '@danmaku-anywhere/danmaku-converter'
+import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
 
@@ -60,13 +61,9 @@ test('fresh install: default options seeded, no console errors', async ({
 
   // The providers list runs each configured provider's connectivity probe on
   // render; mock them so network strict-mode and the console gate stay clean.
-  await context.route(/api\.bilibili\.com\/x\/web-interface\/nav/, (route) =>
-    route.fulfill({ json: { code: 0, message: '0', data: { isLogin: true } } })
-  )
-  await context.route(
-    /pbaccess\.video\.qq\.com\/.*page_server_rpc\.PageServer\/GetPageData/,
-    (route) => route.fulfill({ json: { ret: 0, msg: '', data: {} } })
-  )
+  for (const m of mockLoginProbes()) {
+    await context.route(m.pattern, m.respond)
+  }
 
   const popup = await Popup.open(page, extensionId, '/providers')
   for (const id of PRELOADED_PROVIDER_IDS) {

--- a/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/bookmark.spec.ts
@@ -1,10 +1,9 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -17,35 +16,6 @@ import { applyProfile } from '../../setup/profile'
  * Bilibili season fixture has 2 episodes → 1 stub after deduping the seeded
  * persisted episode by indexedId.
  */
-
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(seasonId: number): EpisodeInsert {
-  // indexedId matches the fixture's first episode so stub dedup leaves 1.
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
-    indexedId: '1300001',
-    title: 'Episode 1',
-    episodeNumber: '1',
-    seasonId,
-    comments: [],
-    commentCount: 0,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
-}
 
 test('mount tree: bookmark adds stubs, remove clears them', async ({
   context,
@@ -63,8 +33,8 @@ test('mount tree: bookmark adds stubs, remove clears them', async ({
     }),
   })
 
-  const season = await da.season.add(SEASON)
-  await da.episode.add(makeEpisode(season.id))
+  const season = await da.season.add(makeBilibiliSeason())
+  await da.episode.add(makeBilibiliEpisode(season.id))
 
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)

--- a/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/delete.spec.ts
@@ -1,9 +1,8 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -15,38 +14,6 @@ import { applyProfile } from '../../setup/profile'
  * Both paths route through the shared confirm Dialog (`popup.dialog`).
  */
 
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(
-  seasonId: number,
-  cid: number,
-  episodeNumber: string
-): EpisodeInsert {
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid, aid: 100000 + cid, bvid: `BV${cid}` },
-    indexedId: String(cid),
-    title: `Ep${episodeNumber}`,
-    episodeNumber,
-    seasonId,
-    comments: [],
-    commentCount: 0,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
-}
-
 test('mount tree: delete season removes it + cascades episodes', async ({
   context,
   page,
@@ -57,8 +24,10 @@ test('mount tree: delete season removes it + cascades episodes', async ({
     providers: { bilibili: { enabled: true } },
   })
 
-  const season = await da.season.add(SEASON)
-  const ep = await da.episode.add(makeEpisode(season.id, 1300001, '1'))
+  const season = await da.season.add(makeBilibiliSeason())
+  const ep = await da.episode.add(
+    makeBilibiliEpisode(season.id, { cid: 1300001, episodeNumber: '1' })
+  )
 
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)
@@ -82,9 +51,13 @@ test('mount tree: delete single episode keeps season + siblings', async ({
     providers: { bilibili: { enabled: true } },
   })
 
-  const season = await da.season.add(SEASON)
-  const ep1 = await da.episode.add(makeEpisode(season.id, 1300001, '1'))
-  const ep2 = await da.episode.add(makeEpisode(season.id, 1300002, '2'))
+  const season = await da.season.add(makeBilibiliSeason())
+  const ep1 = await da.episode.add(
+    makeBilibiliEpisode(season.id, { cid: 1300001, episodeNumber: '1' })
+  )
+  const ep2 = await da.episode.add(
+    makeBilibiliEpisode(season.id, { cid: 1300002, episodeNumber: '2' })
+  )
 
   const popup = await Popup.open(page, extensionId, '/mount')
   await popup.mount.waitForSeason(season.id)

--- a/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/export.spec.ts
@@ -1,10 +1,9 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { readFile } from 'fs/promises'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -16,35 +15,13 @@ import { applyProfile } from '../../setup/profile'
  * Single-episode seasons only; multi-episode exports zip (out of scope).
  */
 
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(seasonId: number): EpisodeInsert {
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
-    indexedId: '1300001',
-    title: 'Ep1',
-    episodeNumber: '1',
-    seasonId,
+function makeEpisode(seasonId: number) {
+  return makeBilibiliEpisode(seasonId, {
     comments: [
       { p: '0.00,1,25,16777215,0,0,0,0', m: 'hello' },
       { p: '1.00,1,25,16777215,0,0,0,0', m: 'world' },
     ],
-    commentCount: 2,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
+  })
 }
 
 test('mount tree: season export downloads an XML payload', async ({
@@ -57,7 +34,7 @@ test('mount tree: season export downloads an XML payload', async ({
     providers: { bilibili: { enabled: true } },
   })
 
-  const season = await da.season.add(SEASON)
+  const season = await da.season.add(makeBilibiliSeason())
   await da.episode.add(makeEpisode(season.id))
 
   const popup = await Popup.open(page, extensionId, '/mount')
@@ -90,7 +67,7 @@ test('mount tree: season exportBackup downloads a JSON payload', async ({
     providers: { bilibili: { enabled: true } },
   })
 
-  const season = await da.season.add(SEASON)
+  const season = await da.season.add(makeBilibiliSeason())
   const ep = await da.episode.add(makeEpisode(season.id))
 
   const popup = await Popup.open(page, extensionId, '/mount')

--- a/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/multi-select.spec.ts
@@ -1,9 +1,8 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
 
@@ -13,38 +12,6 @@ import { applyProfile } from '../../setup/profile'
  * the dialog. Asserts every row + DB record is gone. With no surviving
  * episodes the parent season row also disappears.
  */
-
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(
-  seasonId: number,
-  cid: number,
-  episodeNumber: string
-): EpisodeInsert {
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid, aid: 100000 + cid, bvid: `BV${cid}` },
-    indexedId: String(cid),
-    title: `Ep${episodeNumber}`,
-    episodeNumber,
-    seasonId,
-    comments: [],
-    commentCount: 0,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
-}
 
 test('mount tree: multi-select bulk delete removes every selected episode', async ({
   context,
@@ -56,11 +23,17 @@ test('mount tree: multi-select bulk delete removes every selected episode', asyn
     providers: { bilibili: { enabled: true } },
   })
 
-  const season = await da.season.add(SEASON)
+  const season = await da.season.add(makeBilibiliSeason())
   const seeded = await Promise.all([
-    da.episode.add(makeEpisode(season.id, 1300001, '1')),
-    da.episode.add(makeEpisode(season.id, 1300002, '2')),
-    da.episode.add(makeEpisode(season.id, 1300003, '3')),
+    da.episode.add(
+      makeBilibiliEpisode(season.id, { cid: 1300001, episodeNumber: '1' })
+    ),
+    da.episode.add(
+      makeBilibiliEpisode(season.id, { cid: 1300002, episodeNumber: '2' })
+    ),
+    da.episode.add(
+      makeBilibiliEpisode(season.id, { cid: 1300003, episodeNumber: '3' })
+    ),
   ])
 
   const popup = await Popup.open(page, extensionId, '/mount')

--- a/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
@@ -1,13 +1,15 @@
 import {
   type CommentEntity,
   DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
+  type EpisodeStub,
 } from '@danmaku-anywhere/danmaku-converter'
-import { mockBilibiliXml } from '../../network/bilibili'
+import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
-import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
 
 /**
@@ -19,40 +21,18 @@ import { applyProfile } from '../../setup/profile'
  * disabled, and the episode menu no longer offers Refresh Danmaku.
  */
 
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
 const COMMENTS: CommentEntity[] = [
   { p: '1,1,16777215', m: 'first' },
   { p: '2,1,16777215', m: 'second' },
   { p: '3,1,16777215', m: 'third' },
 ]
 
-function makeEpisode(seasonId: number): EpisodeInsert {
-  // indexedId matches the fixture's first episode so the bookmark dedups to
-  // one stub.
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
-    indexedId: '1300001',
-    title: 'Ep1',
-    episodeNumber: '1',
-    seasonId,
-    comments: COMMENTS,
-    commentCount: COMMENTS.length,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
+const UNFETCHED_STUB: EpisodeStub = {
+  provider: DanmakuSourceType.Bilibili,
+  providerIds: { cid: 1300002, aid: 1400002, bvid: 'BV1300002' },
+  indexedId: '1300002',
+  title: 'Ep2',
+  episodeNumber: '2',
 }
 
 test('deleting a provider orphans its season but keeps it viewable', async ({
@@ -63,20 +43,17 @@ test('deleting a provider orphans its season but keeps it viewable', async ({
 }) => {
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
-    network: mockBilibiliXml({
-      searchBangumi: loadJsonFixture('bilibili-search-bangumi.json'),
-      searchFt: loadJsonFixture('bilibili-search-ft.json'),
-      season: loadJsonFixture('bilibili-season.json'),
-      xml: loadTextFixture('bilibili-xml.xml'),
-    }),
+    network: [...mockLoginProbes()],
   })
 
-  const season = await da.season.add(SEASON)
-  const ep = await da.episode.add(makeEpisode(season.id))
+  const season = await da.season.add(makeBilibiliSeason())
+  const ep = await da.episode.add(
+    makeBilibiliEpisode(season.id, { comments: COMMENTS })
+  )
+  await da.bookmark.add(season.id, [UNFETCHED_STUB])
 
   const popup = await Popup.open(page, extensionId, '/mount')
   let seasonItem = await popup.mount.waitForSeason(season.id)
-  await popup.mount.openItemMenu(seasonItem, 'bookmarkAdd')
   await expect(seasonItem).toContainText(/\+1/)
 
   await Popup.open(page, extensionId, '/providers')

--- a/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/orphaned-season.spec.ts
@@ -43,7 +43,7 @@ test('deleting a provider orphans its season but keeps it viewable', async ({
 }) => {
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
-    network: [...mockLoginProbes()],
+    network: mockLoginProbes(),
   })
 
   const season = await da.season.add(makeBilibiliSeason())

--- a/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/preload-next.spec.ts
@@ -1,10 +1,9 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -16,36 +15,6 @@ import { applyProfile } from '../../setup/profile'
  * the player fires at 50% playback) for episode 1, then asserts the episode-2
  * stub row is replaced by a fetched episode row with a non-zero comment count.
  */
-
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(seasonId: number): EpisodeInsert {
-  // indexedId matches the season fixture's first episode (cid 1300001), so the
-  // bookmark snapshot leaves only the second episode as an unfetched stub.
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
-    indexedId: '1300001',
-    title: 'Ep1',
-    episodeNumber: '1',
-    seasonId,
-    comments: [],
-    commentCount: 0,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
-}
 
 test('mount tree: bookmark-driven preload caches the next episode', async ({
   context,
@@ -63,8 +32,8 @@ test('mount tree: bookmark-driven preload caches the next episode', async ({
     }),
   })
 
-  const season = await da.season.add(SEASON)
-  const episode = await da.episode.add(makeEpisode(season.id))
+  const season = await da.season.add(makeBilibiliSeason())
+  const episode = await da.episode.add(makeBilibiliEpisode(season.id))
 
   const popup = await Popup.open(page, extensionId, '/mount')
   const seasonItem = await popup.mount.waitForSeason(season.id)

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-danmaku.spec.ts
@@ -1,10 +1,9 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -16,34 +15,6 @@ import { applyProfile } from '../../setup/profile'
  * count rendered in the episode row leaves zero, with the DB commentCount
  * bumping above zero.
  */
-
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: '葬送的芙莉莲',
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(seasonId: number): EpisodeInsert {
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
-    indexedId: '1300001',
-    title: 'Ep1',
-    episodeNumber: '1',
-    seasonId,
-    comments: [],
-    commentCount: 0,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
-}
 
 test('mount tree: refresh danmaku fetches new comments for an episode', async ({
   context,
@@ -61,8 +32,8 @@ test('mount tree: refresh danmaku fetches new comments for an episode', async ({
     }),
   })
 
-  const season = await da.season.add(SEASON)
-  const episode = await da.episode.add(makeEpisode(season.id))
+  const season = await da.season.add(makeBilibiliSeason())
+  const episode = await da.episode.add(makeBilibiliEpisode(season.id))
   expect(episode.commentCount).toBe(0)
 
   const popup = await Popup.open(page, extensionId, '/mount')

--- a/packages/danmaku-anywhere/e2e/specs/mount/refresh-metadata.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/mount/refresh-metadata.spec.ts
@@ -1,10 +1,9 @@
-import {
-  DanmakuSourceType,
-  type EpisodeInsert,
-  type SeasonInsert,
-} from '@danmaku-anywhere/danmaku-converter'
 import { mockBilibiliXml } from '../../network/bilibili'
 import { Popup } from '../../pom/Popup'
+import {
+  makeBilibiliEpisode,
+  makeBilibiliSeason,
+} from '../../setup/bilibiliSeed'
 import { expect, test } from '../../setup/fixtures'
 import { loadJsonFixture, loadTextFixture } from '../../setup/fixtures-loader'
 import { applyProfile } from '../../setup/profile'
@@ -19,34 +18,6 @@ import { applyProfile } from '../../setup/profile'
  */
 
 const STALE_TITLE = '旧标题 (stale)'
-
-const SEASON: SeasonInsert = {
-  provider: DanmakuSourceType.Bilibili,
-  providerIds: { seasonId: 41410, mediaId: 28219412 },
-  providerConfigId: 'bilibili',
-  indexedId: '41410',
-  title: STALE_TITLE,
-  type: '番剧',
-  imageUrl: 'https://bilibili-cdn.invalid/x.jpg',
-  episodeCount: 28,
-  year: 2023,
-  schemaVersion: 1,
-}
-
-function makeEpisode(seasonId: number): EpisodeInsert {
-  return {
-    provider: DanmakuSourceType.Bilibili,
-    providerIds: { cid: 1300001, aid: 100001, bvid: 'BV1aaaaaaaa' },
-    indexedId: '1300001',
-    title: 'Ep1',
-    episodeNumber: '1',
-    seasonId,
-    comments: [],
-    commentCount: 0,
-    schemaVersion: 4,
-    lastChecked: 0,
-  }
-}
 
 test('mount tree: refresh metadata replaces stale season info', async ({
   context,
@@ -64,8 +35,8 @@ test('mount tree: refresh metadata replaces stale season info', async ({
     }),
   })
 
-  const seeded = await da.season.add(SEASON)
-  await da.episode.add(makeEpisode(seeded.id))
+  const seeded = await da.season.add(makeBilibiliSeason({ title: STALE_TITLE }))
+  await da.episode.add(makeBilibiliEpisode(seeded.id))
   expect(seeded.title).toBe(STALE_TITLE)
   expect(seeded.version).toBe(1)
 

--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -1,5 +1,6 @@
 import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
+import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
@@ -14,8 +15,6 @@ import { applyProfile } from '../../setup/profile'
  * auth header until it is filled. Field titles localize with the UI language,
  * so they are matched against both the English source and the zh override.
  */
-
-const NAV_URL = /api\.bilibili\.com\/x\/web-interface\/nav/
 
 const customDdp: ProviderConfig = {
   id: 'custom-ddp-form',
@@ -97,15 +96,7 @@ test('edits the built-in Bilibili provider via the generic form', async ({
 }) => {
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
-    network: [
-      {
-        pattern: NAV_URL,
-        respond: (route) =>
-          route.fulfill({
-            json: { code: 0, message: '0', data: { isLogin: true } },
-          }),
-      },
-    ],
+    network: [...mockLoginProbes()],
   })
 
   const popup = await Popup.open(page, extensionId, '/providers')

--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -96,7 +96,7 @@ test('edits the built-in Bilibili provider via the generic form', async ({
 }) => {
   await applyProfile(context, da, {
     providers: { bilibili: { enabled: true } },
-    network: [...mockLoginProbes()],
+    network: mockLoginProbes(),
   })
 
   const popup = await Popup.open(page, extensionId, '/providers')

--- a/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
@@ -2,6 +2,7 @@ import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { Language } from '../../../src/common/localization/language'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockCatalog } from '../../network/catalog'
+import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
@@ -12,10 +13,6 @@ import { applyProfile } from '../../setup/profile'
  * localized name (iQIYI -> 爱奇艺) and the generic config editor renders a
  * dandanplay field under its localized title (Base URL -> 基础地址).
  */
-
-const BILIBILI_NAV = /api\.bilibili\.com\/x\/web-interface\/nav/
-const TENCENT_PROBE =
-  /pbaccess\.video\.qq\.com\/.*page_server_rpc\.PageServer\/GetPageData/
 
 const localDdp: ProviderConfig = {
   id: 'localized-ddp',
@@ -41,18 +38,7 @@ test('catalog and config editor render localized manifest strings', async ({
     customProviders: [localDdp],
     network: [
       mockCatalog(['dandanplay', 'bilibili', 'tencent', 'iqiyi']),
-      {
-        pattern: BILIBILI_NAV,
-        respond: (route) =>
-          route.fulfill({
-            json: { code: 0, message: '0', data: { isLogin: true } },
-          }),
-      },
-      {
-        pattern: TENCENT_PROBE,
-        respond: (route) =>
-          route.fulfill({ json: { ret: 0, msg: '', data: {} } }),
-      },
+      ...mockLoginProbes(),
     ],
   })
 

--- a/packages/danmaku-anywhere/e2e/specs/sources/catalog-import.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/catalog-import.spec.ts
@@ -1,4 +1,5 @@
 import { mockCatalog } from '../../network/catalog'
+import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
 import { applyProfile } from '../../setup/profile'
@@ -12,10 +13,6 @@ import { applyProfile } from '../../setup/profile'
  * referencing the manifest is persisted.
  */
 
-const BILIBILI_NAV = /api\.bilibili\.com\/x\/web-interface\/nav/
-const TENCENT_PROBE =
-  /pbaccess\.video\.qq\.com\/.*page_server_rpc\.PageServer\/GetPageData/
-
 const CATALOG_WITH_IQIYI = ['dandanplay', 'bilibili', 'tencent', 'iqiyi']
 
 test('catalog: refresh surfaces an uninstalled source and import installs it', async ({
@@ -26,21 +23,7 @@ test('catalog: refresh surfaces an uninstalled source and import installs it', a
 }) => {
   await applyProfile(context, da, {
     providers: {},
-    network: [
-      mockCatalog(CATALOG_WITH_IQIYI),
-      {
-        pattern: BILIBILI_NAV,
-        respond: (route) =>
-          route.fulfill({
-            json: { code: 0, message: '0', data: { isLogin: true } },
-          }),
-      },
-      {
-        pattern: TENCENT_PROBE,
-        respond: (route) =>
-          route.fulfill({ json: { ret: 0, msg: '', data: {} } }),
-      },
-    ],
+    network: [mockCatalog(CATALOG_WITH_IQIYI), ...mockLoginProbes()],
   })
 
   const popup = await Popup.open(page, extensionId, '/providers')

--- a/packages/danmaku-anywhere/playwright.config.ts
+++ b/packages/danmaku-anywhere/playwright.config.ts
@@ -4,6 +4,7 @@ const isCI = !!process.env.CI
 
 export default defineConfig({
   testDir: './e2e',
+  globalSetup: './e2e/setup/globalSetup.ts',
   timeout: 30_000,
   retries: 0,
   // Real server for specs needing genuine cross-origin network (route-fulfilled

--- a/packages/danmaku-anywhere/src/devApi/namespaces/BookmarkNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/BookmarkNamespace.ts
@@ -1,23 +1,27 @@
-import type { Bookmark } from '@danmaku-anywhere/danmaku-converter'
+import type { Bookmark, EpisodeStub } from '@danmaku-anywhere/danmaku-converter'
 import { inject, injectable } from 'inversify'
 import { BookmarkService } from '@/background/services/persistence/BookmarkService'
+import { DanmakuAnywhereDb } from '@/common/db/db'
 import { type AnyMethodDef, type DevNamespace, defineMethod } from '../registry'
 
 export interface BookmarkApi {
   list(): Promise<Bookmark[]>
   bySeason(seasonId: number): Promise<Bookmark | undefined>
+  add(seasonId: number, episodes?: EpisodeStub[]): Promise<Bookmark>
   deleteBySeason(seasonId: number): Promise<void>
 }
 
 @injectable('Singleton')
 export class BookmarkNamespace implements DevNamespace {
   readonly name = 'bookmark'
-  readonly description = 'Read/clear bookmarks (IndexedDB)'
+  readonly description = 'Read/write bookmarks (IndexedDB)'
   readonly methods: readonly AnyMethodDef[]
 
   constructor(
     @inject(BookmarkService)
-    private readonly service: BookmarkService
+    private readonly service: BookmarkService,
+    @inject(DanmakuAnywhereDb)
+    private readonly db: DanmakuAnywhereDb
   ) {
     this.methods = [
       defineMethod({
@@ -32,6 +36,32 @@ export class BookmarkNamespace implements DevNamespace {
         kind: 'read',
         args: [{ name: 'seasonId', type: 'number' }],
         handler: (seasonId: number) => this.service.getBySeason(seasonId),
+      }),
+      defineMethod({
+        name: 'add',
+        description:
+          'Insert a bookmark row directly, without the upstream episode fetch',
+        kind: 'write',
+        args: [
+          { name: 'seasonId', type: 'number' },
+          { name: 'episodes', type: 'EpisodeStub[]', optional: true },
+        ],
+        handler: async (seasonId: number, episodes?: EpisodeStub[]) => {
+          const season = await this.db.season.get(seasonId)
+          if (!season) {
+            throw new Error(`Season not found: ${seasonId}`)
+          }
+          const insert = {
+            seasonId,
+            providerConfigId: season.providerConfigId,
+            episodes: episodes ?? [],
+            lastRefreshed: Date.now(),
+            timeUpdated: Date.now(),
+            version: 1,
+          }
+          const id = await this.db.bookmark.add(insert)
+          return { ...insert, id }
+        },
       }),
       defineMethod({
         name: 'deleteBySeason',

--- a/packages/danmaku-anywhere/vite.config.ts
+++ b/packages/danmaku-anywhere/vite.config.ts
@@ -1,6 +1,8 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 import { crx } from '@crxjs/vite-plugin'
 import react from '@vitejs/plugin-react'
-import { defaultClientConditions } from 'vite'
+import { defaultClientConditions, type Plugin } from 'vite'
 import { defineConfig } from 'vitest/config'
 import { manifest } from './manifest'
 import { getBuildContext } from './scripts/getBuildContext'
@@ -46,12 +48,33 @@ const e2eProxyDefines =
       }
     : {}
 
+// Stamps the output with build metadata so the e2e setup can refuse to run
+// against a stale or wrong-env build (see e2e/setup/globalSetup.ts).
+function buildInfo(): Plugin {
+  let outDir = ''
+  return {
+    name: 'da:build-info',
+    apply: 'build',
+    configResolved(config) {
+      outDir = path.resolve(config.root, config.build.outDir)
+    },
+    closeBundle() {
+      mkdirSync(outDir, { recursive: true })
+      writeFileSync(
+        path.join(outDir, 'build-info.json'),
+        JSON.stringify({ daEnv, gitBranch, appVersion, builtAt: Date.now() })
+      )
+    },
+  }
+}
+
 export default defineConfig({
   // @ts-ignore
   plugins: [
     vendorRuntimeAssets(),
     react({}),
     crx({ manifest, browser: browser.name }),
+    buildInfo(),
   ],
   // Don't pre-bundle the variable font packages: when crxjs serves dev assets,
   // `?url` for pre-bundled CSS resolves to a `/vendor/...__url.js` shim instead

--- a/packages/danmaku-anywhere/vite.config.ts
+++ b/packages/danmaku-anywhere/vite.config.ts
@@ -49,7 +49,8 @@ const e2eProxyDefines =
     : {}
 
 // Stamps the output with build metadata so the e2e setup can refuse to run
-// against a stale or wrong-env build (see e2e/setup/globalSetup.ts).
+// against a stale or wrong-env build (see e2e/setup/globalSetup.ts). Skipped
+// for prod so release zips stay free of branch names and timestamps.
 function buildInfo(): Plugin {
   let outDir = ''
   return {
@@ -59,6 +60,9 @@ function buildInfo(): Plugin {
       outDir = path.resolve(config.root, config.build.outDir)
     },
     closeBundle() {
+      if (daEnv === 'prod') {
+        return
+      }
       mkdirSync(outDir, { recursive: true })
       writeFileSync(
         path.join(outDir, 'build-info.json'),


### PR DESCRIPTION
## Summary
- `da.bookmark.add(seasonId, episodes?)` dev-API method: seeds a bookmark row directly so specs that need a bookmark as a precondition no longer drive the Follow UI flow and its network mocks. Used by the reworked `orphaned-season.spec.ts`, which drops its `mockBilibiliXml` fixture dependency entirely.
- Build freshness guard: non-prod builds stamp `build-info.json` (daEnv, builtAt) via a small vite plugin; a Playwright `globalSetup` refuses to run against a stale or wrong-env `build/` with a rebuild hint. Direct `playwright test <spec>` invocations skip the `pretest:e2e` rebuild and previously ran whatever stale build was on disk, producing phantom results. `DA_E2E_ALLOW_STALE_BUILD=1` escapes the check; prod builds skip the stamp so release zips stay free of branch names and timestamps.
- `Popup.open` now documents that re-opening with a different hash route is a same-document navigation (SPA + React Query cache survive), which is the realistic user path and the way the DA-642 stale-cache bug was caught.
- Shared fixtures: `makeBilibiliSeason` / `makeBilibiliEpisode` builders (`e2e/setup/bilibiliSeed.ts`) replace the copy-pasted `SEASON`/`makeEpisode` blocks in 8 mount specs; `mockLoginProbes()` (`e2e/network/loginProbes.ts`) replaces 4 drifting inline bilibili `/nav` + tencent probe mocks. `login-probe.spec.ts` keeps its bespoke instrumented mock (it counts calls).

## Test plan
- Verified: lint (tsc + biome) pass · unit `pnpm vitest run` 551 passed · full e2e suite 60 passed · guard exercised both ways (touch a src file → run fails naming the stale file; rebuild → passes)
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` (the full sweep; this PR touches shared e2e infrastructure)
- [ ] Stale-build check: `touch src/common/utils/utils.ts && pnpm exec playwright test e2e/specs/mount/orphaned-season.spec.ts` should fail fast with the rebuild hint

## Notes
- Accepted fixture drift (verified unasserted): episode `aid`/`bvid` are now derived from `cid`, and bookmark.spec's episode title is `Ep1` instead of `Episode 1`. Network mocks match URL paths only.
- `bookmark.add` rejects on a duplicate season (unique `&seasonId` index): a double-seed is a spec bug worth surfacing, matching the seed-method intent.