### PR TITLE
(extension) validate configValues against the manifest configSchema [DA-634]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -12,7 +12,9 @@ import { applyProfile } from '../../setup/profile'
  * and the built-in Bilibili provider, asserting the schema-driven fields show,
  * a save toast appears, and the edited values land in stored configValues.
  * Also asserts the schema's `required` constraint blocks saving an empty
- * auth header until it is filled. Field titles localize with the UI language,
+ * auth header until it is filled, and that configSchema constraints
+ * (format: uri, minimum) surface as field errors and block saving until
+ * the values are fixed. Field titles localize with the UI language,
  * so they are matched against both the English source and the zh override.
  * Finally, a provider whose manifest spec fails to load shows an error with a
  * retry action instead of a stripped name-only form that would drop its config.
@@ -116,6 +118,77 @@ test('edits the built-in Bilibili provider via the generic form', async ({
   const saved = await da.providerConfig.get('bilibili')
   expect(saved?.name).toBe('Bilibili Custom')
   expect(saved?.configValues.danmakuFormat).toBe('protobuf')
+})
+
+// Authored through the manifest editor because no bundled manifest carries
+// constraint keywords. Required fields are avoided: the editor rejects
+// required-without-default manifests at save.
+const constrainedManifest = {
+  apiVersion: 1,
+  id: 'user:constrained-source',
+  name: 'Constrained Source',
+  version: '1.0.0',
+  hosts: ['example.com'],
+  configSchema: {
+    type: 'object',
+    properties: {
+      baseUrl: { type: 'string', format: 'uri', title: 'Base URL' },
+      limit: {
+        type: 'integer',
+        title: 'Limit',
+        minimum: 1,
+        maximum: 100,
+        default: 10,
+      },
+    },
+  },
+}
+
+test('enforces configSchema constraints before saving config values', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  await applyProfile(context, da, {})
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  await popup.providers.authorManifest()
+  await popup.providers.setManifestJson(JSON.stringify(constrainedManifest))
+  await expect(popup.providers.manifestValid()).toBeVisible()
+  await popup.providers.save()
+  await popup.toast.expectSuccess(/Manifest saved|配置已保存/)
+
+  await popup.providers.edit('Constrained Source')
+  await popup.providers.fillField('Base URL', 'not a url')
+  await popup.providers.fillField('Limit', '0')
+  await popup.providers.save()
+
+  await expect(page.getByText(/Not a valid URL|不是有效的 URL/)).toBeVisible()
+  await expect(page.getByText(/Must be at least 1|不能小于 1/)).toBeVisible()
+
+  const blocked = (await da.providerConfig.list()).find(
+    (config) => config.manifestId === 'user:constrained-source'
+  )
+  expect(blocked?.configValues.baseUrl).toBe('')
+  expect(blocked?.configValues.limit).toBe(10)
+
+  await popup.providers.fillField(
+    'Base URL',
+    'https://constrained.example.invalid'
+  )
+  await popup.providers.fillField('Limit', '50')
+  await popup.providers.save()
+
+  await popup.toast.expectSuccess(/Provider updated|弹幕源已更新/)
+
+  const saved = (await da.providerConfig.list()).find(
+    (config) => config.manifestId === 'user:constrained-source'
+  )
+  expect(saved?.configValues).toMatchObject({
+    baseUrl: 'https://constrained.example.invalid',
+    limit: 50,
+  })
 })
 
 const orphanedProvider: ProviderConfig = {

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -688,6 +688,16 @@
         "addDanDanPlay": "Add DanDanPlay Compatible Provider",
         "addMacCms": "Add MacCMS Provider",
         "edit": "Edit Provider: {{name}}"
+      },
+      "validation": {
+        "integer": "Must be a whole number",
+        "maximum": "Must be at most {{max}}",
+        "maxLength": "Must be at most {{max}} characters",
+        "minimum": "Must be at least {{min}}",
+        "minLength": "Must be at least {{min}} characters",
+        "pattern": "Must match the pattern {{pattern}}",
+        "required": "This field is required",
+        "url": "Not a valid URL"
       }
     },
     "filter": {

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -666,6 +666,16 @@
         "addDanDanPlay": "添加弹弹play弹幕源",
         "addMacCms": "添加MacCMS弹幕源",
         "edit": "编辑弹幕源: {{name}}"
+      },
+      "validation": {
+        "integer": "必须是整数",
+        "maximum": "不能大于 {{max}}",
+        "maxLength": "不能超过 {{max}} 个字符",
+        "minimum": "不能小于 {{min}}",
+        "minLength": "不能少于 {{min}} 个字符",
+        "pattern": "必须匹配模式 {{pattern}}",
+        "required": "此项为必填项",
+        "url": "不是有效的 URL"
       }
     },
     "filter": {

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
@@ -3,6 +3,7 @@ import { Box, Button, CircularProgress, Stack, TextField } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { ErrorMessage } from '@/common/components/ErrorMessage'
+import { useToast } from '@/common/components/Toast/toastStore'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import { useManifestSpec } from '../../hooks/useManifestSpec'
 import { FormActions } from './FormActions'
@@ -31,6 +32,7 @@ function ConfigForm({
   isEdit,
 }: ConfigFormProps) {
   const { t } = useTranslation()
+  const toast = useToast.use.toast()
 
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -54,6 +56,11 @@ function ConfigForm({
       for (const error of configErrors) {
         setError(`config.${error.path}`, { message: error.message })
       }
+      // Rendered fields are already validated by their own rules, so an error
+      // here usually sits on a field the form does not render. Toast it so the
+      // blocked save is never silent.
+      const [first] = configErrors
+      toast.error(`${first.path}: ${first.message}`)
       return
     }
     const next: ProviderConfig = {

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/ProviderConfigForm.tsx
@@ -7,7 +7,11 @@ import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import { useManifestSpec } from '../../hooks/useManifestSpec'
 import { FormActions } from './FormActions'
 import { SchemaObjectFields } from './SchemaFields'
-import { buildDefaultValues, mergeConfigValues } from './schemaForm'
+import {
+  buildDefaultValues,
+  mergeConfigValues,
+  validateConfigValues,
+} from './schemaForm'
 import type { ProviderFormProps } from './types'
 
 interface FormValues {
@@ -39,14 +43,23 @@ function ConfigForm({
     handleSubmit,
     register,
     reset,
+    setError,
     formState: { errors, isSubmitting, isDirty },
   } = methods
 
   const handleFormSubmit = handleSubmit(async (data) => {
+    const configValues = mergeConfigValues(provider.configValues, data.config)
+    const configErrors = validateConfigValues(configSchema, configValues)
+    if (configErrors.length > 0) {
+      for (const error of configErrors) {
+        setError(`config.${error.path}`, { message: error.message })
+      }
+      return
+    }
     const next: ProviderConfig = {
       ...provider,
       name: data.name,
-      configValues: mergeConfigValues(provider.configValues, data.config),
+      configValues,
     }
     await onSubmit(next)
   })

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/SchemaFields.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/SchemaFields.tsx
@@ -59,6 +59,7 @@ export function SchemaObjectFields({
 }
 
 function ScalarField({ name, schema, required }: SchemaFieldProps) {
+  const { t } = useTranslation()
   const { control } = useFormContext()
   const kind = getFieldKind(schema)
   return (
@@ -66,7 +67,9 @@ function ScalarField({ name, schema, required }: SchemaFieldProps) {
       name={name}
       control={control}
       rules={{
-        required,
+        required: required
+          ? t('providers.editor.validation.required', 'This field is required')
+          : false,
         validate: (value) => validateScalar(schema, value) ?? true,
       }}
       render={({ field: { ref, onChange, value, ...field }, fieldState }) => (
@@ -95,6 +98,7 @@ function ScalarField({ name, schema, required }: SchemaFieldProps) {
 }
 
 function SelectField({ name, schema, required }: SchemaFieldProps) {
+  const { t } = useTranslation()
   const { control } = useFormContext()
   const options = (schema.enum ?? []).filter(
     (option): option is string | number =>
@@ -104,7 +108,11 @@ function SelectField({ name, schema, required }: SchemaFieldProps) {
     <Controller
       name={name}
       control={control}
-      rules={{ required }}
+      rules={{
+        required: required
+          ? t('providers.editor.validation.required', 'This field is required')
+          : false,
+      }}
       render={({ field: { ref, value, ...field }, fieldState }) => (
         <TextField
           {...field}

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/SchemaFields.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/SchemaFields.tsx
@@ -115,7 +115,7 @@ function SelectField({ name, schema, required }: SchemaFieldProps) {
           required={required}
           error={!!fieldState.error}
           inputRef={ref}
-          helperText={schema.description}
+          helperText={fieldState.error?.message || schema.description}
           fullWidth
         >
           {options.map((option) => (

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/SchemaFields.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/SchemaFields.tsx
@@ -19,6 +19,7 @@ import {
   getFieldKind,
   getObjectFields,
   toNumberOrUndefined,
+  validateScalar,
 } from './schemaForm'
 
 interface SchemaFieldProps {
@@ -64,7 +65,10 @@ function ScalarField({ name, schema, required }: SchemaFieldProps) {
     <Controller
       name={name}
       control={control}
-      rules={{ required }}
+      rules={{
+        required,
+        validate: (value) => validateScalar(schema, value) ?? true,
+      }}
       render={({ field: { ref, onChange, value, ...field }, fieldState }) => (
         <TextField
           {...field}
@@ -82,7 +86,7 @@ function ScalarField({ name, schema, required }: SchemaFieldProps) {
           type={kind === 'number' ? 'number' : 'text'}
           required={required}
           error={!!fieldState.error}
-          helperText={schema.description}
+          helperText={fieldState.error?.message || schema.description}
           fullWidth
         />
       )}

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/schemaForm.test.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/schemaForm.test.ts
@@ -6,6 +6,8 @@ import {
   getObjectFields,
   mergeConfigValues,
   toNumberOrUndefined,
+  validateConfigValues,
+  validateScalar,
 } from './schemaForm'
 
 /**
@@ -188,6 +190,117 @@ describe('buildDefaultValues', () => {
       enabled: true,
       headers: [{ key: 'only-key', value: '' }],
     })
+  })
+})
+
+describe('validateScalar', () => {
+  it('skips constraint checks for empty values', () => {
+    const schema: ConfigSchema = { type: 'string', minLength: 5 }
+    expect(validateScalar(schema, '')).toBeNull()
+    expect(validateScalar(schema, undefined)).toBeNull()
+    expect(validateScalar(schema, null)).toBeNull()
+  })
+
+  it('returns null when there are no constraints', () => {
+    expect(validateScalar({ type: 'string' }, 'anything')).toBeNull()
+    expect(validateScalar({ type: 'number' }, 12.5)).toBeNull()
+  })
+
+  // The test setup mocks i18n.t to return the key, so messages are asserted
+  // by the constraint key that fired.
+  it('enforces minLength and maxLength', () => {
+    const schema: ConfigSchema = { type: 'string', minLength: 2, maxLength: 4 }
+    expect(validateScalar(schema, 'a')).toContain('minLength')
+    expect(validateScalar(schema, 'abcde')).toContain('maxLength')
+    expect(validateScalar(schema, 'abc')).toBeNull()
+  })
+
+  it('enforces pattern', () => {
+    const schema: ConfigSchema = { type: 'string', pattern: '^[a-z]+$' }
+    expect(validateScalar(schema, 'abc')).toBeNull()
+    expect(validateScalar(schema, 'ABC')).not.toBeNull()
+  })
+
+  it('ignores an invalid pattern regex', () => {
+    const schema: ConfigSchema = { type: 'string', pattern: '[' }
+    expect(validateScalar(schema, 'anything')).toBeNull()
+  })
+
+  it('enforces uri format and ignores unknown formats', () => {
+    const uri: ConfigSchema = { type: 'string', format: 'uri' }
+    expect(validateScalar(uri, 'not a url')).not.toBeNull()
+    expect(validateScalar(uri, 'https://example.test')).toBeNull()
+    const unknown: ConfigSchema = { type: 'string', format: 'hostname' }
+    expect(validateScalar(unknown, 'anything')).toBeNull()
+  })
+
+  it('enforces minimum and maximum', () => {
+    const schema: ConfigSchema = { type: 'number', minimum: 1, maximum: 10 }
+    expect(validateScalar(schema, 0)).toContain('minimum')
+    expect(validateScalar(schema, 11)).toContain('maximum')
+    expect(validateScalar(schema, 5)).toBeNull()
+  })
+
+  it('rejects fractional values for integer schemas', () => {
+    const schema: ConfigSchema = { type: 'integer' }
+    expect(validateScalar(schema, 1.5)).not.toBeNull()
+    expect(validateScalar(schema, 2)).toBeNull()
+  })
+})
+
+describe('validateConfigValues', () => {
+  it('returns no errors without a schema', () => {
+    expect(validateConfigValues(undefined, { foo: 'bar' })).toEqual([])
+  })
+
+  it('reports missing or empty required fields with their path', () => {
+    const schema: ConfigSchema = {
+      type: 'object',
+      required: ['baseUrl'],
+      properties: { baseUrl: { type: 'string' } },
+    }
+    expect(validateConfigValues(schema, {})).toMatchObject([
+      { path: 'baseUrl' },
+    ])
+    expect(validateConfigValues(schema, { baseUrl: '' })).toMatchObject([
+      { path: 'baseUrl' },
+    ])
+    expect(validateConfigValues(schema, { baseUrl: 'x' })).toEqual([])
+  })
+
+  it('reports constraint violations with their path', () => {
+    const schema: ConfigSchema = {
+      type: 'object',
+      properties: { baseUrl: { type: 'string', format: 'uri' } },
+    }
+    expect(validateConfigValues(schema, { baseUrl: 'nope' })).toMatchObject([
+      { path: 'baseUrl' },
+    ])
+  })
+
+  it('walks nested objects and array items', () => {
+    const errors = validateConfigValues(ddpSchema, {
+      baseUrl: 'https://example.test',
+      auth: { enabled: true, headers: [{ key: 'X-Token', value: '' }] },
+    })
+    expect(errors).toMatchObject([{ path: 'auth.headers.0.value' }])
+  })
+
+  it('ignores stored keys the schema does not know about', () => {
+    const schema: ConfigSchema = {
+      type: 'object',
+      properties: { baseUrl: { type: 'string' } },
+    }
+    expect(validateConfigValues(schema, { legacyOnly: 'keep' })).toEqual([])
+  })
+
+  it('accepts a fully valid config', () => {
+    const errors = validateConfigValues(ddpSchema, {
+      baseUrl: 'https://example.test',
+      auth: { enabled: false, headers: [] },
+      chConvert: 0,
+    })
+    expect(errors).toEqual([])
   })
 })
 

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/schemaForm.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/forms/schemaForm.ts
@@ -1,4 +1,6 @@
 import type { ConfigSchema } from '@mr-quin/dango'
+import { i18n } from '@/common/localization/i18n'
+import { tryCatchSync } from '@/common/utils/tryCatch'
 
 export type FieldKind =
   | 'text'
@@ -140,6 +142,176 @@ export function buildDefaultValues(
     out[key] = buildFieldDefault(propSchema, safeValues[key])
   }
   return out
+}
+
+function isEmptyValue(value: unknown): boolean {
+  return value === undefined || value === null || value === ''
+}
+
+function numberConstraint(
+  schema: ConfigSchema,
+  key: string
+): number | undefined {
+  const value = schema[key]
+  return typeof value === 'number' ? value : undefined
+}
+
+function validateString(schema: ConfigSchema, value: string): string | null {
+  const minLength = numberConstraint(schema, 'minLength')
+  if (minLength !== undefined && value.length < minLength) {
+    return i18n.t(
+      'providers.editor.validation.minLength',
+      'Must be at least {{min}} characters',
+      { min: minLength }
+    )
+  }
+  const maxLength = numberConstraint(schema, 'maxLength')
+  if (maxLength !== undefined && value.length > maxLength) {
+    return i18n.t(
+      'providers.editor.validation.maxLength',
+      'Must be at most {{max}} characters',
+      { max: maxLength }
+    )
+  }
+  const pattern = schema.pattern
+  if (typeof pattern === 'string' && pattern.length > 0) {
+    const [regex] = tryCatchSync(() => new RegExp(pattern))
+    if (regex && !regex.test(value)) {
+      return i18n.t(
+        'providers.editor.validation.pattern',
+        'Must match the pattern {{pattern}}',
+        { pattern }
+      )
+    }
+  }
+  if (schema.format === 'uri' || schema.format === 'url') {
+    const [, error] = tryCatchSync(() => new URL(value))
+    if (error) {
+      return i18n.t('providers.editor.validation.url', 'Not a valid URL')
+    }
+  }
+  return null
+}
+
+function validateNumber(schema: ConfigSchema, value: number): string | null {
+  const minimum = numberConstraint(schema, 'minimum')
+  if (minimum !== undefined && value < minimum) {
+    return i18n.t(
+      'providers.editor.validation.minimum',
+      'Must be at least {{min}}',
+      { min: minimum }
+    )
+  }
+  const maximum = numberConstraint(schema, 'maximum')
+  if (maximum !== undefined && value > maximum) {
+    return i18n.t(
+      'providers.editor.validation.maximum',
+      'Must be at most {{max}}',
+      { max: maximum }
+    )
+  }
+  if (schema.type === 'integer' && !Number.isInteger(value)) {
+    return i18n.t(
+      'providers.editor.validation.integer',
+      'Must be a whole number'
+    )
+  }
+  return null
+}
+
+// Empty values are valid here; `required` is enforced separately so optional
+// fields can stay blank without tripping their constraints.
+export function validateScalar(
+  schema: ConfigSchema,
+  value: unknown
+): string | null {
+  if (isEmptyValue(value)) {
+    return null
+  }
+  if (typeof value === 'string') {
+    return validateString(schema, value)
+  }
+  if (typeof value === 'number') {
+    return validateNumber(schema, value)
+  }
+  return null
+}
+
+export interface ConfigValueError {
+  path: string
+  message: string
+}
+
+function joinPath(path: string, key: string): string {
+  return path === '' ? key : `${path}.${key}`
+}
+
+function collectErrors(
+  schema: ConfigSchema,
+  value: unknown,
+  path: string,
+  errors: ConfigValueError[]
+): void {
+  switch (getFieldKind(schema)) {
+    case 'object': {
+      collectObjectErrors(schema, isRecord(value) ? value : {}, path, errors)
+      return
+    }
+    case 'array': {
+      const itemSchema = schema.items
+      if (!itemSchema || !Array.isArray(value)) {
+        return
+      }
+      value.forEach((item, index) => {
+        collectErrors(itemSchema, item, joinPath(path, String(index)), errors)
+      })
+      return
+    }
+    default: {
+      const message = validateScalar(schema, value)
+      if (message) {
+        errors.push({ path, message })
+      }
+    }
+  }
+}
+
+function collectObjectErrors(
+  schema: ConfigSchema,
+  record: Record<string, unknown>,
+  path: string,
+  errors: ConfigValueError[]
+): void {
+  const required = new Set(schema.required ?? [])
+  for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
+    const childPath = joinPath(path, key)
+    const childValue = record[key]
+    if (isEmptyValue(childValue)) {
+      if (required.has(key)) {
+        errors.push({
+          path: childPath,
+          message: i18n.t(
+            'providers.editor.validation.required',
+            'This field is required'
+          ),
+        })
+      }
+      continue
+    }
+    collectErrors(propSchema, childValue, childPath, errors)
+  }
+}
+
+export function validateConfigValues(
+  schema: ConfigSchema | undefined,
+  values: Record<string, unknown>
+): ConfigValueError[] {
+  if (!schema?.properties) {
+    return []
+  }
+  const errors: ConfigValueError[] = []
+  collectObjectErrors(schema, values, '', errors)
+  return errors
 }
 
 // Schema fields fully replace their stored values, but stored keys the schema


### PR DESCRIPTION
## Summary
- The schema-driven provider config form now honors JSON-schema constraints from the manifest's configSchema (`pattern`, `format: uri/url`, `minLength`/`maxLength`, `minimum`/`maximum`, integer wholeness) as react-hook-form field rules, with the violation message shown in the field's helper text. Previously only `required` was enforced, so invalid URLs and out-of-range values saved cleanly and failed later as opaque runtime errors.
- The assembled configValues are also validated against the configSchema on submit (`validateConfigValues` walks objects, arrays, and required keys). Errors map back to fields via `setError`; since rendered fields are already blocked by their own rules, a submit-level error usually sits on an unrendered field, so the first one is also surfaced as an error toast instead of silently blocking the save.
- `SelectField` now shows the error message in helper text like `ScalarField` does, instead of only a red border.
- New `providers.editor.validation.*` strings in en and zh.

## Test plan
- Verified: lint pass (tsc + biome) · unit `pnpm --filter danmaku-anywhere test` 582 passed · e2e `e2e/specs/providers/config-form.spec.ts` 5 passed (rebuilt with `VITE_DA_ENV=e2e`; remaining suite left to CI)
- [ ] `pnpm --filter danmaku-anywhere exec vitest run src/popup/pages/providers/components/forms/schemaForm.test.ts`
- [ ] e2e: `packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts` (new test authors a user manifest with `format: uri` + `minimum`/`maximum` constraints, asserts field errors block the save and fixed values persist)

## Notes
- Bundled manifests carry no constraint keywords today, so the e2e seeds them through a user manifest authored in the manifest editor; the constraints matter for user manifests and future catalog updates.
- `pattern` regexes come from the manifest and run on the popup thread; a catastrophic-backtracking pattern could stall the popup while typing. Manifests are user-installed and already execute arbitrary pipelines, so this stays within the existing trust boundary.
- Constraint values of the wrong type (e.g. `minLength: "5"`) are ignored rather than rejected, consistent with the form's lenient handling of unknown schema shapes.
- The toast path for submit-level errors on unrendered fields has no automated test; it needs a manifest with an unrenderable field kind plus a constraint-violating stored value, which the editor itself refuses to produce.