### PR TITLE
(extension) surface manifest-spec load failures in the provider config form [DA-631]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -14,6 +14,8 @@ import { applyProfile } from '../../setup/profile'
  * Also asserts the schema's `required` constraint blocks saving an empty
  * auth header until it is filled. Field titles localize with the UI language,
  * so they are matched against both the English source and the zh override.
+ * Finally, a provider whose manifest spec fails to load shows an error with a
+ * retry action instead of a stripped name-only form that would drop its config.
  */
 
 const customDdp: ProviderConfig = {
@@ -114,4 +116,49 @@ test('edits the built-in Bilibili provider via the generic form', async ({
   const saved = await da.providerConfig.get('bilibili')
   expect(saved?.name).toBe('Bilibili Custom')
   expect(saved?.configValues.danmakuFormat).toBe('protobuf')
+})
+
+const orphanedProvider: ProviderConfig = {
+  id: 'orphaned-source',
+  manifestId: 'manifest-that-failed-to-load',
+  name: 'Orphaned Source',
+  impl: DanmakuSourceType.DanDanPlay,
+  enabled: true,
+  isBuiltIn: false,
+  configValues: {
+    baseUrl: 'https://orphaned.example.invalid',
+    auth: { enabled: false, headers: [] },
+  },
+}
+
+test.describe('manifest spec load failure', () => {
+  // Editing a provider whose manifest is unregistered rejects the spec RPC; the
+  // service worker logs that rejection.
+  test.use({
+    expectedConsoleErrors: [
+      /\[RpcManager\] Error in RPC handler.*no manifest registered/,
+    ],
+  })
+
+  test('shows an error with retry instead of a stripped form', async ({
+    context,
+    page,
+    extensionId,
+    da,
+  }) => {
+    await applyProfile(context, da, { customProviders: [orphanedProvider] })
+
+    const popup = await Popup.open(page, extensionId, '/providers')
+    await popup.providers.edit('Orphaned Source')
+
+    await expect(
+      page.getByText(/Failed to load provider settings|加载弹幕源设置失败/)
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /^(Retry|重试)$/ })
+    ).toBeVisible()
+
+    await expect(popup.providers.nameField()).toBeHidden()
+    await expect(popup.providers.saveButton()).toBeHidden()
+  })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -197,6 +197,27 @@ describe('ProviderService.getManifestSpec', () => {
 
     expect(spec.name).toBe('DanDanPlay')
   })
+
+  it('rejects when no manifest is registered for the id', async () => {
+    const registry = {
+      ready: Promise.resolve(true),
+      getRunner: vi.fn(() => {
+        throw new Error('no manifest registered with id: missing')
+      }),
+    } as unknown as ManifestRegistry
+    const service = new ProviderService(
+      {} as unknown as DanmakuService,
+      {} as unknown as SeasonService,
+      {} as unknown as ProviderConfigService,
+      vi.fn(() => makeProvider()),
+      registry,
+      {} as unknown as BookmarkService,
+      silentLogger,
+      silentExtensionOptions
+    )
+
+    await expect(service.getManifestSpec('missing')).rejects.toThrow()
+  })
 })
 
 describe('ProviderService legacy-maccms decoupling', () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -406,21 +406,15 @@ export class ProviderService {
     locale?: string
   ): Promise<ProviderManifestSpec> {
     await this.manifestRegistry.ready
-    try {
-      const { manifest } = this.manifestRegistry.getRunner(manifestId)
-      const display = getDisplayStrings(manifest, locale)
-      return {
-        name: display.name,
-        hasLoginProbe: manifest.loginProbe !== undefined,
-        cookieSet: manifest.cookieSet
-          ? { url: manifest.cookieSet.url, title: display.cookieSet?.title }
-          : undefined,
-        configSchema: display.configSchema,
-      }
-    } catch {
-      // Unknown id (legacy:maccms) or a catalog miss: report a minimal spec so
-      // the popup degrades to a name-only form instead of rejecting the RPC.
-      return { name: '', hasLoginProbe: false }
+    const { manifest } = this.manifestRegistry.getRunner(manifestId)
+    const display = getDisplayStrings(manifest, locale)
+    return {
+      name: display.name,
+      hasLoginProbe: manifest.loginProbe !== undefined,
+      cookieSet: manifest.cookieSet
+        ? { url: manifest.cookieSet.url, title: display.cookieSet?.title }
+        : undefined,
+      configSchema: display.configSchema,
     }
   }
 }

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -103,6 +103,7 @@
     "regexShort": "Regex",
     "reset": "Reset",
     "restore": "Restore",
+    "retry": "Retry",
     "save": "Save",
     "saved": "Saved",
     "saving": "Saving...",
@@ -672,6 +673,7 @@
         "viewTitle": "Manifest source"
       },
       "name": "Name",
+      "specError": "Failed to load provider settings. Some fields are missing, saving now would drop them.",
       "testRun": {
         "danmakuCount_one": "{{count}} comments fetched",
         "danmakuCount_other": "{{count}} comments fetched",

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -102,6 +102,7 @@
     "regexShort": "正则",
     "reset": "重置",
     "restore": "恢复",
+    "retry": "重试",
     "save": "保存",
     "saved": "已保存",
     "saving": "正在保存...",
@@ -651,6 +652,7 @@
         "viewTitle": "配置源码"
       },
       "name": "名称",
+      "specError": "加载弹幕源设置失败。部分字段缺失，此时保存会丢失这些字段。",
       "testRun": {
         "danmakuCount_other": "已获取 {{count}} 条弹幕",
         "episodes": "剧集（选择一集获取弹幕）",

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
@@ -1,7 +1,8 @@
 import type { ConfigSchema } from '@mr-quin/dango'
-import { Box, CircularProgress, Stack, TextField } from '@mui/material'
+import { Box, Button, CircularProgress, Stack, TextField } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { ErrorMessage } from '@/common/components/ErrorMessage'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import { useManifestSpec } from '../../hooks/useManifestSpec'
 import { FormActions } from './FormActions'
@@ -89,13 +90,33 @@ function ConfigForm({
 }
 
 export const ProviderConfigForm = (props: ProviderFormProps) => {
-  const { isLoading, data } = useManifestSpec(props.provider.manifestId)
+  const { t } = useTranslation()
+  const { isLoading, isError, data, refetch } = useManifestSpec(
+    props.provider.manifestId
+  )
 
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
         <CircularProgress />
       </Box>
+    )
+  }
+
+  if (isError) {
+    return (
+      <ErrorMessage
+        message={t(
+          'providers.editor.specError',
+          'Failed to load provider settings. Some fields are missing, saving now would drop them.'
+        )}
+        size={160}
+        beforeContent={
+          <Button onClick={() => void refetch()} variant="text">
+            {t('common.retry', 'Retry')}
+          </Button>
+        }
+      />
     )
   }
 

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
@@ -91,7 +91,7 @@ function ConfigForm({
 
 export const ProviderConfigForm = (props: ProviderFormProps) => {
   const { t } = useTranslation()
-  const { isLoading, isError, data, refetch } = useManifestSpec(
+  const { isLoading, isError, isFetching, data, refetch } = useManifestSpec(
     props.provider.manifestId
   )
 
@@ -112,7 +112,11 @@ export const ProviderConfigForm = (props: ProviderFormProps) => {
         )}
         size={160}
         beforeContent={
-          <Button onClick={() => void refetch()} variant="text">
+          <Button
+            onClick={() => void refetch()}
+            variant="text"
+            disabled={isFetching}
+          >
             {t('common.retry', 'Retry')}
           </Button>
         }


### PR DESCRIPTION
## Summary
- `ProviderService.getManifestSpec` no longer swallows an unresolved-manifest error into a fake `{ name: '', hasLoginProbe: false }` spec; it lets the RPC reject. That fake spec was the root of the masquerade: a failed spec load looked identical to a config-less manifest, so the editor rendered a name-only form and saving silently dropped `baseUrl`/`auth`.
- `ProviderConfigForm` gains an explicit error branch (localized message + retry) when the spec query errors, instead of falling through to a stripped form.
- Added `common.retry` and `providers.editor.specError` (en + zh).

## Test plan
- Verified: lint (tsc + biome) pass · unit `pnpm exec vitest run src/background/services/providers src/popup/pages/providers` -> 141 passed · e2e `e2e/specs/providers/config-form.spec.ts` -> 4 passed (incl. new error-state case)
- [ ] `pnpm exec playwright test e2e/specs/providers/config-form.spec.ts`
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test src/background/services/providers/ProviderService.test.ts`

## Notes
- The task scoped this "form-layer only", but a form-only change can't fix the described bug: the background handler caught the unregistered-manifest error and returned a degraded spec, so the query never rejected. The fix removes that swallow. This is safe and restores an existing contract: `getLoginStatus` already wrapped `getManifestSpec` in a try/catch expecting it to throw (that catch was dead code while the swallow stood). `legacy:maccms` is routed to `MacCmsProviderForm`, not this form, so it never hits the changed path; config-less-but-registered manifests still resolve normally and render name-only.
- The e2e seeds a provider whose `manifestId` is unregistered; the spec RPC rejects and the SW logs it, so the spec opts that one log into `expectedConsoleErrors` (scoped to its `describe`).
- Not covered by e2e: retry actually recovering, which would require registering the manifest mid-test.