### PR TITLE
(chore) model-selection guidance for agents [DA-647]

### DIFF
--- a/.claude/commands/da-dev.md
+++ b/.claude/commands/da-dev.md
@@ -9,6 +9,14 @@ Task: $ARGUMENTS
 
 Orchestrates: ClickUp task → branch → implement → verify → self-review → PR → review monitoring → human handoff.
 
+## Models
+
+Apply the model-selection guidance in CLAUDE.md (match the model to the task; don't reflexively inherit the session model). This workflow spans two kinds of session:
+
+- **Orchestrating session** (this one): ClickUp research, brainstorming, planning, and spec writing through step 2. Reasoning and spec quality dominate, so launch it on the most capable model available.
+- **Implementation session** (dispatched into the worktree at step 2, plus any resume): the coding work in steps 3-8. Use a strong coding model, scaled down for mechanical or low-risk changes (config, docs, small self-contained fixes). It need not be the top research-tier model. You choose this when dispatching, and `worktree-tab` threads it through as `claude --model <model>`.
+- **Subagents you spawn** (the step 5 reviews, exploration): pick per task. Their overrides cap at the highest tier the Agent tool exposes, below the orchestrating session's research tier.
+
 ## Step Details
 
 ### 1. ClickUp Task
@@ -29,7 +37,7 @@ That handles `git fetch`, `git worktree add`, env copy, `pnpm install`, `pnpm bu
 
 The task file `da-bootstrap` writes is a bare stub. Before handing off, fetch the ClickUp task (`clickup_get_task DA-XXX`) and append its description to the task file as a brief (the implementation notes, scope, acceptance criteria), so the new session starts with full context instead of re-deriving it. A bare stub is the single biggest cause of a dispatched session going off-track.
 
-Then use the `worktree-tab` skill to open a fresh Claude session in the worktree. The new session reads `<task_file>` and starts from step 3. **Stop the current session here.**
+Then use the `worktree-tab` skill to open a fresh Claude session in the worktree, passing the implementation model you chose (see Models above). The new session reads `<task_file>` and starts from step 3. **Stop the current session here.**
 
 For trivial changes (CLAUDE.md / docs / config-only): branch directly without a worktree:
 
@@ -165,6 +173,6 @@ After the PR is merged, run `/da-cleanup` to remove completed worktrees. This al
 
 - **Lint / type-check fails mid-way:** fix and commit on top. Don't amend.
 - **i18n keys touched but extraction not run:** `cd packages/danmaku-anywhere && pnpm i18n extract`, then stage the regenerated JSON.
-- **New Claude tab closed:** the worktree is still valid. `cd <worktree> && claude --add-dir . "Read ~/.claude/da-tasks/DA-XXX.md and continue"` to resume.
+- **New Claude tab closed:** the worktree is still valid. `cd <worktree> && claude --model <model> --add-dir . "Read ~/.claude/da-tasks/DA-XXX.md and continue"` to resume on the implementation model (see Models).
 - **Session worktree deleted under you** (e.g. `/da-cleanup` ran during the session): the shell cwd becomes invalid. Find the main checkout with `git worktree list` (the entry on `master`). For a trivial change, branch off `origin/master` there; for non-trivial work, bootstrap a fresh worktree. The task notes in `~/.claude/da-tasks/DA-XXX.md` survive the cleanup.
 - **CI flake (unrelated failure):** retry the workflow once via `gh run rerun <id>`. If it fails again, comment on the PR and stop the loop.

--- a/.claude/skills/worktree-tab/SKILL.md
+++ b/.claude/skills/worktree-tab/SKILL.md
@@ -8,10 +8,12 @@ description: Use to open a fresh Claude session in a new terminal tab for a da-d
 `scripts/da-bootstrap.mjs` ends with a `READY` block (`worktree=...`, `branch=...`, `task_file=...`, `title=...`). Parse those, then open a new terminal tab in the worktree running a fresh Claude session:
 
 ```bash
-claude --permission-mode acceptEdits --add-dir . -- "Read <task_file> and follow the instructions"
+claude --model <model> --permission-mode acceptEdits --add-dir . -- "Read <task_file> and follow the instructions"
 ```
 
-How you open the tab depends on the terminal you're in (`$TERM_PROGRAM`). Substitute `<worktree>`, `<task_file>`, `<title>`, and the task id (`DA-XXX`) from the `READY` block throughout.
+`<model>` is the implementation model for the dispatched session: a strong coding model chosen to fit the task, scaled down for mechanical or low-risk changes. It need not be the top research-tier model used for planning and spec writing. Pick from the aliases `claude --help` lists, following the model-selection guidance in `CLAUDE.md`.
+
+How you open the tab depends on the terminal you're in (`$TERM_PROGRAM`). Substitute `<model>`, `<worktree>`, `<task_file>`, `<title>`, and the task id (`DA-XXX`) from the `READY` block throughout.
 
 ## Warp
 
@@ -30,7 +32,7 @@ children = ["left", "right"]
 id = "left"
 type = "terminal"
 directory = "<worktree>"
-commands = ['claude --permission-mode acceptEdits --add-dir . -- "Read <task_file> and follow the instructions"']
+commands = ['claude --model <model> --permission-mode acceptEdits --add-dir . -- "Read <task_file> and follow the instructions"']
 is_focused = true
 
 [[panes]]
@@ -49,7 +51,7 @@ gdbus call --session --dest dev.warp.Warp --object-path /dev/warp/Warp \
 ## Windows Terminal (no Warp)
 
 ```
-wt new-tab --title '<title>' -d '<worktree>' -- powershell -NoExit -Command "claude --permission-mode acceptEdits --add-dir . -- 'Read <task_file> and follow the instructions'"
+wt new-tab --title '<title>' -d '<worktree>' -- powershell -NoExit -Command "claude --model <model> --permission-mode acceptEdits --add-dir . -- 'Read <task_file> and follow the instructions'"
 ```
 
 ## Other terminals

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,16 @@ Always prefer scripts defined in `package.json` over ad-hoc commands. Run `pnpm 
 - Use the `Result` type from `@danmaku-anywhere/result` for explicit error handling
 - Avoid throwing exceptions for expected error paths
 
+## Model selection
+
+When you launch a subagent or fan out work, match the model to the task instead of reflexively inheriting the current session's model or reaching for the most capable one. Subagents inherit the session model by default, which is usually more (and more expensive) than a narrow task needs, so scaling down is a deliberate choice you have to make.
+
+- Heavy reasoning, research, planning, spec writing, ambiguous problems: the most capable model available.
+- Routine implementation and well-scoped edits: a strong mid-tier model.
+- Cheap, narrow, deterministic work (locate a symbol, read a file, simple greps): the cheapest capable tier.
+
+Don't hardcode a model name as policy; the roster changes. Reason in tiers and pick from what is currently offered (`claude --help` lists the session aliases). Know the override ceiling: explicit subagent overrides are limited to the tiers the Agent/Workflow tools expose (currently `opus`/`sonnet`/`haiku`). A top-flagship alias can only be chosen when launching a session with `claude --model`, so a subagent can be scaled down from the session model but not pushed up past the highest override tier.
+
 ## Refactoring guidelines
 
 - Use TDD when refactoring — write tests first, start with reusable primitives


### PR DESCRIPTION
## Summary
- Add a generic `## Model selection` section to `CLAUDE.md`: match the model to the task instead of reflexively inheriting the session model or always reaching for the most capable one. Reason in tiers, don't hardcode a model name as policy (the roster changes), and note the override ceiling (subagent overrides cap at the tiers the Agent/Workflow tools expose; a top-flagship alias is session-launch-only).
- Apply it in `da-dev`: new `## Models` section (orchestrating session on the most capable model for research/plan/spec; dispatched implementation session on a task-fit coding model; spawned subagents picked per task). Dispatch and resume now reference the choice instead of naming models.
- Thread `claude --model <model>` through all three `worktree-tab` launch forms, with `<model>` described as a task-fit coding model chosen from current aliases.

## Test plan
- Verified: lint N/A (markdown-only, no JS/TS; lefthook biome step skipped with no files to inspect) · tests N/A · e2e N/A (no runtime code touched)
- Reviewer: skim the three diffs for accuracy of the model-selection wording.

## Notes
- Docs-only change to committed agent docs; code-targeted review commands and e2e don't apply.
- Verified no new em dashes per CLAUDE.md.