### PR TITLE
(extension) retire dead provider-config fields impl and isBuiltIn [DA-635]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/profile.ts
+++ b/packages/danmaku-anywhere/e2e/setup/profile.ts
@@ -1,7 +1,4 @@
-import {
-  DanDanChConvert,
-  DanmakuSourceType,
-} from '@danmaku-anywhere/danmaku-converter'
+import { DanDanChConvert } from '@danmaku-anywhere/danmaku-converter'
 import type { BrowserContext, Route } from '@playwright/test'
 import type { ExtensionOptions } from '../../src/common/options/extensionOptions/schema'
 import type { ProviderConfig } from '../../src/common/options/providerConfig/schema'
@@ -73,9 +70,7 @@ function buildBuiltInProviderConfigs(
       id: 'dandanplay',
       manifestId: 'dandanplay',
       name: 'DanDanPlay',
-      impl: DanmakuSourceType.DanDanPlay,
       enabled: dandanplay.enabled ?? false,
-      isBuiltIn: true,
       configValues: {
         baseUrl: PROXY_DDP_BASE_URL,
         chConvert: DanDanChConvert.None,
@@ -86,9 +81,7 @@ function buildBuiltInProviderConfigs(
       id: 'bilibili',
       manifestId: 'bilibili',
       name: 'Bilibili',
-      impl: DanmakuSourceType.Bilibili,
       enabled: bilibili.enabled ?? false,
-      isBuiltIn: true,
       configValues: {
         danmakuFormat: 'xml',
         ...bilibili.options,
@@ -98,9 +91,7 @@ function buildBuiltInProviderConfigs(
       id: 'tencent',
       manifestId: 'tencent',
       name: 'Tencent',
-      impl: DanmakuSourceType.Tencent,
       enabled: tencent.enabled ?? false,
-      isBuiltIn: true,
       configValues: {},
     },
   ]

--- a/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/import-migrate.spec.ts
@@ -67,7 +67,7 @@ test('current build migrates an imported v1.5.0 backup and danmaku export', asyn
     'provider config ids migrated to bare'
   ).toEqual([])
   const ddpBaseUrls = providers
-    .filter((p) => p.isBuiltIn === false && p.manifestId === 'dandanplay')
+    .filter((p) => p.manifestId === 'dandanplay' && p.id !== 'dandanplay')
     .map((p) => p.configValues.baseUrl as string | undefined)
   expect(
     ddpBaseUrls,

--- a/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/migration/migration-smoke.spec.ts
@@ -253,14 +253,16 @@ async function readCustomDdpBaseUrl(page: Page): Promise<string | undefined> {
     const pc = sync.providerConfig as
       | {
           data?: Array<{
-            isBuiltIn?: boolean
+            id?: string
             manifestId?: string
             configValues?: { baseUrl?: string }
           }>
         }
       | undefined
+    // The hosted built-in DDP keeps id === manifestId; a custom server has its
+    // own distinct id.
     const custom = (pc?.data ?? []).find(
-      (p) => p.isBuiltIn === false && p.manifestId === 'dandanplay'
+      (p) => p.manifestId === 'dandanplay' && p.id !== 'dandanplay'
     )
     return custom?.configValues?.baseUrl
   })

--- a/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/config-form.spec.ts
@@ -1,4 +1,3 @@
-import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
@@ -22,9 +21,7 @@ const customDdp: ProviderConfig = {
   id: 'custom-ddp-form',
   manifestId: 'dandanplay',
   name: 'My DDP Server',
-  impl: DanmakuSourceType.DanDanPlay,
   enabled: true,
-  isBuiltIn: false,
   configValues: {
     baseUrl: '',
     auth: { enabled: false, headers: [] },
@@ -122,9 +119,7 @@ const orphanedProvider: ProviderConfig = {
   id: 'orphaned-source',
   manifestId: 'manifest-that-failed-to-load',
   name: 'Orphaned Source',
-  impl: DanmakuSourceType.DanDanPlay,
   enabled: true,
-  isBuiltIn: false,
   configValues: {
     baseUrl: 'https://orphaned.example.invalid',
     auth: { enabled: false, headers: [] },

--- a/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/localization.spec.ts
@@ -1,4 +1,3 @@
-import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import { Language } from '../../../src/common/localization/language'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockCatalog } from '../../network/catalog'
@@ -18,9 +17,7 @@ const localDdp: ProviderConfig = {
   id: 'localized-ddp',
   manifestId: 'dandanplay',
   name: 'My DDP',
-  impl: DanmakuSourceType.DanDanPlay,
   enabled: true,
-  isBuiltIn: false,
   configValues: {
     baseUrl: '',
     auth: { enabled: false, headers: [] },

--- a/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-custom.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-custom.spec.ts
@@ -1,4 +1,3 @@
-import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockDandanplayCustom } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
@@ -19,9 +18,7 @@ const customConfig: ProviderConfig = {
   id: 'custom-ddp-1',
   manifestId: 'dandanplay',
   name: 'CustomDdp',
-  impl: DanmakuSourceType.DanDanPlay,
   enabled: true,
-  isBuiltIn: false,
   configValues: {
     baseUrl: CUSTOM_BASE_URL,
     auth: { enabled: false, headers: [] },

--- a/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-local-origin.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/dandanplay-local-origin.spec.ts
@@ -1,4 +1,3 @@
-import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { mockDandanplayCustom } from '../../network/dandanplay'
 import { Popup } from '../../pom/Popup'
@@ -19,9 +18,7 @@ const localConfig: ProviderConfig = {
   id: 'local-ddp-1',
   manifestId: 'dandanplay',
   name: 'LocalDdp',
-  impl: DanmakuSourceType.DanDanPlay,
   enabled: true,
-  isBuiltIn: false,
   configValues: {
     baseUrl: LOCAL_BASE_URL,
     auth: { enabled: false, headers: [] },

--- a/packages/danmaku-anywhere/e2e/specs/sources/instances.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/instances.spec.ts
@@ -1,4 +1,3 @@
-import { DanmakuSourceType } from '@danmaku-anywhere/danmaku-converter'
 import type { ProviderConfig } from '../../../src/common/options/providerConfig/schema'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
@@ -14,7 +13,6 @@ const homeServer: ProviderConfig = {
   id: 'home-ddp',
   manifestId: 'dandanplay',
   name: 'Home NAS',
-  impl: DanmakuSourceType.DanDanPlay,
   enabled: true,
   configValues: {
     baseUrl: 'https://ddp.home.invalid',

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
@@ -18,10 +18,9 @@ import type { ManifestRegistry } from './ManifestRegistry'
  * a ManifestProviderService configured for the source, or the legacy
  * MacCmsProviderService for `legacy:maccms` configs. Any non-maccms
  * manifestId (built-in or catalog) resolves to a ManifestProviderService
- * whose provider tag is derived from the manifestId, not read from the
- * persisted `config.impl`. Custom DanDanPlay servers share the `dandanplay`
- * manifest and thread their baseUrl/auth through configValues; there is no
- * DDP-compat special case.
+ * whose provider tag is derived from the manifestId. Custom DanDanPlay servers
+ * share the `dandanplay` manifest and thread their baseUrl/auth through
+ * configValues; there is no DDP-compat special case.
  */
 
 const RUN_OPTS = MANIFEST_RUN_OPTIONS
@@ -79,10 +78,8 @@ function customDdp(opts: {
   return {
     id: 'custom-1',
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-    impl: DanmakuSourceType.DanDanPlay,
     name: 'Custom DDP',
     enabled: true,
-    isBuiltIn: false,
     configValues: opts,
   }
 }
@@ -93,10 +90,8 @@ describe('ProviderFactory dispatch', () => {
     const service = factory({
       id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
       manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-      impl: DanmakuSourceType.DanDanPlay,
       name: 'DanDanPlay',
       enabled: true,
-      isBuiltIn: true,
       configValues: {},
     })
 
@@ -110,10 +105,8 @@ describe('ProviderFactory dispatch', () => {
     const service = factory({
       id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
       manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
-      impl: DanmakuSourceType.Bilibili,
       name: 'Bilibili',
       enabled: true,
-      isBuiltIn: true,
       configValues: { danmakuFormat: 'protobuf' },
     })
 
@@ -133,10 +126,8 @@ describe('ProviderFactory dispatch', () => {
     const service = factory({
       id: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
       manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
-      impl: DanmakuSourceType.Tencent,
       name: 'Tencent',
       enabled: true,
-      isBuiltIn: true,
       configValues: {},
     })
 
@@ -171,10 +162,8 @@ describe('ProviderFactory dispatch', () => {
     const service = factory({
       id: LEGACY_MACCMS_ID,
       manifestId: LEGACY_MACCMS_ID,
-      impl: DanmakuSourceType.MacCMS,
       name: 'MacCMS',
       enabled: true,
-      isBuiltIn: false,
       configValues: {},
     })
 
@@ -182,15 +171,13 @@ describe('ProviderFactory dispatch', () => {
     expect((service as unknown as { tag?: string }).tag).toBe('maccms-legacy')
   })
 
-  it('resolves a non-built-in catalog manifestId to ManifestProviderService with the derived tag, ignoring a stale impl', async () => {
+  it('resolves a non-built-in catalog manifestId to ManifestProviderService with the tag derived from the manifestId', async () => {
     const factory = await buildFactory()
     const service = factory({
       id: 'iqiyi-1',
       manifestId: 'iqiyi',
-      impl: DanmakuSourceType.Bilibili,
       name: 'iQIYI',
       enabled: true,
-      isBuiltIn: false,
       configValues: { region: 'cn' },
     })
 
@@ -201,21 +188,5 @@ describe('ProviderFactory dispatch', () => {
       { q: 'x', region: 'cn' },
       RUN_OPTS
     )
-  })
-
-  it('derives the tag from the manifestId even when the stored impl is Custom', async () => {
-    const factory = await buildFactory()
-    const service = factory({
-      id: 'iqiyi-2',
-      manifestId: 'iqiyi',
-      impl: DanmakuSourceType.Custom,
-      name: 'iQIYI',
-      enabled: true,
-      isBuiltIn: false,
-      configValues: {},
-    })
-
-    expect(service).toBeInstanceOf(ManifestProviderService)
-    expect(service.forProvider).toBe(DanmakuSourceType.DanDanPlay)
   })
 })

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -2,6 +2,7 @@ import {
   DanmakuSourceType,
   type EpisodeMeta,
   LEGACY_MACCMS_ID,
+  providerTypeFromManifestId,
   type WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -37,17 +38,12 @@ const silentExtensionOptions = {
   get: async () => ({ lang: 'zh' }),
 } as unknown as ExtensionOptionsService
 
-function makeConfig(
-  manifestId: string,
-  impl: DanmakuSourceType
-): ProviderConfig {
+function makeConfig(manifestId: string): ProviderConfig {
   return {
     id: `${manifestId}-1`,
     manifestId,
-    impl,
     name: manifestId,
     enabled: true,
-    isBuiltIn: false,
     configValues: {},
   }
 }
@@ -82,7 +78,7 @@ function build(
     id: 1,
     providerConfigId: config.id,
     providerIds: { animeId: 42 },
-    provider: config.impl,
+    provider: providerTypeFromManifestId(config.manifestId),
     title: 'Show',
   }
 
@@ -230,10 +226,7 @@ describe('ProviderService legacy-maccms decoupling', () => {
       const provider = makeProvider({
         getEpisodes: vi.fn(async () => []),
       })
-      const { service } = build(
-        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
-        provider
-      )
+      const { service } = build(makeConfig('iqiyi'), provider)
 
       await expect(service.fetchEpisodesBySeason(1)).resolves.toEqual([])
       expect(provider.getEpisodes).toHaveBeenCalledWith({ animeId: 42 })
@@ -241,10 +234,7 @@ describe('ProviderService legacy-maccms decoupling', () => {
 
     it('throws for a legacy MacCMS config', async () => {
       const provider = makeProvider()
-      const { service } = build(
-        makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS),
-        provider
-      )
+      const { service } = build(makeConfig(LEGACY_MACCMS_ID), provider)
 
       await expect(service.fetchEpisodesBySeason(1)).rejects.toThrow(
         'MacCMS does not support fetching episodes'
@@ -254,11 +244,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
 
     it('throws a source-removed error when the season is orphaned', async () => {
       const provider = makeProvider()
-      const { service } = build(
-        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
-        provider,
-        { configMissing: true }
-      )
+      const { service } = build(makeConfig('iqiyi'), provider, {
+        configMissing: true,
+      })
 
       await expect(service.fetchEpisodesBySeason(1)).rejects.toThrow(
         'This source has been removed'
@@ -276,11 +264,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
       }
       const existing = { ...insert, id: 99 }
       const provider = makeProvider({ search: vi.fn(async () => [insert]) })
-      const { service, seasonService } = build(
-        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
-        provider,
-        { findExisting: existing }
-      )
+      const { service, seasonService } = build(makeConfig('iqiyi'), provider, {
+        findExisting: existing,
+      })
 
       const result = await service.searchSeason({
         providerConfigId: 'iqiyi-1',
@@ -303,7 +289,7 @@ describe('ProviderService legacy-maccms decoupling', () => {
         search: vi.fn(async () => [customSeason]),
       })
       const { service, seasonService } = build(
-        makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS),
+        makeConfig(LEGACY_MACCMS_ID),
         provider,
         { findExisting: { ...customSeason, id: 7 } }
       )
@@ -329,10 +315,7 @@ describe('ProviderService legacy-maccms decoupling', () => {
 
     it('fetches danmaku for a generic source', async () => {
       const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
-      const { service } = build(
-        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
-        provider
-      )
+      const { service } = build(makeConfig('iqiyi'), provider)
 
       await service.getDanmaku({ type: 'by-meta', meta, options: {} })
 
@@ -342,11 +325,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
     it('serves cached danmaku without fetching or resolving the config', async () => {
       const cached = { id: 5, comments: [] }
       const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
-      const { service } = build(
-        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
-        provider,
-        { existingDanmaku: [cached] }
-      )
+      const { service } = build(makeConfig('iqiyi'), provider, {
+        existingDanmaku: [cached],
+      })
 
       const result = await service.getDanmaku({
         type: 'by-meta',
@@ -364,10 +345,7 @@ describe('ProviderService legacy-maccms decoupling', () => {
         ...meta,
         season: { id: 1, providerConfigId: `${LEGACY_MACCMS_ID}-1` },
       } as unknown as WithSeason<EpisodeMeta>
-      const { service } = build(
-        makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS),
-        provider
-      )
+      const { service } = build(makeConfig(LEGACY_MACCMS_ID), provider)
 
       await expect(
         service.getDanmaku({ type: 'by-meta', meta: maccmsMeta, options: {} })
@@ -377,11 +355,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
 
     it('throws a source-removed error when forcing an orphaned season', async () => {
       const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
-      const { service } = build(
-        makeConfig('iqiyi', DanmakuSourceType.DanDanPlay),
-        provider,
-        { configMissing: true }
-      )
+      const { service } = build(makeConfig('iqiyi'), provider, {
+        configMissing: true,
+      })
 
       await expect(
         service.getDanmaku({
@@ -419,9 +395,7 @@ describe('ProviderService.refreshCatalog', () => {
 
     const providerConfigService = {
       getAll: vi.fn(async () =>
-        opts.installedManifestIds.map((manifestId) =>
-          makeConfig(manifestId, DanmakuSourceType.DanDanPlay)
-        )
+        opts.installedManifestIds.map((manifestId) => makeConfig(manifestId))
       ),
       hasSeeded: vi.fn(async () => true),
     } as unknown as ProviderConfigService

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/constant.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/constant.ts
@@ -11,14 +11,12 @@ export const PROXY_DDP_BASE_URL = `${import.meta.env.VITE_PROXY_URL}/ddp`
 
 export interface AutoImportProvider {
   manifestId: string
-  impl: DanmakuSourceType
   configValues: Record<string, unknown>
 }
 
 export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
   {
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
-    impl: DanmakuSourceType.DanDanPlay,
     configValues: {
       baseUrl: PROXY_DDP_BASE_URL,
       chConvert: DanDanChConvert.None,
@@ -26,7 +24,6 @@ export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
   },
   {
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Bilibili],
-    impl: DanmakuSourceType.Bilibili,
     // Pin xml; the manifest defaults to protobuf, which would change the format
     // for users who never picked it.
     configValues: {
@@ -35,7 +32,6 @@ export const AUTO_IMPORT_PROVIDERS: AutoImportProvider[] = [
   },
   {
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.Tencent],
-    impl: DanmakuSourceType.Tencent,
     configValues: {},
   },
 ]
@@ -49,7 +45,6 @@ export function autoImportToProviderConfig(
     id: entry.manifestId,
     manifestId: entry.manifestId,
     name,
-    impl: entry.impl,
     enabled: true,
     configValues: { ...entry.configValues },
   }
@@ -74,7 +69,6 @@ export function createCustomDanDanPlayProvider(
     id: input.id ?? getRandomUUID(),
     manifestId: PROVIDER_TO_BUILTIN_ID[DanmakuSourceType.DanDanPlay],
     name: input.name ?? 'DanDanPlay',
-    impl: DanmakuSourceType.DanDanPlay,
     enabled: true,
     configValues: {
       baseUrl: inputValues.baseUrl ?? '',
@@ -98,7 +92,6 @@ export function createCustomMacCmsProvider(
     id: input.id ?? getRandomUUID(),
     manifestId: LEGACY_MACCMS_ID,
     name: input.name ?? 'MacCMS',
-    impl: DanmakuSourceType.MacCMS,
     enabled: true,
     configValues: {
       danmakuBaseUrl: inputValues.danmakuBaseUrl ?? '',

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.test.ts
@@ -7,6 +7,7 @@ import {
   migrateBuiltinPrefixedProviderIds,
   migrateDanDanPlayApiBaseUrl,
   migrateDanmakuSourcesToProviders,
+  migrateDropDeadProviderFields,
   migrateProviderConfigsToFlat,
 } from './migration'
 
@@ -20,6 +21,8 @@ import {
  *   freshly-derived `manifestId` uses bare built-in ids.
  * - `migrateBuiltinPrefixedProviderIds`: strips the legacy `builtin:` prefix
  *   from stored `id`/`manifestId` and de-duplicates the resulting list.
+ * - `migrateDropDeadProviderFields`: drops the retired `impl`/`isBuiltIn`
+ *   fields, leaving corrupt records untouched.
  */
 
 describe('migrateDanmakuSourcesToProviders', () => {
@@ -52,11 +55,8 @@ describe('migrateDanmakuSourcesToProviders', () => {
 
       expect(providers).toHaveLength(3) // Only built-in providers
       expect(providers[0].manifestId).toBe('dandanplay')
-      expect(providers[0].impl).toBe(DanmakuSourceType.DanDanPlay)
       expect(providers[1].manifestId).toBe('bilibili')
-      expect(providers[1].impl).toBe(DanmakuSourceType.Bilibili)
       expect(providers[2].manifestId).toBe('tencent')
-      expect(providers[2].impl).toBe(DanmakuSourceType.Tencent)
     })
 
     it('should migrate with the sample data structure from user', () => {
@@ -91,7 +91,6 @@ describe('migrateDanmakuSourcesToProviders', () => {
       const ddp = providers[0]
       expect(ddp.id).toBe('dandanplay')
       expect(ddp.manifestId).toBe('dandanplay')
-      expect(ddp.impl).toBe(DanmakuSourceType.DanDanPlay)
       expect(ddp.enabled).toBe(true)
       expect(ddp.configValues.baseUrl).toBe(PROXY_DDP_BASE_URL)
       expect(ddp.configValues.chConvert).toBe(1)
@@ -99,20 +98,17 @@ describe('migrateDanmakuSourcesToProviders', () => {
       const bili = providers[1]
       expect(bili.id).toBe('bilibili')
       expect(bili.manifestId).toBe('bilibili')
-      expect(bili.impl).toBe(DanmakuSourceType.Bilibili)
       expect(bili.enabled).toBe(true)
       expect(bili.configValues.danmakuFormat).toBe('protobuf')
 
       const tencent = providers[2]
       expect(tencent.id).toBe('tencent')
       expect(tencent.manifestId).toBe('tencent')
-      expect(tencent.impl).toBe(DanmakuSourceType.Tencent)
       expect(tencent.enabled).toBe(true)
 
       const maccms = providers[3]
       expect(maccms.id).toBe('legacy:maccms')
       expect(maccms.manifestId).toBe('legacy:maccms')
-      expect(maccms.impl).toBe(DanmakuSourceType.MacCMS)
       expect(maccms.name).toBe('MacCMS')
       expect(maccms.enabled).toBe(true)
       expect(maccms.configValues.danmakuBaseUrl).toBe('https://vs.okcdn100.top')
@@ -190,7 +186,6 @@ describe('migrateDanmakuSourcesToProviders', () => {
       const maccms = providers[3]
       expect(maccms.id).toBe('legacy:maccms')
       expect(maccms.manifestId).toBe('legacy:maccms')
-      expect(maccms.impl).toBe(DanmakuSourceType.MacCMS)
       expect(maccms.name).toBe('MacCMS')
       expect(maccms.enabled).toBe(true)
       expect(maccms.configValues.danmakuBaseUrl).toBe(
@@ -463,7 +458,6 @@ describe('migrateProviderConfigsToFlat', () => {
     // A custom DDP server (DanDanPlayCompatible) folds directly onto the
     // unified DanDanPlay manifest, keeping its custom baseUrl.
     expect(flat[3].manifestId).toBe('dandanplay')
-    expect(flat[3].isBuiltIn).toBe(false)
     expect(flat[3].configValues.baseUrl).toBe('https://compat.example')
 
     expect(flat[4].manifestId).toBe('legacy:maccms')
@@ -477,9 +471,7 @@ describe('migrateProviderConfigsToFlat', () => {
         id: 'dandanplay',
         manifestId: 'dandanplay',
         name: 'DanDanPlay',
-        impl: DanmakuSourceType.DanDanPlay,
         enabled: true,
-        isBuiltIn: true,
         configValues: { chConvert: DanDanChConvert.None },
       },
     ]
@@ -849,12 +841,72 @@ describe('migrateDanDanPlayApiBaseUrl', () => {
         id: 'custom-ddp-2',
         manifestId: 'dandanplay',
         name: 'My DDP',
-        impl: DanmakuSourceType.DanDanPlay,
         enabled: true,
-        isBuiltIn: false,
         configValues: {},
       },
     ])
     expect(out[0].configValues.baseUrl).toBeUndefined()
+  })
+})
+
+describe('migrateDropDeadProviderFields', () => {
+  it('drops impl and isBuiltIn while keeping the rest of the record', () => {
+    const stored = [
+      {
+        id: 'dandanplay',
+        manifestId: 'dandanplay',
+        name: 'DanDanPlay',
+        impl: DanmakuSourceType.DanDanPlay,
+        enabled: true,
+        isBuiltIn: true,
+        configValues: { chConvert: DanDanChConvert.None },
+      },
+    ]
+
+    const out = migrateDropDeadProviderFields(stored)
+
+    expect(out[0]).toEqual({
+      id: 'dandanplay',
+      manifestId: 'dandanplay',
+      name: 'DanDanPlay',
+      enabled: true,
+      configValues: { chConvert: DanDanChConvert.None },
+    })
+  })
+
+  it('is idempotent on a record that already lacks the dead fields', () => {
+    const clean = [
+      {
+        id: 'bilibili',
+        manifestId: 'bilibili',
+        name: 'Bilibili',
+        enabled: false,
+        configValues: { danmakuFormat: 'xml' },
+      },
+    ]
+
+    expect(migrateDropDeadProviderFields(clean)).toEqual(clean)
+  })
+
+  it('leaves a corrupt record untouched while cleaning valid ones', () => {
+    const corrupt = { id: 'broken', impl: DanmakuSourceType.Bilibili }
+    const stored = [
+      {
+        id: 'tencent',
+        manifestId: 'tencent',
+        name: 'Tencent',
+        impl: DanmakuSourceType.Tencent,
+        enabled: true,
+        isBuiltIn: true,
+        configValues: {},
+      },
+      corrupt as never,
+    ]
+
+    const out = migrateDropDeadProviderFields(stored)
+
+    expect(out).toHaveLength(2)
+    expect(out[0]).not.toHaveProperty('impl')
+    expect(out[1]).toBe(corrupt)
   })
 })

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.test.ts
@@ -909,4 +909,9 @@ describe('migrateDropDeadProviderFields', () => {
     expect(out[0]).not.toHaveProperty('isBuiltIn')
     expect(out[1]).toBeNull()
   })
+
+  it('passes a non-array store through without throwing', () => {
+    const corrupt = null as never
+    expect(migrateDropDeadProviderFields(corrupt)).toBe(corrupt)
+  })
 })

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.test.ts
@@ -888,8 +888,7 @@ describe('migrateDropDeadProviderFields', () => {
     expect(migrateDropDeadProviderFields(clean)).toEqual(clean)
   })
 
-  it('leaves a corrupt record untouched while cleaning valid ones', () => {
-    const corrupt = { id: 'broken', impl: DanmakuSourceType.Bilibili }
+  it('passes non-object entries through untouched while cleaning valid ones', () => {
     const stored = [
       {
         id: 'tencent',
@@ -900,13 +899,14 @@ describe('migrateDropDeadProviderFields', () => {
         isBuiltIn: true,
         configValues: {},
       },
-      corrupt as never,
+      null as never,
     ]
 
     const out = migrateDropDeadProviderFields(stored)
 
     expect(out).toHaveLength(2)
     expect(out[0]).not.toHaveProperty('impl')
-    expect(out[1]).toBe(corrupt)
+    expect(out[0]).not.toHaveProperty('isBuiltIn')
+    expect(out[1]).toBeNull()
   })
 })

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
@@ -383,10 +383,14 @@ export function ensureBuiltinProviders(
 // runtime now that the provider tag comes from manifestId, so drop just those
 // two keys and keep the rest of the record intact. Dropping them explicitly
 // rather than re-parsing through the schema keeps this migration independent of
-// later schema changes. Non-object entries are passed through untouched.
+// later schema changes. A non-array store and non-object entries are passed
+// through untouched.
 export function migrateDropDeadProviderFields(
   data: ProviderConfig[]
 ): ProviderConfig[] {
+  if (!Array.isArray(data)) {
+    return data
+  }
   return data.map((config) => {
     if (config === null || typeof config !== 'object') {
       return config

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
@@ -145,8 +145,6 @@ export function migrateDanmakuSourcesToProviders(
           id: LEGACY_MACCMS_ID,
           manifestId: LEGACY_MACCMS_ID,
           name: 'MacCMS',
-          impl: DanmakuSourceType.MacCMS,
-          isBuiltIn: false,
           enabled: oldSources.custom.enabled ?? true,
           configValues: pruneUndefined({
             danmakuBaseUrl: baseUrl,
@@ -216,8 +214,6 @@ export function migrateProviderConfigsToFlat(
     const base = {
       id: old.id as string,
       name: old.name as string,
-      impl: old.impl as DanmakuSourceType,
-      isBuiltIn: !!old.isBuiltIn,
       // Default to visible when the field is missing.
       enabled: old.enabled ?? true,
     }
@@ -349,7 +345,6 @@ export function migrateDanDanPlayApiBaseUrl(
     if (
       config === null ||
       typeof config !== 'object' ||
-      config.isBuiltIn ||
       config.manifestId !== ddpManifestId
     ) {
       return config
@@ -382,4 +377,17 @@ export function ensureBuiltinProviders(
     }
   }
   return additions.length > 0 ? [...data, ...additions] : data
+}
+
+// Records from before v5 persisted `impl` and `isBuiltIn`. Neither is read at
+// runtime now that the provider tag comes from manifestId, so re-parse each
+// record to drop them. A record that fails the schema is left untouched rather
+// than aborting the whole migration.
+export function migrateDropDeadProviderFields(
+  data: ProviderConfig[]
+): ProviderConfig[] {
+  return data.map((config) => {
+    const parsed = providerConfigSchema.safeParse(config)
+    return parsed.success ? parsed.data : config
+  })
 }

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/migration.ts
@@ -380,14 +380,21 @@ export function ensureBuiltinProviders(
 }
 
 // Records from before v5 persisted `impl` and `isBuiltIn`. Neither is read at
-// runtime now that the provider tag comes from manifestId, so re-parse each
-// record to drop them. A record that fails the schema is left untouched rather
-// than aborting the whole migration.
+// runtime now that the provider tag comes from manifestId, so drop just those
+// two keys and keep the rest of the record intact. Dropping them explicitly
+// rather than re-parsing through the schema keeps this migration independent of
+// later schema changes. Non-object entries are passed through untouched.
 export function migrateDropDeadProviderFields(
   data: ProviderConfig[]
 ): ProviderConfig[] {
   return data.map((config) => {
-    const parsed = providerConfigSchema.safeParse(config)
-    return parsed.success ? parsed.data : config
+    if (config === null || typeof config !== 'object') {
+      return config
+    }
+    const { impl, isBuiltIn, ...rest } = config as ProviderConfig & {
+      impl?: unknown
+      isBuiltIn?: unknown
+    }
+    return rest
   })
 }

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/schema.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/schema.ts
@@ -1,19 +1,14 @@
 import { z } from 'zod'
-import { DanmakuSourceType } from '@/common/danmaku/enums'
 import type { Options } from '@/common/options/OptionsService/types'
 
 // Flat shape: per-source quirks live in `configValues` validated by the
 // manifest's `configSchema`. The host doesn't need to know what fields are
-// valid — that's the manifest's job.
+// valid, that's the manifest's job. The provider tag is derived from
+// `manifestId` on read (providerTypeFromManifestId), not persisted.
 export const providerConfigSchema = z.object({
   id: z.string(),
   manifestId: z.string(),
-  impl: z.enum(DanmakuSourceType),
   name: z.string().min(1),
-  // Deprecated: there is no built-in concept anymore, the seeded defaults are
-  // ordinary auto-imported configs. Kept optional so stored data still parses;
-  // nothing reads it.
-  isBuiltIn: z.boolean().optional(),
   enabled: z.boolean(),
   configValues: z.record(z.string(), z.unknown()),
 })

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.test.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.test.ts
@@ -1,16 +1,12 @@
-import {
-  DanmakuSourceType,
-  LEGACY_MACCMS_ID,
-  PROVIDER_TO_BUILTIN_ID,
-} from '@danmaku-anywhere/danmaku-converter'
+import { LEGACY_MACCMS_ID } from '@danmaku-anywhere/danmaku-converter'
 import { describe, expect, it, vi } from 'vitest'
 import type { ProviderConfig } from './schema'
 import { ProviderConfigService } from './service'
 
 /**
  * Covers supportsAutomaticMode after the capability decouple: every
- * manifest-driven source qualifies for automatic mode regardless of impl,
- * and legacy MacCMS (no manifest) is the only opt-out.
+ * manifest-driven source qualifies for automatic mode, keyed off the
+ * manifestId, and legacy MacCMS (no manifest) is the only opt-out.
  */
 
 function makeService(): ProviderConfigService {
@@ -20,16 +16,11 @@ function makeService(): ProviderConfigService {
   return new ProviderConfigService(logger, factory)
 }
 
-function makeConfig(
-  manifestId: string,
-  impl: DanmakuSourceType
-): ProviderConfig {
+function makeConfig(manifestId: string): ProviderConfig {
   return {
     id: manifestId,
     manifestId,
-    impl,
     name: 'test',
-    isBuiltIn: false,
     enabled: true,
     configValues: {},
   }
@@ -39,21 +30,21 @@ describe('supportsAutomaticMode', () => {
   const service = makeService()
 
   it.each([
-    [DanmakuSourceType.DanDanPlay],
-    [DanmakuSourceType.Bilibili],
-    [DanmakuSourceType.Tencent],
-  ])('returns true for manifest-driven source %s', (impl) => {
-    const config = makeConfig(PROVIDER_TO_BUILTIN_ID[impl], impl)
+    ['dandanplay'],
+    ['bilibili'],
+    ['tencent'],
+  ])('returns true for manifest-driven source %s', (manifestId) => {
+    const config = makeConfig(manifestId)
     expect(service.supportsAutomaticMode(config)).toBe(true)
   })
 
   it('returns true for a custom manifest-driven source', () => {
-    const config = makeConfig('custom:something', DanmakuSourceType.DanDanPlay)
+    const config = makeConfig('custom:something')
     expect(service.supportsAutomaticMode(config)).toBe(true)
   })
 
   it('returns false only for legacy MacCMS', () => {
-    const config = makeConfig(LEGACY_MACCMS_ID, DanmakuSourceType.MacCMS)
+    const config = makeConfig(LEGACY_MACCMS_ID)
     expect(service.supportsAutomaticMode(config)).toBe(false)
   })
 })

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/service.ts
@@ -16,6 +16,7 @@ import {
   ensureBuiltinProviders,
   migrateBuiltinPrefixedProviderIds,
   migrateDanDanPlayApiBaseUrl,
+  migrateDropDeadProviderFields,
   migrateProviderConfigsToFlat,
 } from './migration'
 import type { ProviderConfig } from './schema'
@@ -80,6 +81,21 @@ export class ProviderConfigService implements IStoreService {
             // leave the data untouched rather than reset to defaults.
             console.error(
               '[providerConfig] DanDanPlay baseUrl migration failed, leaving configs unchanged:',
+              error
+            )
+            return data
+          }
+        },
+      })
+      .version(5, {
+        upgrade: (data) => {
+          try {
+            return migrateDropDeadProviderFields(data)
+          } catch (error) {
+            // Dropping dead fields is cosmetic; never cost the user their
+            // configs over it.
+            console.error(
+              '[providerConfig] dead-field migration failed, leaving configs unchanged:',
               error
             )
             return data

--- a/packages/danmaku-anywhere/src/popup/pages/providers/catalog.test.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/catalog.test.ts
@@ -1,6 +1,5 @@
 import type { ConfigSchema } from '@mr-quin/dango'
 import { describe, expect, it } from 'vitest'
-import { DanmakuSourceType } from '@/common/danmaku/enums'
 import { PROXY_DDP_BASE_URL } from '@/common/options/providerConfig/constant'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
 import type { ProviderManifestInfo } from '@/common/rpcClient/background/types'
@@ -17,8 +16,7 @@ import {
 
 /**
  * Catalog import builds a ProviderConfig from a registered manifest. Asserts
- * the config is tagged with the DanDanPlay impl (never Custom, per the
- * fail-fast resolution invariant), defaults its values from the manifest's
+ * the config references the manifest, defaults its values from the manifest's
  * configSchema, and that the form is only required when a required field has
  * no default to fall back on.
  */
@@ -31,12 +29,10 @@ const manifest: ProviderManifestInfo = {
 }
 
 describe('createConfigFromManifest', () => {
-  it('references the manifest and never tags impl as Custom', () => {
+  it('references the manifest', () => {
     const config = createConfigFromManifest(manifest)
     expect(config.manifestId).toBe('iqiyi')
     expect(config.name).toBe('iQIYI')
-    expect(config.impl).toBe(DanmakuSourceType.DanDanPlay)
-    expect(config.impl).not.toBe(DanmakuSourceType.Custom)
     expect(config.enabled).toBe(true)
     expect(config.id).toBeTruthy()
   })
@@ -103,7 +99,6 @@ function cfg(id: string, manifestId: string): ProviderConfig {
     id,
     manifestId,
     name: id,
-    impl: DanmakuSourceType.DanDanPlay,
     enabled: true,
     configValues: {},
   }

--- a/packages/danmaku-anywhere/src/popup/pages/providers/catalog.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/catalog.ts
@@ -10,8 +10,6 @@ import {
   getObjectFields,
 } from './components/forms/schemaForm'
 
-// impl is just a label on imported configs, but it can't be Custom: the
-// provider factory rejects Custom for anything that isn't maccms.
 export function createConfigFromManifest(
   manifest: ProviderManifestInfo
 ): ProviderConfig {
@@ -19,7 +17,6 @@ export function createConfigFromManifest(
     id: getRandomUUID(),
     manifestId: manifest.id,
     name: manifest.name,
-    impl: DanmakuSourceType.DanDanPlay,
     enabled: true,
     configValues: buildDefaultValues(manifest.configSchema, {}),
   }


### PR DESCRIPTION
## Summary
- Remove `impl` and `isBuiltIn` from `providerConfigSchema` and every config-construction path. Neither was read at runtime: the provider tag is derived from `manifestId` on read via `providerTypeFromManifestId`, and the built-in concept is gone.
- Add a config v5 migration (`migrateDropDeadProviderFields`) that strips the two fields from stored records by re-parsing through the zod schema (zod drops unknown keys). It keeps the chain's idempotent, non-aborting style: a record that fails the schema is left untouched rather than aborting the upgrade.
- Drop the now-redundant `config.isBuiltIn` guard from the v4 `migrateDanDanPlayApiBaseUrl` migration. The proxy DDP baseUrl never carries an `/api` suffix, so the regex was already the real gate.

## Test plan
- Verified: lint (tsc + biome) pass · tests `vitest` migration/service/ProviderFactory/ProviderService/catalog specs -> 101 passed · e2e config-form, dandanplay-custom, localization, instances, dandanplay-local-origin -> 8 passed
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` for the full unit sweep
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test:e2e` (the seed fixtures in `e2e/setup/profile.ts` and the touched specs no longer set the removed fields)

## Notes
- Existing v2/v3 migrations and their test fixtures keep `impl`/`isBuiltIn` as legacy input (realistic pre-v5 stored shape); the v2 idempotent path already strips them via schema re-parse, and v5 is the canonical stripper for data already at v4 in the wild.