### PR TITLE
(extension) recover from manifest update and catalog-load failures [DA-633]

### DIFF
--- a/packages/danmaku-anywhere/e2e/AGENTS.md
+++ b/packages/danmaku-anywhere/e2e/AGENTS.md
@@ -91,6 +91,8 @@ test.use({ expectedConsoleErrors: [/SchemaValidationError: known stale fixture/]
 
 One-line justification per entry. Treat opt-outs as tech debt — leaving them unjustified means a real regression hides behind a "we always saw that one."
 
+When passing two or more patterns, use strings, not RegExps. Playwright's `test.use` reads any array whose second element is `typeof 'object'` as a `[value, options]` fixture tuple, and a RegExp is an object — so a multi-RegExp array silently collapses to its first pattern and the assertion throws `expectedConsoleErrors.some is not a function`. A single-RegExp array is safe.
+
 ## Page Objects (POMs)
 
 POMs live under `e2e/pom/`. The composed root is `Popup` (`e2e/pom/Popup.ts`); page-area POMs hang off it (`popup.mount`, `popup.search`, `popup.seasonDetails`, `popup.toast`, `popup.dialog`). `IntegrationPage` is standalone — it doesn't open via `chrome-extension://`.

--- a/packages/danmaku-anywhere/e2e/AGENTS.md
+++ b/packages/danmaku-anywhere/e2e/AGENTS.md
@@ -91,7 +91,7 @@ test.use({ expectedConsoleErrors: [/SchemaValidationError: known stale fixture/]
 
 One-line justification per entry. Treat opt-outs as tech debt — leaving them unjustified means a real regression hides behind a "we always saw that one."
 
-When passing two or more patterns, use strings, not RegExps. Playwright's `test.use` reads any array whose second element is `typeof 'object'` as a `[value, options]` fixture tuple, and a RegExp is an object — so a multi-RegExp array silently collapses to its first pattern and the assertion throws `expectedConsoleErrors.some is not a function`. A single-RegExp array is safe.
+When passing two or more patterns, use strings, not RegExps. Playwright's `test.use` reads any array whose second element is `typeof 'object'` as a `[value, options]` fixture tuple, and a RegExp is an object: a multi-RegExp array silently collapses to its first pattern. The fixture throws a pointed error when this happens. A single-RegExp array is safe.
 
 ## Page Objects (POMs)
 

--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -25,6 +25,9 @@ export function manifestVersion(id: string): string {
   return loadManifest(id).version
 }
 
+// Shape of the chrome.storage `manifests` record as specs read it back.
+export type StoredManifests = Record<string, { manifest: { version: string } }>
+
 // Builds a chrome.storage `manifests` record from the real dango manifests,
 // optionally pinning some ids to an older version so the catalog advertises a
 // newer one (an "update available"). Seed via the profile's rawStorage.

--- a/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
@@ -55,6 +55,22 @@ export class ProvidersPage {
     await this.updateButton().click()
   }
 
+  updatingButton(): Locator {
+    return this.page.getByRole('button', { name: /^(Updating…|更新中…)$/ })
+  }
+
+  retryButton(): Locator {
+    return this.page.getByRole('button', { name: /^(Retry|重试)$/ })
+  }
+
+  updateFailedLabel(): Locator {
+    return this.page.getByText(/^(Update failed|更新失败)$/)
+  }
+
+  checkedNeverLabel(): Locator {
+    return this.page.getByText(/not checked yet|尚未检查/)
+  }
+
   field(label: string | RegExp): Locator {
     return this.page.getByLabel(label)
   }

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -89,6 +89,14 @@ export const test = base.extend<{
   // Skipped when the test already failed so a real failure isn't drowned out.
   _assertNoUnexpectedConsoleErrors: [
     async ({ context, expectedConsoleErrors }, use, testInfo) => {
+      // Playwright reads a multi-RegExp array passed to test.use as a
+      // [value, options] fixture tuple (a RegExp is typeof 'object'), leaving
+      // a bare RegExp here and silently dropping the other patterns.
+      if (!Array.isArray(expectedConsoleErrors)) {
+        throw new Error(
+          'expectedConsoleErrors resolved to a non-array. When passing multiple patterns, use strings instead of RegExps (see e2e/AGENTS.md).'
+        )
+      }
       await use()
       if (testInfo.status === 'failed' || testInfo.status === 'timedOut') {
         return

--- a/packages/danmaku-anywhere/e2e/specs/sources/update-recovery.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/update-recovery.spec.ts
@@ -1,0 +1,114 @@
+import {
+  manifestStoreSeed,
+  manifestVersion,
+  mockCatalog,
+} from '../../network/catalog'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Failure recovery on the providers page. An update whose manifest file fails
+ * to download shows the in-flight "Updating" state, then marks the row as
+ * failed with a Retry action; once the outage clears, Retry applies the
+ * update. A catalog refresh against an unreachable index (after its single
+ * retry) surfaces an error toast instead of silently keeping the stale list.
+ */
+
+type StoredManifests = Record<string, { manifest: { version: string } }>
+
+const BUMPED = '9.9.9'
+
+test.use({
+  // The outage paths under test log from the SW before the popup surfaces
+  // them as toasts: per-file fetch failure, index failure after its retry,
+  // and the RPC handler relaying the rejection to the popup. These must be
+  // strings: Playwright reads a multi-RegExp array as a [value, options]
+  // fixture tuple (typeof RegExp is 'object') and drops every pattern but
+  // the first.
+  expectedConsoleErrors: [
+    'Failed to fetch catalog manifest',
+    'Failed to fetch manifest catalog',
+    'Error in RPC handler',
+  ],
+})
+
+test('a failed update marks the row and Retry applies it once the outage clears', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  const current = manifestVersion('bilibili')
+
+  await applyProfile(context, da, {
+    providers: { bilibili: {} },
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed() },
+    ],
+    network: [mockCatalog(undefined, { bilibili: BUMPED })],
+  })
+
+  // Registered after applyProfile so it shadows the catalog mock's file
+  // route. Holding the response open keeps the in-flight state assertable.
+  let outage = true
+  let releaseFile!: () => void
+  const fileHeld = new Promise<void>((resolve) => {
+    releaseFile = resolve
+  })
+  await context.route(/\/manifest\/file/, async (route) => {
+    if (!outage) {
+      return route.fallback()
+    }
+    await fileHeld
+    await route.fulfill({ status: 500, body: 'unavailable' })
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeVisible()
+
+  await popup.providers.update()
+  await expect(popup.providers.updatingButton()).toBeVisible()
+  releaseFile()
+
+  await popup.toast.expectError(/Failed to apply updates/)
+  await expect(popup.providers.updateFailedLabel()).toBeVisible()
+  await expect(popup.providers.retryButton()).toBeVisible()
+
+  outage = false
+  await popup.providers.retryButton().click()
+
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeHidden()
+  const stored = (await da.storage.get('local', 'manifests')) as StoredManifests
+  expect(stored.bilibili.manifest.version).toBe(BUMPED)
+})
+
+test('a catalog refresh against an unreachable index surfaces an error toast', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  await applyProfile(context, da, {
+    providers: { bilibili: {} },
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed() },
+    ],
+    network: [mockCatalog()],
+  })
+
+  // Registered after applyProfile so it shadows the catalog mock's index.
+  await context.route(/\/manifest(\?|$)/, (route) =>
+    route.fulfill({ status: 503, body: 'unavailable' })
+  )
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  await expect(popup.providers.checkedNeverLabel()).toBeVisible()
+
+  await popup.providers.refreshCatalog()
+
+  await popup.toast.expectError(/Failed to fetch the manifest catalog/, {
+    timeout: 10_000,
+  })
+  await expect(popup.providers.checkedNeverLabel()).toBeVisible()
+})

--- a/packages/danmaku-anywhere/e2e/specs/sources/update-recovery.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/update-recovery.spec.ts
@@ -2,6 +2,7 @@ import {
   manifestStoreSeed,
   manifestVersion,
   mockCatalog,
+  type StoredManifests,
 } from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
@@ -10,22 +11,18 @@ import { applyProfile } from '../../setup/profile'
 /**
  * Failure recovery on the providers page. An update whose manifest file fails
  * to download shows the in-flight "Updating" state, then marks the row as
- * failed with a Retry action; once the outage clears, Retry applies the
- * update. A catalog refresh against an unreachable index (after its single
- * retry) surfaces an error toast instead of silently keeping the stale list.
+ * failed with a Retry action; Retry applies it once the outage clears. The
+ * failed row survives a full catalog outage, and a refresh against an
+ * unreachable index surfaces an error toast instead of a silent stale list.
  */
-
-type StoredManifests = Record<string, { manifest: { version: string } }>
 
 const BUMPED = '9.9.9'
 
 test.use({
   // The outage paths under test log from the SW before the popup surfaces
   // them as toasts: per-file fetch failure, index failure after its retry,
-  // and the RPC handler relaying the rejection to the popup. These must be
-  // strings: Playwright reads a multi-RegExp array as a [value, options]
-  // fixture tuple (typeof RegExp is 'object') and drops every pattern but
-  // the first.
+  // and the RPC handler relaying the rejection to the popup. Strings, not
+  // RegExps: see the multi-pattern tuple gotcha in e2e/AGENTS.md.
   expectedConsoleErrors: [
     'Failed to fetch catalog manifest',
     'Failed to fetch manifest catalog',
@@ -81,6 +78,45 @@ test('a failed update marks the row and Retry applies it once the outage clears'
   await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeHidden()
   const stored = (await da.storage.get('local', 'manifests')) as StoredManifests
   expect(stored.bilibili.manifest.version).toBe(BUMPED)
+})
+
+test('a failed update keeps its row when the whole catalog is unreachable', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  const current = manifestVersion('bilibili')
+
+  await applyProfile(context, da, {
+    providers: { bilibili: {} },
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed() },
+    ],
+    network: [mockCatalog(undefined, { bilibili: BUMPED })],
+  })
+
+  // Registered after applyProfile so it shadows the whole catalog mock
+  // (index and files) once the outage starts.
+  let outage = false
+  await context.route(/\/manifest/, async (route) => {
+    if (!outage) {
+      return route.fallback()
+    }
+    await route.fulfill({ status: 503, body: 'unavailable' })
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeVisible()
+
+  outage = true
+  await popup.providers.update()
+
+  await popup.toast.expectError(/Failed to fetch the manifest catalog/, {
+    timeout: 10_000,
+  })
+  await expect(popup.providers.updateFailedLabel()).toBeVisible()
+  await expect(popup.providers.retryButton()).toBeVisible()
 })
 
 test('a catalog refresh against an unreachable index surfaces an error toast', async ({

--- a/packages/danmaku-anywhere/e2e/specs/sources/updates.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/updates.spec.ts
@@ -2,6 +2,7 @@ import {
   manifestStoreSeed,
   manifestVersion,
   mockCatalog,
+  type StoredManifests,
 } from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
@@ -14,8 +15,6 @@ import { applyProfile } from '../../setup/profile'
  * version is not prompted as an update: a Refresh applies it in place so the
  * Catalog row shows the latest, ready to import.
  */
-
-type StoredManifests = Record<string, { manifest: { version: string } }>
 
 const BUMPED = '9.9.9'
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -463,7 +463,7 @@ describe('ManifestRegistry', () => {
     expect(await registry.getLastCheckedAt()).toBeNull()
   })
 
-  it('getPendingUpdates returns nothing when the index fetch fails', async () => {
+  it('getPendingUpdates throws when the index fetch fails (distinct from no updates)', async () => {
     stubFetch(() => ({ status: 503, body: 'unavailable' }))
     const store = new InMemoryStore({
       one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
@@ -471,9 +471,9 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
 
-    expect(await settleIndexRetry(() => registry.getPendingUpdates())).toEqual(
-      []
-    )
+    await expect(
+      settleIndexRetry(() => registry.getPendingUpdates())
+    ).rejects.toThrow(/Failed to fetch the manifest catalog/)
   })
 
   it('applyUpdates replaces only the named ids and rebuilds their runners', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -14,7 +14,8 @@ import type {
  * user imports), detect-vs-apply (getPendingUpdates diffs versions without
  * fetching files or applying; applyUpdates replaces only the named preinstalled
  * ids, never a user import or an unseeded id), skipping a bad/failed file,
- * index failures, that neither update() nor getPendingUpdates stamps
+ * index failures (one retry after a delay, then give up), that neither
+ * update() nor getPendingUpdates stamps
  * lastCheckedAt (only recordChecked does), and
  * register / unregister / hydrate-skip-invalid.
  */
@@ -109,7 +110,19 @@ function stubCatalogFetch(
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
+
+// A failed index fetch sleeps before its single retry, so run the call under
+// fake timers and skip past the delay. The no-op catch keeps a rejection that
+// settles during the timer advance from surfacing as unhandled.
+async function settleIndexRetry<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers()
+  const promise = run()
+  promise.catch(() => {})
+  await vi.advanceTimersByTimeAsync(1000)
+  return promise
+}
 
 class InMemoryStore implements IManifestStore {
   private lastCheckedAt: number | null = null
@@ -279,14 +292,35 @@ describe('ManifestRegistry', () => {
     )
   })
 
-  it('update leaves the store empty when the index fetch fails', async () => {
-    stubFetch(() => ({ status: 503, body: 'unavailable' }))
+  it('update retries once and leaves the store empty when the index fetch keeps failing', async () => {
+    const fetchMock = stubFetch(() => ({ status: 503, body: 'unavailable' }))
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.update()).resolves.toBe(false)
+    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(false)
 
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(await store.getAll()).toEqual({})
     expect(registry.list()).toEqual([])
+  })
+
+  it('update succeeds when the index fetch recovers on the retry', async () => {
+    let indexCalls = 0
+    stubFetch((url) => {
+      if (url.includes('/manifest/file')) {
+        return { status: 200, body: makeManifest('one') }
+      }
+      indexCalls += 1
+      if (indexCalls === 1) {
+        return { status: 503, body: 'unavailable' }
+      }
+      return { status: 200, body: { manifests: [catalogEntry('one')] } }
+    })
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(true)
+
+    expect(indexCalls).toBe(2)
+    expect(registry.list()).toEqual(['one'])
   })
 
   it('update leaves the store empty when the index body is malformed', async () => {
@@ -297,7 +331,7 @@ describe('ManifestRegistry', () => {
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(registry.update()).resolves.toBe(false)
+    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(false)
 
     expect(await store.getAll()).toEqual({})
     expect(registry.list()).toEqual([])
@@ -437,7 +471,9 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
 
-    expect(await registry.getPendingUpdates()).toEqual([])
+    expect(await settleIndexRetry(() => registry.getPendingUpdates())).toEqual(
+      []
+    )
   })
 
   it('applyUpdates replaces only the named ids and rebuilds their runners', async () => {
@@ -518,9 +554,9 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     await registry.ready
 
-    await expect(registry.applyUpdates(['one'])).rejects.toThrow(
-      /Failed to fetch the manifest catalog/
-    )
+    await expect(
+      settleIndexRetry(() => registry.applyUpdates(['one']))
+    ).rejects.toThrow(/Failed to fetch the manifest catalog/)
   })
 
   it('update leaves a user import untouched even when the catalog lists the same id', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -35,6 +35,10 @@ const zCatalogIndex = z.object({
 type CatalogEntry = z.infer<typeof zCatalogEntry>
 type CatalogManifest = { raw: unknown; parsed: Manifest }
 
+// Shared by every catalog-gated path; tests and the popup toast match on it.
+export const CATALOG_UNREACHABLE_MESSAGE =
+  'Failed to fetch the manifest catalog'
+
 function storedVersion(manifest: unknown): unknown {
   if (
     manifest !== null &&
@@ -153,12 +157,14 @@ export class ManifestRegistry {
   }
 
   // Index-only: diff stored versions against the catalog without fetching files
-  // or applying.
+  // or applying. Throws on an unreachable catalog: "no updates" and "could not
+  // check" must stay distinguishable, or a failed check would clear the
+  // popup's pending list.
   async getPendingUpdates(): Promise<ManifestUpdate[]> {
     await this.ready
     const entries = await this.loadIndex()
     if (!entries) {
-      return []
+      throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     const stored = await this.store.getAll()
     const updates: ManifestUpdate[] = []
@@ -188,7 +194,7 @@ export class ManifestRegistry {
     await this.ready
     const entries = await this.loadIndex()
     if (!entries) {
-      throw new Error('Failed to fetch the manifest catalog')
+      throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     const wanted = new Set(manifestIds)
     const stored = await this.store.getAll()
@@ -284,8 +290,6 @@ export class ManifestRegistry {
     return fetched.map(({ parsed }) => parsed.id)
   }
 
-  // One retry smooths over a transient network blip without stalling a real
-  // outage for long.
   private async loadIndex(): Promise<CatalogEntry[] | null> {
     try {
       return await this.fetchIndex()

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -12,7 +12,7 @@ import type {
   ManifestUpdate,
   ProviderManifestInfo,
 } from '@/common/rpcClient/background/types'
-import { invariant } from '@/common/utils/utils'
+import { invariant, sleep } from '@/common/utils/utils'
 import { extensionFetchLike } from './extensionFetchLike'
 import {
   type IManifestStore,
@@ -284,7 +284,15 @@ export class ManifestRegistry {
     return fetched.map(({ parsed }) => parsed.id)
   }
 
+  // One retry smooths over a transient network blip without stalling a real
+  // outage for long.
   private async loadIndex(): Promise<CatalogEntry[] | null> {
+    try {
+      return await this.fetchIndex()
+    } catch (e) {
+      this.log.warn('Catalog index fetch failed, retrying:', e)
+    }
+    await sleep(1000)
     try {
       return await this.fetchIndex()
     } catch (e) {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -477,7 +477,7 @@ describe('ProviderService.refreshCatalog', () => {
     expect(recordChecked).toHaveBeenCalledTimes(1)
   })
 
-  it('does not record a check when the catalog index fetch fails', async () => {
+  it('throws and does not record a check when the catalog index fetch fails', async () => {
     const recordChecked = vi.fn(async () => {})
     const getPendingUpdates = vi.fn(async () => [])
     const registry = {
@@ -500,7 +500,9 @@ describe('ProviderService.refreshCatalog', () => {
       silentExtensionOptions
     )
 
-    await service.refreshCatalog()
+    await expect(service.refreshCatalog()).rejects.toThrow(
+      /Failed to fetch the manifest catalog/
+    )
 
     expect(getPendingUpdates).not.toHaveBeenCalled()
     expect(recordChecked).not.toHaveBeenCalled()

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -406,10 +406,11 @@ describe('ProviderService.refreshCatalog', () => {
   }) {
     const applyUpdates = vi.fn(async () => {})
     const recordChecked = vi.fn(async () => {})
+    const getPendingUpdates = vi.fn(async () => opts.pending)
     const registry = {
       ready: Promise.resolve(true),
       update: vi.fn(async () => true),
-      getPendingUpdates: vi.fn(async () => opts.pending),
+      getPendingUpdates,
       applyUpdates,
       recordChecked,
       listManifests: vi.fn(() => []),
@@ -436,7 +437,7 @@ describe('ProviderService.refreshCatalog', () => {
       silentExtensionOptions
     )
 
-    return { service, applyUpdates, recordChecked }
+    return { service, applyUpdates, recordChecked, getPendingUpdates }
   }
 
   it('auto-applies updates for uninstalled manifests only', async () => {
@@ -464,6 +465,20 @@ describe('ProviderService.refreshCatalog', () => {
     await service.refreshCatalog()
 
     expect(applyUpdates).not.toHaveBeenCalled()
+  })
+
+  it('still records the check when pending detection fails mid-sync', async () => {
+    const { service, applyUpdates, recordChecked, getPendingUpdates } =
+      buildForRefresh({
+        pending: [],
+        installedManifestIds: [],
+      })
+    getPendingUpdates.mockRejectedValueOnce(new Error('index died mid-sync'))
+
+    await service.refreshCatalog()
+
+    expect(applyUpdates).not.toHaveBeenCalled()
+    expect(recordChecked).toHaveBeenCalledTimes(1)
   })
 
   it('stamps lastCheckedAt after bringing the catalog current', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -366,7 +366,8 @@ export class ProviderService {
     // mid-sync; skip the best-effort auto-apply rather than fail the sync.
     const pending = await this.manifestRegistry
       .getPendingUpdates()
-      .catch(() => {
+      .catch((e) => {
+        this.logger.warn('Failed to detect pending updates mid-sync:', e)
         return []
       })
     const configs = await this.providerConfigService.getAll()

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -34,7 +34,10 @@ import type {
 import { invariant, isServiceWorker } from '@/common/utils/utils'
 import type { OmitSeasonId } from './IDanmakuProvider'
 import { MANIFEST_RUN_OPTIONS } from './ManifestProviderService'
-import { ManifestRegistry } from './ManifestRegistry'
+import {
+  CATALOG_UNREACHABLE_MESSAGE,
+  ManifestRegistry,
+} from './ManifestRegistry'
 import {
   DanmakuProviderFactory,
   type IDanmakuProviderFactory,
@@ -344,7 +347,7 @@ export class ProviderService {
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
     const synced = await this.syncCatalog()
     if (!synced) {
-      throw new Error('Failed to fetch the manifest catalog')
+      throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     return this.listManifests(locale)
   }
@@ -359,7 +362,13 @@ export class ProviderService {
     if (!fetched) {
       return false
     }
-    const pending = await this.manifestRegistry.getPendingUpdates()
+    // update() just reached the index, so a failure here means it died
+    // mid-sync; skip the best-effort auto-apply rather than fail the sync.
+    const pending = await this.manifestRegistry
+      .getPendingUpdates()
+      .catch(() => {
+        return []
+      })
     const configs = await this.providerConfigService.getAll()
     const installed = new Set(configs.map((config) => config.manifestId))
     const uninstalled = pending

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -339,19 +339,25 @@ export class ProviderService {
     await this.syncCatalog()
   }
 
+  // Throws on an unreachable catalog so a user-driven refresh surfaces the
+  // failure instead of silently returning the stale list.
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
-    await this.syncCatalog()
+    const synced = await this.syncCatalog()
+    if (!synced) {
+      throw new Error('Failed to fetch the manifest catalog')
+    }
     return this.listManifests(locale)
   }
 
   // Bring the catalog current: updates for uninstalled sources (no config or
   // user data to disturb) are applied here, while installed-source updates stay
   // manual via the Updates list. Records the check only on a real sync, so
-  // "checked Nm ago" never advances on a bare detection.
-  async syncCatalog(): Promise<void> {
+  // "checked Nm ago" never advances on a bare detection. Returns whether the
+  // catalog index was reachable.
+  async syncCatalog(): Promise<boolean> {
     const fetched = await this.manifestRegistry.update()
     if (!fetched) {
-      return
+      return false
     }
     const pending = await this.manifestRegistry.getPendingUpdates()
     const configs = await this.providerConfigService.getAll()
@@ -370,6 +376,7 @@ export class ProviderService {
     }
     await this.manifestRegistry.recordChecked()
     await this.seedDefaultProviders()
+    return true
   }
 
   // Seed the preloaded configs once, after the catalog loads so each name comes

--- a/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/en/translation.json
@@ -708,9 +708,11 @@
     },
     "name": "Danmaku Providers",
     "updates": {
+      "failed": "Update failed",
       "title": "Updates available",
       "update": "Update",
       "updateAll": "Update all",
+      "updating": "Updating…",
       "version": "v{{from}} → v{{to}}"
     }
   },

--- a/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
+++ b/packages/danmaku-anywhere/src/common/localization/locales/zh/translation.json
@@ -685,9 +685,11 @@
     },
     "name": "弹幕源",
     "updates": {
+      "failed": "更新失败",
       "title": "有可用更新",
       "update": "更新",
       "updateAll": "全部更新",
+      "updating": "更新中…",
       "version": "v{{from}} → v{{to}}"
     }
   },

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/CatalogSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/CatalogSection.tsx
@@ -57,7 +57,7 @@ export const CatalogSection = ({
 }: CatalogSectionProps) => {
   const { t } = useTranslation()
   const toast = useToast.use.toast()
-  const { data, isLoading, isError } = useManifestList()
+  const { data, isLoading, isError, refetch } = useManifestList()
   const refresh = useRefreshCatalog()
 
   const checkedLabel = useCheckedAgoLabel(data?.lastCheckedAt ?? null)
@@ -79,9 +79,17 @@ export const CatalogSection = ({
     }
     if (isError) {
       return (
-        <Typography variant="body2" color="error" sx={{ py: 1 }}>
-          {t('providers.catalog.error', 'Failed to load catalog')}
-        </Typography>
+        <Stack
+          direction="row"
+          sx={{ alignItems: 'center', justifyContent: 'space-between', py: 1 }}
+        >
+          <Typography variant="body2" color="error">
+            {t('providers.catalog.error', 'Failed to load catalog')}
+          </Typography>
+          <Button size="small" onClick={() => refetch()}>
+            {t('common.retry', 'Retry')}
+          </Button>
+        </Stack>
       )
     }
     if (visible.length === 0) {

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/CatalogSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/CatalogSection.tsx
@@ -86,7 +86,11 @@ export const CatalogSection = ({
           <Typography variant="body2" color="error">
             {t('providers.catalog.error', 'Failed to load catalog')}
           </Typography>
-          <Button size="small" disabled={isFetching} onClick={() => refetch()}>
+          <Button
+            size="small"
+            disabled={isFetching}
+            onClick={() => void refetch()}
+          >
             {t('common.retry', 'Retry')}
           </Button>
         </Stack>

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/CatalogSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/CatalogSection.tsx
@@ -57,7 +57,7 @@ export const CatalogSection = ({
 }: CatalogSectionProps) => {
   const { t } = useTranslation()
   const toast = useToast.use.toast()
-  const { data, isLoading, isError, refetch } = useManifestList()
+  const { data, isLoading, isError, isFetching, refetch } = useManifestList()
   const refresh = useRefreshCatalog()
 
   const checkedLabel = useCheckedAgoLabel(data?.lastCheckedAt ?? null)
@@ -86,7 +86,7 @@ export const CatalogSection = ({
           <Typography variant="body2" color="error">
             {t('providers.catalog.error', 'Failed to load catalog')}
           </Typography>
-          <Button size="small" onClick={() => refetch()}>
+          <Button size="small" disabled={isFetching} onClick={() => refetch()}>
             {t('common.retry', 'Retry')}
           </Button>
         </Stack>

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/UpdatesSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/UpdatesSection.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Stack, Typography } from '@mui/material'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '@/common/components/Toast/toastStore'
 import type { ProviderManifestInfo } from '@/common/rpcClient/background/types'
@@ -20,6 +21,9 @@ export const UpdatesSection = ({
   const toast = useToast.use.toast()
   const { data } = usePendingUpdates()
   const apply = useApplyUpdates()
+  // Keyed per row: the mutation object only remembers its last call, so a
+  // retry of one row must not clear another row's failure marker.
+  const [failedIds, setFailedIds] = useState<ReadonlySet<string>>(new Set())
 
   const updates = installedUpdates(data ?? [], installedManifestIds)
 
@@ -29,14 +33,24 @@ export const UpdatesSection = ({
 
   const runApply = (manifestIds: string[]) => {
     apply.mutate(manifestIds, {
+      onSuccess: () => {
+        setFailedIds((prev) => {
+          const next = new Set(prev)
+          for (const id of manifestIds) {
+            next.delete(id)
+          }
+          return next
+        })
+      },
       onError: (error) => {
+        setFailedIds((prev) => new Set([...prev, ...manifestIds]))
         toast.error(error.message)
       },
     })
   }
 
   const attempted = (manifestId: string) => {
-    return apply.variables?.includes(manifestId) === true
+    return apply.variables?.includes(manifestId) ?? false
   }
 
   const buttonLabel = (updating: boolean, failed: boolean) => {
@@ -68,7 +82,7 @@ export const UpdatesSection = ({
       <Stack sx={{ gap: 1 }}>
         {updates.map((update) => {
           const updatingThis = apply.isPending && attempted(update.manifestId)
-          const failedThis = apply.isError && attempted(update.manifestId)
+          const failedThis = !updatingThis && failedIds.has(update.manifestId)
           const versionLabel = t(
             'providers.updates.version',
             'v{{from}} → v{{to}}',

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/UpdatesSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/UpdatesSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CircularProgress, Stack } from '@mui/material'
+import { Box, Button, Stack, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '@/common/components/Toast/toastStore'
 import type { ProviderManifestInfo } from '@/common/rpcClient/background/types'
@@ -35,6 +35,20 @@ export const UpdatesSection = ({
     })
   }
 
+  const attempted = (manifestId: string) => {
+    return apply.variables?.includes(manifestId) === true
+  }
+
+  const buttonLabel = (updating: boolean, failed: boolean) => {
+    if (updating) {
+      return t('providers.updates.updating', 'Updating…')
+    }
+    if (failed) {
+      return t('common.retry', 'Retry')
+    }
+    return t('providers.updates.update', 'Update')
+  }
+
   return (
     <Box sx={{ pb: 1.5 }}>
       <SectionHeader
@@ -53,8 +67,13 @@ export const UpdatesSection = ({
       </SectionHeader>
       <Stack sx={{ gap: 1 }}>
         {updates.map((update) => {
-          const updatingThis =
-            apply.isPending && apply.variables?.includes(update.manifestId)
+          const updatingThis = apply.isPending && attempted(update.manifestId)
+          const failedThis = apply.isError && attempted(update.manifestId)
+          const versionLabel = t(
+            'providers.updates.version',
+            'v{{from}} → v{{to}}',
+            { from: update.fromVersion, to: update.toVersion }
+          )
           return (
             <Box key={update.manifestId} sx={sourceCardSx}>
               <ProviderRow
@@ -62,23 +81,29 @@ export const UpdatesSection = ({
                 primary={
                   manifestById.get(update.manifestId)?.name ?? update.manifestId
                 }
-                secondary={t(
-                  'providers.updates.version',
-                  'v{{from}} → v{{to}}',
-                  { from: update.fromVersion, to: update.toVersion }
-                )}
+                secondary={
+                  failedThis ? (
+                    <Typography
+                      component="span"
+                      variant="inherit"
+                      color="error"
+                    >
+                      {t('providers.updates.failed', 'Update failed')}
+                    </Typography>
+                  ) : (
+                    versionLabel
+                  )
+                }
                 action={
                   <Button
                     size="small"
                     variant="outlined"
                     onClick={() => runApply([update.manifestId])}
                     disabled={apply.isPending}
+                    loading={updatingThis}
+                    loadingPosition="start"
                   >
-                    {updatingThis ? (
-                      <CircularProgress size={16} />
-                    ) : (
-                      t('providers.updates.update', 'Update')
-                    )}
+                    {buttonLabel(updatingThis, failedThis)}
                   </Button>
                 }
               />

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
@@ -16,10 +16,12 @@ export const useApplyUpdates = () => {
   return useMutation({
     mutationFn: (manifestIds: string[]) =>
       chromeRpcClient.providerApplyUpdates({ manifestIds }),
-    onSuccess: () => {
+    onSettled: () => {
       // Applying changes stored versions, so both the pending list and the
-      // manifest list (used for the version subtitles) need to refetch. The
-      // version is locale-independent, so invalidate every locale's list.
+      // manifest list (used for the version subtitles) need to refetch. A
+      // failed apply can still have persisted some of the requested manifests,
+      // so refetch on error too. The version is locale-independent, so
+      // invalidate every locale's list.
       void queryClient.invalidateQueries({
         queryKey: sourceQueryKeys.pendingUpdates(),
       })

--- a/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/hooks/usePendingUpdates.ts
@@ -8,6 +8,9 @@ export const usePendingUpdates = () => {
     select: (res) => res.data,
     queryKey: sourceQueryKeys.pendingUpdates(),
     refetchOnWindowFocus: false,
+    // The background already retries the catalog index fetch once; client
+    // retries would multiply that during an outage.
+    retry: false,
   })
 }
 


### PR DESCRIPTION
## Summary
- A failed manifest update now marks the row "Update failed" with a Retry button (per-row state, so retrying one row does not clear another row's marker) instead of dead-ending on a toast; the in-flight state shows "Updating…" instead of a bare spinner.
- `ManifestRegistry.getPendingUpdates` now throws on an unreachable catalog instead of returning `[]`, so a failed check is distinguishable from "no updates" and the popup keeps its cached pending list (and the Retry affordance) during a full outage.
- A user-driven catalog refresh now surfaces an unreachable index as an error toast: `syncCatalog` reports reachability and `refreshCatalog` throws on failure instead of silently returning the stale list. Background syncs (install, alarm) are unaffected.
- The catalog index fetch retries once after 1s before giving up; the pending-updates query sets `retry: false` so client retries don't multiply it.
- Catalog list load failure now renders a Retry button next to the error message.
- e2e hardening: `expectedConsoleErrors` fixture now throws a pointed error when Playwright's `test.use` tuple interpretation collapses a multi-RegExp array (documented in `e2e/AGENTS.md`); shared `StoredManifests` type moved to `e2e/network/catalog.ts`.

## Test plan
- Verified: lint pass (tsc + biome) · `pnpm --filter '...[origin/master]' test` 569 passed (+ new registry/service cases after review fixes, 104 in providers suite) · e2e: `sources/update-recovery.spec.ts` (3 specs, new), `sources/updates.spec.ts`, `sources/catalog-import.spec.ts`, `providers/config-form.spec.ts`, `lifecycle/install.spec.ts` all pass locally
- [ ] `pnpm exec playwright test e2e/specs/sources/update-recovery.spec.ts` covers: file-outage update failure → Updating… → failed row → Retry succeeds; full-outage failure keeps the row visible; refresh against a dead index toasts the error
- CatalogSection's load-error Retry button has no automated coverage: the list query is RPC-backed (no network fetch), so its failure can't be induced with Playwright route mocks

## Notes
- The retry lives on the index fetch only; per-file fetch failures surface through the new row-level Retry instead.
- Worst-case latency during a hanging outage is ~11s per index load (5s timeout + 1s backoff + 5s timeout); affected paths are background queries and the refresh button spinner.
- `syncCatalog` still records the check if the index dies between its two reads (the catalog was reachable for the sync itself); auto-apply is skipped for that round.