### PR TITLE
(extension) product-analytics pipeline: typed events to Axiom [DA-648]

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -13,6 +13,10 @@
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
+    },
+    "axiom": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.axiom.co/mcp"]
     }
   }
 }

--- a/backend/proxy/src/middleware/rateLimit.ts
+++ b/backend/proxy/src/middleware/rateLimit.ts
@@ -2,7 +2,7 @@ import { HTTPException } from 'hono/http-exception'
 import { factory } from '@/factory'
 import { getIsTestEnv } from '@/utils/getIsTestEnv'
 
-type RateLimiterKeys = 'DDP_RATE_LIMITER'
+type RateLimiterKeys = 'DDP_RATE_LIMITER' | 'INTAKE_RATE_LIMITER'
 
 interface RateLimitOptions {
   rateLimiter: RateLimiterKeys

--- a/backend/proxy/src/routes/api/intake/axiom.ts
+++ b/backend/proxy/src/routes/api/intake/axiom.ts
@@ -1,24 +1,19 @@
 import { serializeError } from '@/utils/serializeError'
 
-const AXIOM_INGEST_ORIGIN = 'https://api.axiom.co'
-
 export async function forwardToAxiom(
   env: Env,
   events: unknown[]
 ): Promise<void> {
   try {
     const token = await env.AXIOM_TOKEN.get()
-    const response = await fetch(
-      `${AXIOM_INGEST_ORIGIN}/v1/ingest/${env.AXIOM_DATASET}`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(events),
-      }
-    )
+    const response = await fetch(env.AXIOM_INTAKE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(events),
+    })
 
     if (!response.ok) {
       console.error(

--- a/backend/proxy/src/routes/api/intake/axiom.ts
+++ b/backend/proxy/src/routes/api/intake/axiom.ts
@@ -1,0 +1,33 @@
+import { serializeError } from '@/utils/serializeError'
+
+const AXIOM_INGEST_ORIGIN = 'https://api.axiom.co'
+
+export async function forwardToAxiom(
+  env: Env,
+  events: unknown[]
+): Promise<void> {
+  try {
+    const token = await env.AXIOM_TOKEN.get()
+    const response = await fetch(
+      `${AXIOM_INGEST_ORIGIN}/v1/ingest/${env.AXIOM_DATASET}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(events),
+      }
+    )
+
+    if (!response.ok) {
+      console.error(
+        'Axiom ingest failed',
+        response.status,
+        await response.text()
+      )
+    }
+  } catch (error) {
+    console.error('Axiom ingest error', serializeError(error))
+  }
+}

--- a/backend/proxy/src/routes/api/intake/intake.test.ts
+++ b/backend/proxy/src/routes/api/intake/intake.test.ts
@@ -1,0 +1,126 @@
+import { env } from 'cloudflare:test'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeUnitTestRequest } from '@/test-utils/makeUnitTestRequest'
+import '@/test-utils/mockBindings'
+import { createRateLimiterMock } from '@/test-utils/createMockRateLimiter'
+import { MAX_BATCH_LENGTH, MAX_EVENT_BYTES } from './schema'
+
+const IncomingRequest = Request
+
+const INTAKE_URL = 'http://example.com/v1/intake'
+
+const validEvent = (overrides: Record<string, unknown> = {}) => {
+  return {
+    installId: 'install-1',
+    event: 'heartbeat',
+    properties: { browser: 'chrome' },
+    clientTs: 1700000000000,
+    version: '1.0.0',
+    environment: 'prod',
+    surface: 'background',
+    ...overrides,
+  }
+}
+
+const postBatch = (body: unknown) => {
+  return makeUnitTestRequest(
+    new IncomingRequest(INTAKE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  )
+}
+
+describe('intake API', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(async () => new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+    env.INTAKE_RATE_LIMITER = createRateLimiterMock()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('accepts a valid batch and forwards enriched events to Axiom', async () => {
+    const response = await postBatch([validEvent()])
+
+    expect(response.status).toBe(202)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('https://api.axiom.co/v1/ingest/da-events')
+    expect(init.headers.Authorization).toBe('Bearer axiom-token')
+
+    const forwarded = JSON.parse(init.body)
+    expect(forwarded).toHaveLength(1)
+    expect(forwarded[0]).toMatchObject({
+      installId: 'install-1',
+      event: 'heartbeat',
+      country: null,
+    })
+    expect(typeof forwarded[0].receivedAt).toBe('string')
+  })
+
+  it('forwards unknown event names without rejecting them', async () => {
+    const response = await postBatch([
+      validEvent({ event: 'someBrandNewEvent', properties: { foo: 'bar' } }),
+    ])
+
+    expect(response.status).toBe(202)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a malformed envelope', async () => {
+    const response = await postBatch([validEvent({ surface: 'spaceship' })])
+
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty batch', async () => {
+    const response = await postBatch([])
+
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a batch over the length cap', async () => {
+    const batch = Array.from({ length: MAX_BATCH_LENGTH + 1 }, () =>
+      validEvent()
+    )
+
+    const response = await postBatch(batch)
+
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an event whose properties exceed the per-item cap', async () => {
+    const big = 'x'.repeat(MAX_EVENT_BYTES + 1)
+    const response = await postBatch([validEvent({ properties: { big } })])
+
+    expect(response.status).toBe(413)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the rate limit is exceeded', async () => {
+    env.INTAKE_RATE_LIMITER = createRateLimiterMock({ success: false })
+
+    const response = await postBatch([validEvent()])
+
+    expect(response.status).toBe(429)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('responds 202 even when the Axiom forward fails', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'))
+
+    const response = await postBatch([validEvent()])
+
+    expect(response.status).toBe(202)
+  })
+})

--- a/backend/proxy/src/routes/api/intake/intake.test.ts
+++ b/backend/proxy/src/routes/api/intake/intake.test.ts
@@ -61,6 +61,7 @@ describe('intake API', () => {
       installId: 'install-1',
       event: 'heartbeat',
       country: null,
+      serverEnvironment: env.ENVIRONMENT,
     })
     expect(typeof forwarded[0].receivedAt).toBe('string')
   })

--- a/backend/proxy/src/routes/api/intake/intake.test.ts
+++ b/backend/proxy/src/routes/api/intake/intake.test.ts
@@ -52,7 +52,7 @@ describe('intake API', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     const [url, init] = fetchSpy.mock.calls[0]
-    expect(url).toBe('https://api.axiom.co/v1/ingest/da-events')
+    expect(url).toBe(env.AXIOM_INTAKE_URL)
     expect(init.headers.Authorization).toBe('Bearer axiom-token')
 
     const forwarded = JSON.parse(init.body)

--- a/backend/proxy/src/routes/api/intake/intake.test.ts
+++ b/backend/proxy/src/routes/api/intake/intake.test.ts
@@ -107,6 +107,16 @@ describe('intake API', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
+  it('measures the per-item cap in bytes, not UTF-16 code units', async () => {
+    // Each CJK char is 1 code unit but 3 UTF-8 bytes; this stays under the cap
+    // by length yet exceeds it by bytes.
+    const cjk = '危'.repeat(MAX_EVENT_BYTES - 100)
+    const response = await postBatch([validEvent({ properties: { cjk } })])
+
+    expect(response.status).toBe(413)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it('rejects when the rate limit is exceeded', async () => {
     env.INTAKE_RATE_LIMITER = createRateLimiterMock({ success: false })
 

--- a/backend/proxy/src/routes/api/intake/router.ts
+++ b/backend/proxy/src/routes/api/intake/router.ts
@@ -1,0 +1,50 @@
+import { zValidator } from '@hono/zod-validator'
+import { HTTPException } from 'hono/http-exception'
+import { describeRoute } from 'hono-openapi'
+import { factory } from '@/factory'
+import { useRateLimiter } from '@/middleware/rateLimit'
+import { forwardToAxiom } from './axiom'
+import { intakeBatchSchema, MAX_EVENT_BYTES, MAX_PAYLOAD_BYTES } from './schema'
+
+export const intakeRouter = factory.createApp()
+
+intakeRouter.post(
+  '/',
+  describeRoute({
+    description: 'Ingest a batch of product analytics events',
+    responses: {
+      202: { description: 'Batch accepted for forwarding' },
+      400: { description: 'Malformed batch' },
+      413: { description: 'Batch or event too large' },
+      429: { description: 'Rate limit exceeded' },
+    },
+  }),
+  useRateLimiter({ rateLimiter: 'INTAKE_RATE_LIMITER' }),
+  async (c, next) => {
+    const contentLength = Number(c.req.header('content-length') ?? 0)
+    if (contentLength > MAX_PAYLOAD_BYTES) {
+      throw new HTTPException(413, { message: 'Payload too large' })
+    }
+    await next()
+  },
+  zValidator('json', intakeBatchSchema),
+  async (c) => {
+    const events = c.req.valid('json')
+
+    for (const event of events) {
+      if (JSON.stringify(event.properties).length > MAX_EVENT_BYTES) {
+        throw new HTTPException(413, { message: 'Event properties too large' })
+      }
+    }
+
+    const receivedAt = new Date().toISOString()
+    const country = c.req.raw.cf?.country ?? null
+    const enriched = events.map((event) => {
+      return { ...event, receivedAt, country }
+    })
+
+    c.executionCtx.waitUntil(forwardToAxiom(c.env, enriched))
+
+    return c.json({ success: true }, 202)
+  }
+)

--- a/backend/proxy/src/routes/api/intake/router.ts
+++ b/backend/proxy/src/routes/api/intake/router.ts
@@ -43,8 +43,11 @@ intakeRouter.post(
 
     const receivedAt = new Date().toISOString()
     const country = c.req.raw.cf?.country ?? null
+    // Staging and production share one dataset; tag the ingesting worker so the
+    // two are filterable (server-set, unlike the client-build `environment`).
+    const serverEnvironment = c.env.ENVIRONMENT
     const enriched = events.map((event) => {
-      return { ...event, receivedAt, country }
+      return { ...event, receivedAt, country, serverEnvironment }
     })
 
     c.executionCtx.waitUntil(forwardToAxiom(c.env, enriched))

--- a/backend/proxy/src/routes/api/intake/router.ts
+++ b/backend/proxy/src/routes/api/intake/router.ts
@@ -31,8 +31,12 @@ intakeRouter.post(
   async (c) => {
     const events = c.req.valid('json')
 
+    const encoder = new TextEncoder()
     for (const event of events) {
-      if (JSON.stringify(event.properties).length > MAX_EVENT_BYTES) {
+      if (
+        encoder.encode(JSON.stringify(event.properties)).length >
+        MAX_EVENT_BYTES
+      ) {
         throw new HTTPException(413, { message: 'Event properties too large' })
       }
     }

--- a/backend/proxy/src/routes/api/intake/schema.ts
+++ b/backend/proxy/src/routes/api/intake/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const SURFACES = ['popup', 'content', 'player', 'background'] as const
+
+export const MAX_BATCH_LENGTH = 50
+export const MAX_EVENT_BYTES = 4 * 1024
+export const MAX_PAYLOAD_BYTES = 64 * 1024
+
+const eventSchema = z.object({
+  installId: z.string().min(1).max(64),
+  event: z.string().min(1).max(64),
+  properties: z.record(z.string(), z.unknown()).default({}),
+  clientTs: z.number(),
+  version: z.string().max(32),
+  environment: z.string().max(16),
+  surface: z.enum(SURFACES),
+})
+
+export const intakeBatchSchema = z
+  .array(eventSchema)
+  .min(1)
+  .max(MAX_BATCH_LENGTH)

--- a/backend/proxy/src/routes/api/routes.ts
+++ b/backend/proxy/src/routes/api/routes.ts
@@ -6,6 +6,7 @@ import { bangumiRouter } from './bangumi/router'
 import { configRouter } from './config/router'
 import { ddpRouter } from './ddp/router'
 import { filesRouter } from './files/router'
+import { intakeRouter } from './intake/router'
 import { kazumiRouter } from './kazumi/router'
 import { llmRouter } from './llm/router'
 import { manifestRouter } from './manifest/router'
@@ -22,3 +23,4 @@ api.route('/kazumi', kazumiRouter)
 api.route('/manifest', manifestRouter)
 api.route('/config', configRouter)
 api.route('/files', filesRouter)
+api.route('/v1/intake', intakeRouter)

--- a/backend/proxy/src/test-utils/mockBindings.ts
+++ b/backend/proxy/src/test-utils/mockBindings.ts
@@ -1,5 +1,6 @@
 import { env } from 'cloudflare:test'
 import { vi } from 'vitest'
+import { createRateLimiterMock } from './createMockRateLimiter'
 
 declare module 'cloudflare:test' {
   interface ProvidedEnv extends Env {}
@@ -14,3 +15,5 @@ const createSecretMock = (value: string) => {
 env.DANMAKU_GEMINI_API_KEY = createSecretMock('gemini-api')
 env.DA_AI_GATEWAY_ID = createSecretMock('da-ai-gateway-id')
 env.DA_AI_GATEWAY_NAME = createSecretMock('da-ai-gateway-name')
+env.AXIOM_TOKEN = createSecretMock('axiom-token')
+env.INTAKE_RATE_LIMITER = createRateLimiterMock()

--- a/backend/proxy/worker-configuration.d.ts
+++ b/backend/proxy/worker-configuration.d.ts
@@ -14,6 +14,9 @@ declare namespace Cloudflare {
 		BETTER_AUTH_SECRET: SecretsStoreSecret;
 		GOOGLE_CLIENT_SECRET: SecretsStoreSecret;
 		RESEND_API_KEY: SecretsStoreSecret;
+		AXIOM_TOKEN: SecretsStoreSecret;
+		INTAKE_RATE_LIMITER: RateLimit;
+		AXIOM_DATASET: "da-events";
 		CF_VERSION_METADATA: WorkerVersionMetadata;
 		BETTER_AUTH_TRUSTED_ORIGINS: "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,https://api.danmaku-staging.weeblify.app";
 		EMAIL_FROM: "Danmaku Anywhere <hello@danmaku.weeblify.app>";
@@ -35,6 +38,9 @@ declare namespace Cloudflare {
 		BETTER_AUTH_SECRET: SecretsStoreSecret;
 		GOOGLE_CLIENT_SECRET: SecretsStoreSecret;
 		RESEND_API_KEY: SecretsStoreSecret;
+		AXIOM_TOKEN: SecretsStoreSecret;
+		INTAKE_RATE_LIMITER: RateLimit;
+		AXIOM_DATASET: "da-events";
 		CF_VERSION_METADATA: WorkerVersionMetadata;
 		BETTER_AUTH_TRUSTED_ORIGINS: "https://danmaku.weeblify.app,https://api.danmaku.weeblify.app";
 		EMAIL_FROM: "Danmaku Anywhere <hello@danmaku.weeblify.app>";
@@ -56,6 +62,9 @@ declare namespace Cloudflare {
 		BETTER_AUTH_SECRET: SecretsStoreSecret;
 		GOOGLE_CLIENT_SECRET: SecretsStoreSecret;
 		RESEND_API_KEY: SecretsStoreSecret;
+		AXIOM_TOKEN: SecretsStoreSecret;
+		INTAKE_RATE_LIMITER: RateLimit;
+		AXIOM_DATASET: "da-events";
 		CF_VERSION_METADATA: WorkerVersionMetadata;
 		BETTER_AUTH_TRUSTED_ORIGINS: "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,https://api.danmaku-staging.weeblify.app" | "https://danmaku.weeblify.app,https://api.danmaku.weeblify.app" | "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,https://api.danmaku-staging.weeblify.app,http://localhost:4200";
 		EMAIL_FROM: "Danmaku Anywhere <hello@danmaku.weeblify.app>";
@@ -74,7 +83,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "BETTER_AUTH_TRUSTED_ORIGINS" | "EMAIL_FROM" | "ENVIRONMENT" | "DANDANPLAY_API_HOST" | "DANDANPLAY_APP_ID" | "ALLOWED_ORIGIN" | "GEMINI_MODEL" | "BETTER_AUTH_URL" | "GOOGLE_CLIENT_ID">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "BETTER_AUTH_TRUSTED_ORIGINS" | "EMAIL_FROM" | "ENVIRONMENT" | "DANDANPLAY_API_HOST" | "DANDANPLAY_APP_ID" | "ALLOWED_ORIGIN" | "GEMINI_MODEL" | "BETTER_AUTH_URL" | "GOOGLE_CLIENT_ID" | "AXIOM_DATASET">> {}
 }
 
 // Begin runtime types

--- a/backend/proxy/worker-configuration.d.ts
+++ b/backend/proxy/worker-configuration.d.ts
@@ -16,7 +16,7 @@ declare namespace Cloudflare {
 		RESEND_API_KEY: SecretsStoreSecret;
 		AXIOM_TOKEN: SecretsStoreSecret;
 		INTAKE_RATE_LIMITER: RateLimit;
-		AXIOM_DATASET: "da-events";
+		AXIOM_INTAKE_URL: "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events";
 		CF_VERSION_METADATA: WorkerVersionMetadata;
 		BETTER_AUTH_TRUSTED_ORIGINS: "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,https://api.danmaku-staging.weeblify.app";
 		EMAIL_FROM: "Danmaku Anywhere <hello@danmaku.weeblify.app>";
@@ -40,7 +40,7 @@ declare namespace Cloudflare {
 		RESEND_API_KEY: SecretsStoreSecret;
 		AXIOM_TOKEN: SecretsStoreSecret;
 		INTAKE_RATE_LIMITER: RateLimit;
-		AXIOM_DATASET: "da-events";
+		AXIOM_INTAKE_URL: "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events";
 		CF_VERSION_METADATA: WorkerVersionMetadata;
 		BETTER_AUTH_TRUSTED_ORIGINS: "https://danmaku.weeblify.app,https://api.danmaku.weeblify.app";
 		EMAIL_FROM: "Danmaku Anywhere <hello@danmaku.weeblify.app>";
@@ -64,7 +64,7 @@ declare namespace Cloudflare {
 		RESEND_API_KEY: SecretsStoreSecret;
 		AXIOM_TOKEN: SecretsStoreSecret;
 		INTAKE_RATE_LIMITER: RateLimit;
-		AXIOM_DATASET: "da-events";
+		AXIOM_INTAKE_URL: "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events";
 		CF_VERSION_METADATA: WorkerVersionMetadata;
 		BETTER_AUTH_TRUSTED_ORIGINS: "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,https://api.danmaku-staging.weeblify.app" | "https://danmaku.weeblify.app,https://api.danmaku.weeblify.app" | "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,https://api.danmaku-staging.weeblify.app,http://localhost:4200";
 		EMAIL_FROM: "Danmaku Anywhere <hello@danmaku.weeblify.app>";
@@ -83,7 +83,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "BETTER_AUTH_TRUSTED_ORIGINS" | "EMAIL_FROM" | "ENVIRONMENT" | "DANDANPLAY_API_HOST" | "DANDANPLAY_APP_ID" | "ALLOWED_ORIGIN" | "GEMINI_MODEL" | "BETTER_AUTH_URL" | "GOOGLE_CLIENT_ID" | "AXIOM_DATASET">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "BETTER_AUTH_TRUSTED_ORIGINS" | "EMAIL_FROM" | "ENVIRONMENT" | "DANDANPLAY_API_HOST" | "DANDANPLAY_APP_ID" | "ALLOWED_ORIGIN" | "GEMINI_MODEL" | "BETTER_AUTH_URL" | "GOOGLE_CLIENT_ID" | "AXIOM_INTAKE_URL">> {}
 }
 
 // Begin runtime types

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -17,12 +17,18 @@
     "GEMINI_MODEL": "gemini-flash-lite-latest",
     "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
     "GOOGLE_CLIENT_ID": "",
-    "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>"
+    "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
+    "AXIOM_DATASET": "da-events"
   },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
   },
   "secrets_store_secrets": [
+    {
+      "binding": "AXIOM_TOKEN",
+      "store_id": "4a9ca50edba84431879f34b0b67f9998",
+      "secret_name": "AXIOM_TOKEN_STG"
+    },
     {
       "binding": "DANMAKU_GEMINI_API_KEY",
       "store_id": "4a9ca50edba84431879f34b0b67f9998",
@@ -74,7 +80,13 @@
       "migrations_dir": "./drizzle"
     }
   ],
-  "ratelimits": [],
+  "ratelimits": [
+    {
+      "name": "INTAKE_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 200, "period": 60 }
+    }
+  ],
   "services": [
     {
       "binding": "DDP_SERVICE",
@@ -90,12 +102,18 @@
         "GEMINI_MODEL": "gemini-flash-lite-latest",
         "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
-        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>"
+        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
+        "AXIOM_DATASET": "da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
       },
       "secrets_store_secrets": [
+        {
+          "binding": "AXIOM_TOKEN",
+          "store_id": "4a9ca50edba84431879f34b0b67f9998",
+          "secret_name": "AXIOM_TOKEN_STG"
+        },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
@@ -154,7 +172,13 @@
           "service": "ddp-microservice-staging"
         }
       ],
-      "ratelimits": []
+      "ratelimits": [
+        {
+          "name": "INTAKE_RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 200, "period": 60 }
+        }
+      ]
     },
     "production": {
       "vars": {
@@ -164,12 +188,18 @@
         "GEMINI_MODEL": "gemini-flash-lite-latest",
         "BETTER_AUTH_URL": "https://api.danmaku.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
-        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>"
+        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
+        "AXIOM_DATASET": "da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
       },
       "secrets_store_secrets": [
+        {
+          "binding": "AXIOM_TOKEN",
+          "store_id": "4a9ca50edba84431879f34b0b67f9998",
+          "secret_name": "AXIOM_TOKEN"
+        },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
@@ -227,7 +257,13 @@
           "service": "ddp-microservice-production"
         }
       ],
-      "ratelimits": []
+      "ratelimits": [
+        {
+          "name": "INTAKE_RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 200, "period": 60 }
+        }
+      ]
     }
   }
 }

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -18,7 +18,7 @@
     "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
     "GOOGLE_CLIENT_ID": "",
     "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
-    "AXIOM_DATASET": "da-events"
+    "AXIOM_INTAKE_URL": "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events"
   },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
@@ -103,7 +103,7 @@
         "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
         "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
-        "AXIOM_DATASET": "da-events"
+        "AXIOM_INTAKE_URL": "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
@@ -189,7 +189,7 @@
         "BETTER_AUTH_URL": "https://api.danmaku.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
         "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
-        "AXIOM_DATASET": "da-events"
+        "AXIOM_INTAKE_URL": "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -27,7 +27,7 @@
     {
       "binding": "AXIOM_TOKEN",
       "store_id": "4a9ca50edba84431879f34b0b67f9998",
-      "secret_name": "AXIOM_TOKEN_STG"
+      "secret_name": "AXIOM_DA_STG_INTAKE"
     },
     {
       "binding": "DANMAKU_GEMINI_API_KEY",
@@ -112,7 +112,7 @@
         {
           "binding": "AXIOM_TOKEN",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
-          "secret_name": "AXIOM_TOKEN_STG"
+          "secret_name": "AXIOM_DA_STG_INTAKE"
         },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",
@@ -198,7 +198,7 @@
         {
           "binding": "AXIOM_TOKEN",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
-          "secret_name": "AXIOM_TOKEN"
+          "secret_name": "AXIOM_DA_INTAKE"
         },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -27,7 +27,7 @@
     {
       "binding": "AXIOM_TOKEN",
       "store_id": "4a9ca50edba84431879f34b0b67f9998",
-      "secret_name": "AXIOM_TOKEN_STG"
+      "secret_name": "AXIOM_DA_STG_INTAKE"
     },
     {
       "binding": "DANMAKU_GEMINI_API_KEY",
@@ -112,7 +112,7 @@
         {
           "binding": "AXIOM_TOKEN",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
-          "secret_name": "AXIOM_TOKEN_STG"
+          "secret_name": "AXIOM_DA_STG_INTAKE"
         },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",
@@ -202,7 +202,7 @@
         {
           "binding": "AXIOM_TOKEN",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
-          "secret_name": "AXIOM_TOKEN"
+          "secret_name": "AXIOM_DA_INTAKE"
         },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -18,7 +18,7 @@
     "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
     "GOOGLE_CLIENT_ID": "",
     "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
-    "AXIOM_DATASET": "da-events"
+    "AXIOM_INTAKE_URL": "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events"
   },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
@@ -103,7 +103,7 @@
         "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
         "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
-        "AXIOM_DATASET": "da-events"
+        "AXIOM_INTAKE_URL": "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
@@ -193,7 +193,7 @@
         "BETTER_AUTH_URL": "https://api.danmaku.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
         "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
-        "AXIOM_DATASET": "da-events"
+        "AXIOM_INTAKE_URL": "https://us-east-1.aws.edge.axiom.co/v1/ingest/da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -17,12 +17,18 @@
     "GEMINI_MODEL": "gemini-flash-lite-latest",
     "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
     "GOOGLE_CLIENT_ID": "",
-    "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>"
+    "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
+    "AXIOM_DATASET": "da-events"
   },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
   },
   "secrets_store_secrets": [
+    {
+      "binding": "AXIOM_TOKEN",
+      "store_id": "4a9ca50edba84431879f34b0b67f9998",
+      "secret_name": "AXIOM_TOKEN_STG"
+    },
     {
       "binding": "DANMAKU_GEMINI_API_KEY",
       "store_id": "4a9ca50edba84431879f34b0b67f9998",
@@ -74,7 +80,13 @@
       "migrations_dir": "./drizzle"
     }
   ],
-  "ratelimits": [],
+  "ratelimits": [
+    {
+      "name": "INTAKE_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 200, "period": 60 }
+    }
+  ],
   "services": [
     {
       "binding": "DDP_SERVICE",
@@ -90,12 +102,18 @@
         "GEMINI_MODEL": "gemini-flash-lite-latest",
         "BETTER_AUTH_URL": "https://api.danmaku-staging.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
-        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>"
+        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
+        "AXIOM_DATASET": "da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
       },
       "secrets_store_secrets": [
+        {
+          "binding": "AXIOM_TOKEN",
+          "store_id": "4a9ca50edba84431879f34b0b67f9998",
+          "secret_name": "AXIOM_TOKEN_STG"
+        },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
@@ -154,7 +172,13 @@
           "service": "ddp-microservice-staging"
         }
       ],
-      "ratelimits": []
+      "ratelimits": [
+        {
+          "name": "INTAKE_RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 200, "period": 60 }
+        }
+      ]
     },
     "production": {
       "observability": {
@@ -168,12 +192,18 @@
         "GEMINI_MODEL": "gemini-flash-lite-latest",
         "BETTER_AUTH_URL": "https://api.danmaku.weeblify.app",
         "GOOGLE_CLIENT_ID": "",
-        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>"
+        "EMAIL_FROM": "Danmaku Anywhere <hello@danmaku.weeblify.app>",
+        "AXIOM_DATASET": "da-events"
       },
       "version_metadata": {
         "binding": "CF_VERSION_METADATA"
       },
       "secrets_store_secrets": [
+        {
+          "binding": "AXIOM_TOKEN",
+          "store_id": "4a9ca50edba84431879f34b0b67f9998",
+          "secret_name": "AXIOM_TOKEN"
+        },
         {
           "binding": "DANMAKU_GEMINI_API_KEY",
           "store_id": "4a9ca50edba84431879f34b0b67f9998",
@@ -231,7 +261,13 @@
           "service": "ddp-microservice-production"
         }
       ],
-      "ratelimits": []
+      "ratelimits": [
+        {
+          "name": "INTAKE_RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 200, "period": 60 }
+        }
+      ]
     }
   }
 }

--- a/packages/danmaku-anywhere/src/background/alarm/AlarmManager.test.ts
+++ b/packages/danmaku-anywhere/src/background/alarm/AlarmManager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import type { ProviderService } from '@/background/services/providers/ProviderService'
+import type { TelemetryManager } from '@/background/telemetry/TelemetryManager'
 import type { ILogger } from '@/common/Logger'
 import type { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import { mockChrome } from '@/tests/mockChromeApis'
@@ -42,10 +43,15 @@ describe('AlarmManager manifest refresh', () => {
     )
     mockChrome.alarms.get.mockResolvedValue(undefined)
 
+    const telemetryManager = {
+      track: vi.fn(),
+    } as unknown as TelemetryManager
+
     const manager = new AlarmManager(
       {} as unknown as DanmakuService,
       extensionOptionsService,
       providerService,
+      telemetryManager,
       silentLogger
     )
 
@@ -67,5 +73,58 @@ describe('AlarmManager manifest refresh', () => {
       await handle({ name: 'some-other-alarm' } as chrome.alarms.Alarm)
     }
     expect(syncCatalog).not.toHaveBeenCalled()
+  })
+})
+
+describe('AlarmManager heartbeat', () => {
+  it('creates the heartbeat alarm and emits a heartbeat event when it fires', async () => {
+    const extensionOptionsService = {
+      onChange: vi.fn(),
+      get: vi.fn(async () => ({
+        retentionPolicy: { enabled: false, deleteCommentsAfter: 0 },
+      })),
+    } as unknown as ExtensionOptionsService
+
+    const track = vi.fn()
+    const telemetryManager = { track } as unknown as TelemetryManager
+
+    const handlers: ((alarm: chrome.alarms.Alarm) => unknown)[] = []
+    mockChrome.alarms.onAlarm.addListener.mockImplementation((h) =>
+      handlers.push(h)
+    )
+    mockChrome.alarms.get.mockResolvedValue(undefined)
+
+    const manager = new AlarmManager(
+      {} as unknown as DanmakuService,
+      extensionOptionsService,
+      {} as unknown as ProviderService,
+      telemetryManager,
+      silentLogger
+    )
+
+    manager.setup()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(mockChrome.alarms.create).toHaveBeenCalledWith(
+      'heartbeat',
+      expect.objectContaining({ periodInMinutes: expect.any(Number) })
+    )
+
+    for (const handle of handlers) {
+      await handle({ name: 'heartbeat' } as chrome.alarms.Alarm)
+    }
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'heartbeat',
+      expect.objectContaining({ browser: expect.any(String) }),
+      'background',
+      expect.any(Number)
+    )
+
+    track.mockClear()
+    for (const handle of handlers) {
+      await handle({ name: 'some-other-alarm' } as chrome.alarms.Alarm)
+    }
+    expect(track).not.toHaveBeenCalled()
   })
 })

--- a/packages/danmaku-anywhere/src/background/alarm/AlarmManager.ts
+++ b/packages/danmaku-anywhere/src/background/alarm/AlarmManager.ts
@@ -1,7 +1,9 @@
 import { inject, injectable } from 'inversify'
 import { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import { ProviderService } from '@/background/services/providers/ProviderService'
+import { TelemetryManager } from '@/background/telemetry/TelemetryManager'
 import { alarmKeys } from '@/common/alarms/constants'
+import { IS_FIREFOX } from '@/common/constants'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 
@@ -16,6 +18,8 @@ export class AlarmManager {
     private extensionOptionsService: ExtensionOptionsService,
     @inject(ProviderService)
     private providerService: ProviderService,
+    @inject(TelemetryManager)
+    private telemetryManager: TelemetryManager,
     @inject(LoggerSymbol) logger: ILogger
   ) {
     this.logger = logger.sub('[AlarmManager]')
@@ -38,6 +42,7 @@ export class AlarmManager {
     // if this happens, we may miss an alarm
     void this.createDanmakuPurgeAlarm()
     void this.createManifestRefreshAlarm()
+    void this.createHeartbeatAlarm()
 
     const handleDanmakuPurgeAlarm = this.createHandleDanmakuPurgeAlarm()
 
@@ -47,6 +52,34 @@ export class AlarmManager {
     if (!chrome.alarms.onAlarm.hasListener(this.handleManifestRefreshAlarm)) {
       chrome.alarms.onAlarm.addListener(this.handleManifestRefreshAlarm)
     }
+    if (!chrome.alarms.onAlarm.hasListener(this.handleHeartbeatAlarm)) {
+      chrome.alarms.onAlarm.addListener(this.handleHeartbeatAlarm)
+    }
+  }
+
+  private async createHeartbeatAlarm() {
+    const alarm = await chrome.alarms.get(alarmKeys.HEARTBEAT)
+
+    if (alarm) {
+      return
+    }
+
+    await chrome.alarms.create(alarmKeys.HEARTBEAT, {
+      periodInMinutes: 60 * 24,
+    })
+  }
+
+  private handleHeartbeatAlarm = (alarm: chrome.alarms.Alarm) => {
+    if (alarm.name !== alarmKeys.HEARTBEAT) {
+      return
+    }
+
+    this.telemetryManager.track(
+      'heartbeat',
+      { browser: IS_FIREFOX ? 'firefox' : 'chrome' },
+      'background',
+      Date.now()
+    )
   }
 
   // Create an alarm to purge old data

--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -8,6 +8,7 @@ import { MountConfigTabReloader } from '@/background/scripting/MountConfigTabRel
 import { ScriptingManager } from '@/background/scripting/ScriptingManager'
 import { ProviderService } from '@/background/services/providers/ProviderService'
 import { OptionsManager } from '@/background/syncOptions/OptionsManager'
+import { TelemetryManager } from '@/background/telemetry/TelemetryManager'
 import { deferredConfigureStore } from '@/background/utils/deferredConfigureStore'
 import { generateId } from '@/background/utils/generateId'
 import {
@@ -33,6 +34,7 @@ container.get(RpcManager).setup()
 container.get(NetRequestManager).setup()
 container.get(AlarmManager).setup()
 container.get(PortsManager).setup()
+void container.get(TelemetryManager).setup()
 
 container.get(ProviderService).setup()
 

--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -9,6 +9,7 @@ import { MountConfigTabReloader } from '@/background/scripting/MountConfigTabRel
 import { ScriptingManager } from '@/background/scripting/ScriptingManager'
 import { ProviderService } from '@/background/services/providers/ProviderService'
 import { OptionsManager } from '@/background/syncOptions/OptionsManager'
+import { TelemetryManager } from '@/background/telemetry/TelemetryManager'
 import { deferredConfigureStore } from '@/background/utils/deferredConfigureStore'
 import { generateId } from '@/background/utils/generateId'
 import {
@@ -35,6 +36,7 @@ container.get(NetRequestManager).setup()
 setupCookieReplay()
 container.get(AlarmManager).setup()
 container.get(PortsManager).setup()
+void container.get(TelemetryManager).setup()
 
 container.get(ProviderService).setup()
 

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -44,6 +44,7 @@ import { SeasonMap } from '@/common/seasonMap/SeasonMap'
 import { DebugFileService } from '../services/DebugFile/DebugFile.service'
 import { EpisodeMatchingService } from '../services/matching/EpisodeMatchingService'
 import { ProviderService } from '../services/providers/ProviderService'
+import { TelemetryManager } from '../telemetry/TelemetryManager'
 
 @injectable('Singleton')
 export class RpcManager {
@@ -84,7 +85,9 @@ export class RpcManager {
     @inject(ManifestRegistry)
     private manifestRegistry: ManifestRegistry,
     @inject(ManifestSandbox)
-    private manifestSandbox: ManifestSandbox
+    private manifestSandbox: ManifestSandbox,
+    @inject(TelemetryManager)
+    private telemetryManager: TelemetryManager
   ) {
     this.logger = logger.sub('[RpcManager]')
   }
@@ -298,6 +301,14 @@ export class RpcManager {
         },
         remoteLog: async (data) => {
           void this.logService.log(data)
+        },
+        telemetryEvent: async (input) => {
+          this.telemetryManager.track(
+            input.event,
+            input.properties,
+            input.surface,
+            input.clientTs
+          )
         },
         exportDebugData: async () => {
           return this.debugFileService.upload()

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.test.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DA_ENV, EXTENSION_VERSION } from '@/common/constants'
+import type { ILogger } from '@/common/Logger'
+import type { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
+import { TelemetryManager } from './TelemetryManager'
+
+/**
+ * TelemetryManager buffers relayed events in the background and flushes them to
+ * the intake endpoint. Verifies the size trigger (20 events), the 30s timer
+ * trigger, the consent gate (drops everything when analytics is off or no
+ * install id), and drop-on-failure (a failed flush never throws and the batch
+ * is not retried).
+ */
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  sub: () => silentLogger,
+} as unknown as ILogger
+
+const makeOptionsService = (options: {
+  enableAnalytics: boolean
+  id?: string
+}) => {
+  return {
+    get: vi.fn(async () => options),
+    onChange: vi.fn(),
+  } as unknown as ExtensionOptionsService
+}
+
+const makeManager = async (options: {
+  enableAnalytics: boolean
+  id?: string
+}) => {
+  const manager = new TelemetryManager(
+    makeOptionsService(options),
+    silentLogger
+  )
+  await manager.setup()
+  return manager
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn(async () => new Response('{}', { status: 202 }))
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('TelemetryManager', () => {
+  it('flushes once the buffer reaches the size threshold', async () => {
+    const manager = await makeManager({
+      enableAnalytics: true,
+      id: 'install-1',
+    })
+
+    for (let i = 0; i < 20; i++) {
+      manager.track('search', { keyword: 'x' }, 'popup', 1700000000000)
+    }
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+
+    const [, init] = fetchSpy.mock.calls[0]
+    const batch = JSON.parse(init.body)
+    expect(batch).toHaveLength(20)
+    expect(batch[0]).toMatchObject({
+      installId: 'install-1',
+      event: 'search',
+      surface: 'popup',
+      version: EXTENSION_VERSION,
+      environment: DA_ENV,
+    })
+  })
+
+  it('flushes a partial buffer after the timer elapses', async () => {
+    vi.useFakeTimers()
+    const manager = await makeManager({
+      enableAnalytics: true,
+      id: 'install-1',
+    })
+
+    manager.track('heartbeat', { browser: 'chrome' }, 'background', 1)
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops events when consent is disabled', async () => {
+    const manager = await makeManager({
+      enableAnalytics: false,
+      id: 'install-1',
+    })
+
+    for (let i = 0; i < 25; i++) {
+      manager.track('search', { keyword: 'x' }, 'popup', 1)
+    }
+    await Promise.resolve()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('drops events when there is no install id', async () => {
+    const manager = await makeManager({ enableAnalytics: true, id: undefined })
+
+    for (let i = 0; i < 25; i++) {
+      manager.track('search', { keyword: 'x' }, 'popup', 1)
+    }
+    await Promise.resolve()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a failed flush', async () => {
+    fetchSpy.mockRejectedValue(new Error('offline'))
+    const manager = await makeManager({
+      enableAnalytics: true,
+      id: 'install-1',
+    })
+
+    for (let i = 0; i < 20; i++) {
+      manager.track('search', { keyword: 'first' }, 'popup', 1)
+    }
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 202 }))
+    for (let i = 0; i < 20; i++) {
+      manager.track('search', { keyword: 'second' }, 'popup', 1)
+    }
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
+
+    const secondBatch = JSON.parse(fetchSpy.mock.calls[1][1].body)
+    expect(secondBatch).toHaveLength(20)
+    expect(
+      secondBatch.every(
+        (e: { properties: { keyword: string } }) =>
+          e.properties.keyword === 'second'
+      )
+    ).toBe(true)
+  })
+})

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.test.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.test.ts
@@ -76,6 +76,33 @@ describe('TelemetryManager', () => {
       version: EXTENSION_VERSION,
       environment: DA_ENV,
     })
+    expect(batch[0].properties).toEqual({ keyword: 'x' })
+  })
+
+  it('does not schedule a second flush after a size-triggered flush', async () => {
+    vi.useFakeTimers()
+    const manager = await makeManager({
+      enableAnalytics: true,
+      id: 'install-1',
+    })
+
+    for (let i = 0; i < 20; i++) {
+      manager.track('search', { keyword: 'x' }, 'popup', 1)
+    }
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes background-origin events immediately', async () => {
+    const manager = await makeManager({
+      enableAnalytics: true,
+      id: 'install-1',
+    })
+
+    manager.track('heartbeat', { browser: 'chrome' }, 'background', 1)
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
   })
 
   it('flushes a partial buffer after the timer elapses', async () => {
@@ -85,7 +112,7 @@ describe('TelemetryManager', () => {
       id: 'install-1',
     })
 
-    manager.track('heartbeat', { browser: 'chrome' }, 'background', 1)
+    manager.track('search', { keyword: 'x' }, 'popup', 1)
     expect(fetchSpy).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(30_000)

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.test.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.test.ts
@@ -95,6 +95,28 @@ describe('TelemetryManager', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('does not drop an event relayed before setup resolves', async () => {
+    let resolveGet: (value: { enableAnalytics: boolean; id?: string }) => void =
+      () => {}
+    const optionsService = {
+      get: vi.fn(
+        () =>
+          new Promise<{ enableAnalytics: boolean; id?: string }>((resolve) => {
+            resolveGet = resolve
+          })
+      ),
+      onChange: vi.fn(),
+    } as unknown as ExtensionOptionsService
+    const manager = new TelemetryManager(optionsService, silentLogger)
+
+    void manager.setup()
+    manager.track('heartbeat', { browser: 'chrome' }, 'background', 1)
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    resolveGet({ enableAnalytics: true, id: 'install-1' })
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+  })
+
   it('flushes background-origin events immediately', async () => {
     const manager = await makeManager({
       enableAnalytics: true,

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
@@ -70,7 +70,10 @@ export class TelemetryManager {
       surface,
     })
 
-    if (this.buffer.length >= FLUSH_AT_EVENTS) {
+    // Background-origin events (e.g. the daily heartbeat) are rare and fire
+    // while the worker is awake; flush now so a size-1 buffer is not lost when
+    // MV3 suspends the worker before the timer elapses.
+    if (this.buffer.length >= FLUSH_AT_EVENTS || surface === 'background') {
       void this.flush()
     } else {
       this.scheduleFlush()

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
@@ -60,6 +60,9 @@ export class TelemetryManager {
     this.installId = options.id
 
     this.extensionOptionsService.onChange((next) => {
+      if (!next) {
+        return
+      }
       this.consent = next.enableAnalytics
       this.installId = next.id
     })

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
@@ -26,6 +26,7 @@ export class TelemetryManager {
   private flushTimer: ReturnType<typeof setTimeout> | null = null
   private consent = true
   private installId?: string
+  private initPromise: Promise<void> | null = null
 
   constructor(
     @inject(ExtensionOptionsService)
@@ -39,7 +40,21 @@ export class TelemetryManager {
     if (this.disabled) {
       return
     }
+    await this.ensureReady()
+  }
 
+  private ensureReady(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.load().catch((e) => {
+        // Allow a later track() to retry the initial read.
+        this.initPromise = null
+        this.logger.debug('Init failed', e)
+      })
+    }
+    return this.initPromise
+  }
+
+  private async load() {
     const options = await this.extensionOptionsService.get()
     this.consent = options.enableAnalytics
     this.installId = options.id
@@ -56,7 +71,24 @@ export class TelemetryManager {
     surface: Surface,
     clientTs: number
   ) {
-    if (this.disabled || !this.consent || !this.installId) {
+    if (this.disabled) {
+      return
+    }
+
+    // Defer behind init so an event relayed before the first options read (e.g.
+    // a heartbeat on a worker woken by its alarm) is not dropped.
+    void this.ensureReady().then(() => {
+      this.enqueue(event, properties, surface, clientTs)
+    })
+  }
+
+  private enqueue(
+    event: TelemetryEventName,
+    properties: object,
+    surface: Surface,
+    clientTs: number
+  ) {
+    if (!this.consent || !this.installId) {
       return
     }
 

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
@@ -1,0 +1,119 @@
+import { inject, injectable } from 'inversify'
+import { DA_ENV, EXTENSION_VERSION, IS_DA_E2E } from '@/common/constants'
+import { IS_STANDALONE_RUNTIME } from '@/common/environment/isStandalone'
+import { type ILogger, LoggerSymbol } from '@/common/Logger'
+import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
+import type { Surface, TelemetryEventName } from '@/common/telemetry/events'
+
+const FLUSH_AT_EVENTS = 20
+const FLUSH_INTERVAL_MS = 30_000
+const INTAKE_URL = `${import.meta.env.VITE_PROXY_URL}/v1/intake`
+
+interface TelemetryEnvelope {
+  installId: string
+  event: string
+  properties: object
+  clientTs: number
+  version: string
+  environment: string
+  surface: Surface
+}
+
+@injectable('Singleton')
+export class TelemetryManager {
+  private logger: ILogger
+  private buffer: TelemetryEnvelope[] = []
+  private flushTimer: ReturnType<typeof setTimeout> | null = null
+  private consent = true
+  private installId?: string
+
+  constructor(
+    @inject(ExtensionOptionsService)
+    private extensionOptionsService: ExtensionOptionsService,
+    @inject(LoggerSymbol) logger: ILogger
+  ) {
+    this.logger = logger.sub('[TelemetryManager]')
+  }
+
+  async setup() {
+    if (this.disabled) {
+      return
+    }
+
+    const options = await this.extensionOptionsService.get()
+    this.consent = options.enableAnalytics
+    this.installId = options.id
+
+    this.extensionOptionsService.onChange((next) => {
+      this.consent = next.enableAnalytics
+      this.installId = next.id
+    })
+  }
+
+  track(
+    event: TelemetryEventName,
+    properties: object,
+    surface: Surface,
+    clientTs: number
+  ) {
+    if (this.disabled || !this.consent || !this.installId) {
+      return
+    }
+
+    this.buffer.push({
+      installId: this.installId,
+      event,
+      properties,
+      clientTs,
+      version: EXTENSION_VERSION,
+      environment: DA_ENV,
+      surface,
+    })
+
+    if (this.buffer.length >= FLUSH_AT_EVENTS) {
+      void this.flush()
+    } else {
+      this.scheduleFlush()
+    }
+  }
+
+  private get disabled() {
+    return IS_DA_E2E || IS_STANDALONE_RUNTIME
+  }
+
+  private scheduleFlush() {
+    if (this.flushTimer !== null) {
+      return
+    }
+    this.flushTimer = setTimeout(() => {
+      void this.flush()
+    }, FLUSH_INTERVAL_MS)
+  }
+
+  private async flush() {
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+
+    if (this.buffer.length === 0) {
+      return
+    }
+
+    const batch = this.buffer
+    this.buffer = []
+
+    try {
+      await fetch(INTAKE_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'da-version': EXTENSION_VERSION,
+        },
+        body: JSON.stringify(batch),
+      })
+    } catch (e) {
+      this.logger.debug('Flush failed, dropping batch', e)
+    }
+  }
+}

--- a/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
+++ b/packages/danmaku-anywhere/src/background/telemetry/TelemetryManager.ts
@@ -114,6 +114,8 @@ export class TelemetryManager {
           'da-version': EXTENSION_VERSION,
         },
         body: JSON.stringify(batch),
+        // Let an in-flight flush complete even if MV3 suspends the worker.
+        keepalive: true,
       })
     } catch (e) {
       this.logger.debug('Flush failed, dropping batch', e)

--- a/packages/danmaku-anywhere/src/common/alarms/constants.ts
+++ b/packages/danmaku-anywhere/src/common/alarms/constants.ts
@@ -1,4 +1,5 @@
 export const alarmKeys = {
   PURGE_DANMAKU: 'purge-danmaku' as const,
   REFRESH_MANIFESTS: 'refresh-manifests' as const,
+  HEARTBEAT: 'heartbeat' as const,
 } as const

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSettingsPageCore/DanmakuStylesForm.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSettingsPageCore/DanmakuStylesForm.tsx
@@ -6,7 +6,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { DocIcon } from '@/common/components/DocIcon'
@@ -18,6 +18,7 @@ import { usePlatformInfo } from '@/common/hooks/usePlatformInfo'
 import { useResetForm } from '@/common/hooks/useResetForm'
 import type { DanmakuOptions } from '@/common/options/danmakuOptions/constant'
 import { useDanmakuOptions } from '@/common/options/danmakuOptions/useDanmakuOptions'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { FontSelector } from './FontSelector'
 import { LabeledScrubber } from './LabeledScrubber'
 import { LabeledSlider } from './LabeledSlider'
@@ -208,6 +209,34 @@ const convertDisplaySpeedToActual = (displaySpeed: number) => {
 
 export type SaveStatus = 'idle' | 'saving' | 'saved'
 
+const occlusionKeys: (keyof DanmakuOptions)[] = [
+  'occlusion',
+  'occlusionModel',
+  'occlusionConfidence',
+  'occlusionEdgeSoftness',
+  'occlusionQuality',
+]
+
+function trackStyleChange(next: DanmakuOptions, previous: DanmakuOptions) {
+  const changedKeys = (Object.keys(next) as (keyof DanmakuOptions)[]).filter(
+    (key) => JSON.stringify(next[key]) !== JSON.stringify(previous[key])
+  )
+
+  if (changedKeys.length === 0) {
+    return
+  }
+
+  getTrackingService().track('styleUpdate', { changedKeys })
+
+  if (changedKeys.some((key) => occlusionKeys.includes(key))) {
+    getTrackingService().track('occlusionToggle', {
+      enabled: next.occlusion,
+      model: next.occlusionModel,
+      quality: next.occlusionQuality,
+    })
+  }
+}
+
 export type DanmakuStylesFormProps = {
   onSaveStatusChange?: (status: SaveStatus) => void
 }
@@ -226,8 +255,13 @@ export const DanmakuStylesForm = ({
 
   const { control, setValue, getValues, watch, handleSubmit, subscribe } = form
 
+  const lastTrackedRef = useRef<DanmakuOptions>(config)
+
   const onSave = async (formData: DanmakuOptions) => {
     onSaveStatusChange?.('saving')
+
+    trackStyleChange(formData, lastTrackedRef.current)
+    lastTrackedRef.current = formData
 
     await partialUpdate(formData)
 

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/UrlParseSection.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/UrlParseSection.tsx
@@ -77,7 +77,13 @@ export function UrlParseSection({
     queryKey,
     retry: false,
     queryFn: async () => {
-      getTrackingService().track('parseUrl', { url: trimmedUrl })
+      let hostname = ''
+      try {
+        hostname = new URL(trimmedUrl).hostname
+      } catch {
+        // leave empty when the input is not a parseable URL
+      }
+      getTrackingService().track('parseUrl', { hostname })
       return chromeRpcClient.mediaParseUrl({ url: trimmedUrl })
     },
     select: (res) => res.data,

--- a/packages/danmaku-anywhere/src/common/components/SearchPageCore/UrlParseSection.tsx
+++ b/packages/danmaku-anywhere/src/common/components/SearchPageCore/UrlParseSection.tsx
@@ -81,7 +81,7 @@ export function UrlParseSection({
       try {
         hostname = new URL(trimmedUrl).hostname
       } catch {
-        // leave empty when the input is not a parseable URL
+        hostname = ''
       }
       getTrackingService().track('parseUrl', { hostname })
       return chromeRpcClient.mediaParseUrl({ url: trimmedUrl })

--- a/packages/danmaku-anywhere/src/common/options/providerConfig/useProviderConfig.ts
+++ b/packages/danmaku-anywhere/src/common/options/providerConfig/useProviderConfig.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { useInjectService } from '@/common/hooks/useInjectService'
 import { bookmarkQueryKeys, storageQueryKeys } from '@/common/queries/queryKeys'
 import { useSuspenseExtStorageQuery } from '@/common/storage/hooks/useSuspenseExtStorageQuery'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import type { ProviderConfig, ProviderConfigOptions } from './schema'
 import { ProviderConfigService } from './service'
 
@@ -47,7 +48,12 @@ export const useEditProviderConfig = () => {
   const providerConfigService = useInjectService(ProviderConfigService)
 
   const createMutation = useMutation({
-    mutationFn: providerConfigService.create.bind(providerConfigService),
+    mutationFn: (input: unknown) => providerConfigService.create(input),
+    onSuccess: (config) => {
+      getTrackingService().track('providerConfigCreate', {
+        manifestId: config.manifestId,
+      })
+    },
     meta,
   })
 
@@ -59,11 +65,27 @@ export const useEditProviderConfig = () => {
       id: string
       config: Partial<ProviderConfig>
     }) => providerConfigService.update(id, config),
+    onSuccess: (config) => {
+      getTrackingService().track('providerConfigUpdate', {
+        manifestId: config.manifestId,
+      })
+    },
     meta,
   })
 
   const deleteMutation = useMutation({
     mutationFn: providerConfigService.delete.bind(providerConfigService),
+    onMutate: async (id: string) => {
+      const config = await providerConfigService.get(id)
+      return { manifestId: config?.manifestId }
+    },
+    onSuccess: (_, __, context) => {
+      if (context?.manifestId) {
+        getTrackingService().track('providerConfigDelete', {
+          manifestId: context.manifestId,
+        })
+      }
+    },
     // Deleting a config also deletes its bookmarks in the background, so the
     // bookmark cache must refetch or the tree keeps showing dead stubs.
     meta: { invalidates: [queryKey, bookmarkQueryKeys.all()] },
@@ -72,6 +94,11 @@ export const useEditProviderConfig = () => {
   const toggleMutation = useMutation({
     mutationFn: ({ id, enabled }: { id: string; enabled?: boolean }) =>
       providerConfigService.toggle(id, enabled),
+    onSuccess: (config) => {
+      getTrackingService().track('providerConfigToggle', {
+        manifestId: config.manifestId,
+      })
+    },
     meta,
   })
 

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -66,6 +66,7 @@ import type {
   MountConfigAiConfig,
 } from '@/common/options/mountConfig/schema'
 import type { SeasonMapSnapshot } from '@/common/seasonMap/SeasonMap'
+import type { TelemetryRelayEvent } from '@/common/telemetry/events'
 import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 import type { RPCDef } from '../../rpc/types'
 
@@ -263,6 +264,7 @@ export type BackgroundMethods = {
   getExtensionManifest: RPCDef<void, chrome.runtime.ManifestV3>
   getAlarm: RPCDef<string, chrome.alarms.Alarm | null>
   remoteLog: RPCDef<LogEntry, void>
+  telemetryEvent: RPCDef<TelemetryRelayEvent, void>
   exportDebugData: RPCDef<void, { id: string }>
   getFontList: RPCDef<void, chrome.fontSettings.FontName[]>
   getPlatformInfo: RPCDef<void, chrome.runtime.PlatformInfo>

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -67,6 +67,7 @@ import type {
   MountConfigAiConfig,
 } from '@/common/options/mountConfig/schema'
 import type { SeasonMapSnapshot } from '@/common/seasonMap/SeasonMap'
+import type { TelemetryRelayEvent } from '@/common/telemetry/events'
 import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 import type { RPCDef } from '../../rpc/types'
 
@@ -267,6 +268,7 @@ export type BackgroundMethods = {
   getExtensionManifest: RPCDef<void, chrome.runtime.ManifestV3>
   getAlarm: RPCDef<string, chrome.alarms.Alarm | null>
   remoteLog: RPCDef<LogEntry, void>
+  telemetryEvent: RPCDef<TelemetryRelayEvent, void>
   exportDebugData: RPCDef<void, { id: string }>
   getFontList: RPCDef<void, chrome.fontSettings.FontName[]>
   getPlatformInfo: RPCDef<void, chrome.runtime.PlatformInfo>

--- a/packages/danmaku-anywhere/src/common/telemetry/TrackingService.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/TrackingService.ts
@@ -1,8 +1,17 @@
 import { type Core, clarity } from 'clarity-js'
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import type {
+  Surface,
+  TelemetryEventMap,
+  TelemetryEventName,
+} from '@/common/telemetry/events'
 
 export abstract class TrackingService {
   abstract identify(userId: string): void
-  abstract track(name: string, attributes?: object): void
+  abstract track<E extends TelemetryEventName>(
+    name: E,
+    properties: TelemetryEventMap[E]
+  ): void
   abstract tag(key: string, value: string): void
   abstract init(): void
 }
@@ -12,7 +21,10 @@ export class NoopTrackingService implements TrackingService {
     // noop
   }
 
-  track(name: string, attributes?: object): void {
+  track<E extends TelemetryEventName>(
+    name: E,
+    properties: TelemetryEventMap[E]
+  ): void {
     // noop
   }
 
@@ -26,25 +38,50 @@ export class NoopTrackingService implements TrackingService {
 }
 
 export class CombinedTrackingService implements TrackingService {
-  constructor(private clarityOptions: Core.Config) {}
+  constructor(
+    private surface: Surface,
+    private clarityOptions?: Core.Config
+  ) {}
 
   identify(userId: string) {
-    clarity.identify(userId)
-  }
-
-  track(name: string, attributes?: object) {
-    try {
-      clarity.event(name, JSON.stringify(attributes))
-    } catch {
-      // ignore
+    if (this.clarityOptions) {
+      clarity.identify(userId)
     }
   }
 
+  track<E extends TelemetryEventName>(
+    name: E,
+    properties: TelemetryEventMap[E]
+  ) {
+    if (this.clarityOptions) {
+      try {
+        clarity.event(name, JSON.stringify(properties))
+      } catch {
+        // ignore
+      }
+    }
+
+    void chromeRpcClient
+      .telemetryEvent({
+        event: name,
+        properties,
+        surface: this.surface,
+        clientTs: Date.now(),
+      })
+      .catch(() => {
+        // telemetry is fire-and-forget; a relay failure must never surface
+      })
+  }
+
   tag(key: string, value: string) {
-    clarity.set(key, value)
+    if (this.clarityOptions) {
+      clarity.set(key, value)
+    }
   }
 
   init() {
-    clarity.start(this.clarityOptions)
+    if (this.clarityOptions) {
+      clarity.start(this.clarityOptions)
+    }
   }
 }

--- a/packages/danmaku-anywhere/src/common/telemetry/events.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/events.ts
@@ -1,0 +1,77 @@
+import type {
+  OcclusionModel,
+  OcclusionQuality,
+} from '@/common/options/danmakuOptions/constant'
+import type { OcclusionStatusReason } from '@/content/player/occlusion/Occlusion.types'
+
+export type Surface = 'popup' | 'content' | 'player' | 'background'
+
+export type DanmakuMountMode = 'manual' | 'auto'
+
+export type EpisodeMatchResult = 'success' | 'disambiguation' | 'notFound'
+
+interface ProviderConfigEventProps {
+  manifestId: string
+}
+
+// Migrated events forward their existing payloads untouched; `object` keeps the
+// catalog from constraining shapes the backend treats as opaque anyway.
+type OpaqueProps = object
+
+type EmptyProps = Record<string, never>
+
+export interface TelemetryEventMap {
+  heartbeat: { browser: string }
+
+  fetchDanmaku: OpaqueProps
+  integrationPolicyMediaChange: OpaqueProps
+  integrationPolicyError: OpaqueProps
+  dragFabEnd: OpaqueProps
+  searchSeason: OpaqueProps
+  search: OpaqueProps
+  parseUrl: { hostname: string }
+  editConfig: OpaqueProps
+  addConfig: OpaqueProps
+
+  occlusionToggle: {
+    enabled: boolean
+    model: OcclusionModel
+    quality: OcclusionQuality
+  }
+  occlusionStart: { model: OcclusionModel; quality: OcclusionQuality }
+  occlusionStatus: { reason: OcclusionStatusReason }
+
+  clickSkipButton: OpaqueProps
+  skipButtonToggle: { enabled: boolean }
+
+  danmakuMount: {
+    mode: DanmakuMountMode
+    providerType: string
+    commentCount: number
+  }
+  danmakuUnmount: { mode: DanmakuMountMode }
+  episodeMatch: { result: EpisodeMatchResult }
+  styleUpdate: { changedKeys: string[] }
+
+  providerConfigCreate: ProviderConfigEventProps
+  providerConfigUpdate: ProviderConfigEventProps
+  providerConfigDelete: ProviderConfigEventProps
+  providerConfigToggle: ProviderConfigEventProps
+
+  manifestSave: { mode: 'create' | 'update' }
+  manifestDelete: EmptyProps
+
+  backupExport: EmptyProps
+  backupImport: EmptyProps
+  cloudBackupCreate: EmptyProps
+  cloudBackupRestore: EmptyProps
+}
+
+export type TelemetryEventName = keyof TelemetryEventMap
+
+export interface TelemetryRelayEvent {
+  event: TelemetryEventName
+  properties: object
+  surface: Surface
+  clientTs: number
+}

--- a/packages/danmaku-anywhere/src/common/telemetry/events.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/events.ts
@@ -14,8 +14,8 @@ interface ProviderConfigEventProps {
   manifestId: string
 }
 
-// Migrated events forward their existing payloads untouched; `object` keeps the
-// catalog from constraining shapes the backend treats as opaque anyway.
+// The backend treats these payloads as opaque, so the catalog does not
+// constrain their shape.
 type OpaqueProps = object
 
 type EmptyProps = Record<string, never>

--- a/packages/danmaku-anywhere/src/common/telemetry/events.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/events.ts
@@ -46,7 +46,7 @@ export interface TelemetryEventMap {
 
   danmakuMount: {
     mode: DanmakuMountMode
-    providerType: string
+    manifestId: string | null
     commentCount: number
   }
   danmakuUnmount: { mode: DanmakuMountMode }

--- a/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/getTrackingService.ts
@@ -1,11 +1,16 @@
 import { EXTENSION_VERSION, IS_DA_E2E } from '@/common/constants'
-import type { EnvironmentType } from '@/common/environment/context'
+import type { Surface } from '@/common/telemetry/events'
 import {
   CombinedTrackingService,
   NoopTrackingService,
   type TrackingService,
 } from '@/common/telemetry/TrackingService'
 import { IS_STANDALONE_RUNTIME } from '../environment/isStandalone'
+
+const CLARITY_PROJECT_IDS: Partial<Record<Surface, string>> = {
+  popup: 'sh0awpf0za',
+  content: 'sh39frrlqn',
+}
 
 let trackingService: TrackingService | null = null
 export const getTrackingService = () => {
@@ -17,28 +22,33 @@ export const getTrackingService = () => {
 
 export const createTrackingService = (
   environment: string,
-  type: EnvironmentType
+  surface: Surface
 ) => {
-  // No real telemetry under e2e (or standalone): specs must not emit Clarity traffic.
+  // No real telemetry under e2e (or standalone): specs must not emit Clarity or
+  // background-sink traffic.
   if (trackingService !== null || IS_STANDALONE_RUNTIME || IS_DA_E2E) {
     return trackingService ?? new NoopTrackingService()
   }
 
-  const isPopup = type === 'popup'
+  const clarityProjectId = CLARITY_PROJECT_IDS[surface]
 
-  const clarityOptions = {
-    projectId: isPopup ? 'sh0awpf0za' : 'sh39frrlqn',
-    upload: 'https://m.clarity.ms/collect',
-    track: true,
-    content: true,
-  }
+  const clarityOptions = clarityProjectId
+    ? {
+        projectId: clarityProjectId,
+        upload: 'https://m.clarity.ms/collect',
+        track: true,
+        content: true,
+      }
+    : undefined
 
-  const service = new CombinedTrackingService(clarityOptions)
+  const service = new CombinedTrackingService(surface, clarityOptions)
   trackingService = service
 
-  service.tag('environment', environment)
-  service.tag('type', type)
-  service.tag('version', EXTENSION_VERSION)
+  if (clarityOptions) {
+    service.tag('environment', environment)
+    service.tag('type', surface)
+    service.tag('version', EXTENSION_VERSION)
+  }
 
   return trackingService
 }

--- a/packages/danmaku-anywhere/src/common/telemetry/useSetupTracking.ts
+++ b/packages/danmaku-anywhere/src/common/telemetry/useSetupTracking.ts
@@ -10,8 +10,9 @@ import type { TrackingService } from './TrackingService'
 export const useSetupTracking = () => {
   const { data } = useExtensionOptions()
   const { environment, type } = useEnvironmentContext()
+  const surface = type === 'popup' ? 'popup' : 'content'
   const trackingServiceRef = useRef<TrackingService>(
-    createTrackingService(environment, type)
+    createTrackingService(environment, surface)
   )
 
   useEffect(() => {

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -134,10 +134,13 @@ export const useLoadDanmaku = () => {
   )
 
   const loadMutation = useMutation({
-    mutationFn: async (data: DanmakuFetchDto) => {
-      return fetchMutation.mutateAsync(data, {
+    mutationFn: async ({
+      mode = 'manual',
+      ...data
+    }: DanmakuFetchDto & { mode?: DanmakuMountMode }) => {
+      return fetchMutation.mutateAsync(data as DanmakuFetchDto, {
         onSuccess: (cache) => {
-          mountDanmaku([cache])
+          mountDanmaku([cache], mode)
         },
         onError: (err) => {
           toast.error(err.message)
@@ -147,10 +150,13 @@ export const useLoadDanmaku = () => {
   })
 
   const loadGenericMutation = useMutation({
-    mutationFn: async (data: MacCMSFetchData) => {
-      return fetchGenericMutation.mutateAsync(data, {
+    mutationFn: async ({
+      mode = 'manual',
+      ...data
+    }: MacCMSFetchData & { mode?: DanmakuMountMode }) => {
+      return fetchGenericMutation.mutateAsync(data as MacCMSFetchData, {
         onSuccess: (cache) => {
-          mountDanmaku([cache])
+          mountDanmaku([cache], mode)
         },
         onError: (err) => {
           toast.error(err.message)

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -14,8 +14,15 @@ import { useFetchDanmaku } from '@/common/danmaku/queries/useFetchDanmaku'
 import { useFetchGenericDanmaku } from '@/common/danmaku/queries/useFetchGenericDanmaku'
 import { episodeToString, isProvider } from '@/common/danmaku/utils'
 import { playerRpcClient } from '@/common/rpcClient/background/client'
+import type { DanmakuMountMode } from '@/common/telemetry/events'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { concatArr } from '@/common/utils/utils'
 import { useStore } from '@/content/controller/store/store'
+
+interface MountVariables {
+  episodes: GenericEpisode[]
+  mode: DanmakuMountMode
+}
 
 const useMountDanmaku = () => {
   const { toast } = useToast()
@@ -24,7 +31,7 @@ const useMountDanmaku = () => {
   const { mount } = useStore.use.danmaku()
 
   return useMutation({
-    mutationFn: async (episodes: GenericEpisode[]) => {
+    mutationFn: async ({ episodes }: MountVariables) => {
       const activeFrame = getActiveFrame()
       if (!activeFrame) {
         throw new Error('No active frame to mount danmaku')
@@ -47,9 +54,19 @@ const useMountDanmaku = () => {
 
       return activeFrame.frameId
     },
-    onSuccess: (mountedFrameId, danmaku) => {
-      mount(danmaku)
+    onSuccess: (mountedFrameId, { episodes, mode }) => {
+      mount(episodes)
       updateFrame(mountedFrameId, { mounted: true })
+
+      const commentCount = episodes.reduce(
+        (sum, episode) => sum + episode.commentCount,
+        0
+      )
+      getTrackingService().track('danmakuMount', {
+        mode,
+        providerType: String(episodes[0].provider),
+        commentCount,
+      })
     },
     onError: (err) => {
       toast.error(err.message)
@@ -74,42 +91,47 @@ export const useLoadDanmaku = () => {
     episodes.length === 1 &&
     isProvider(episodes[0], DanmakuSourceType.DanDanPlay)
 
-  const mountDanmaku = useEventCallback((episodes: GenericEpisode[]) => {
-    return mountMutation.mutateAsync(episodes, {
-      // This is called in addition to the onSuccess of mountMutation
-      onSuccess: () => {
-        if (episodes.length === 1) {
-          const episode = episodes[0]
-          toast.success(
-            t(
-              'danmaku.alert.mounted',
-              'Danmaku Mounted: {{name}} ({{count}})',
-              {
-                name: episodeToString(episode),
-                count: episode.commentCount,
-              }
-            ),
-            {
-              actionFn: isProvider(episode, DanmakuSourceType.DanDanPlay)
-                ? refreshComments
-                : undefined,
-              actionLabel: t('danmaku.refresh', 'Refresh Danmaku'),
+  const mountDanmaku = useEventCallback(
+    (episodes: GenericEpisode[], mode: DanmakuMountMode = 'manual') => {
+      return mountMutation.mutateAsync(
+        { episodes, mode },
+        {
+          // This is called in addition to the onSuccess of mountMutation
+          onSuccess: () => {
+            if (episodes.length === 1) {
+              const episode = episodes[0]
+              toast.success(
+                t(
+                  'danmaku.alert.mounted',
+                  'Danmaku Mounted: {{name}} ({{count}})',
+                  {
+                    name: episodeToString(episode),
+                    count: episode.commentCount,
+                  }
+                ),
+                {
+                  actionFn: isProvider(episode, DanmakuSourceType.DanDanPlay)
+                    ? refreshComments
+                    : undefined,
+                  actionLabel: t('danmaku.refresh', 'Refresh Danmaku'),
+                }
+              )
+            } else {
+              toast.success(
+                t(
+                  'danmaku.alert.mountedMultiple',
+                  'Mounted {{count}} selected danmaku',
+                  {
+                    count: episodes.length,
+                  }
+                )
+              )
             }
-          )
-        } else {
-          toast.success(
-            t(
-              'danmaku.alert.mountedMultiple',
-              'Mounted {{count}} selected danmaku',
-              {
-                count: episodes.length,
-              }
-            )
-          )
+          },
         }
-      },
-    })
-  })
+      )
+    }
+  )
 
   const loadMutation = useMutation({
     mutationFn: async (data: DanmakuFetchDto) => {

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -58,13 +58,17 @@ const useMountDanmaku = () => {
       mount(episodes)
       updateFrame(mountedFrameId, { mounted: true })
 
+      const firstEpisode = episodes[0]
+      if (!firstEpisode) {
+        return
+      }
       const commentCount = episodes.reduce(
         (sum, episode) => sum + episode.commentCount,
         0
       )
       getTrackingService().track('danmakuMount', {
         mode,
-        providerType: String(episodes[0].provider),
+        providerType: String(firstEpisode.provider),
         commentCount,
       })
     },

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -13,6 +13,8 @@ import { DanmakuSourceType } from '@/common/danmaku/enums'
 import { useFetchDanmaku } from '@/common/danmaku/queries/useFetchDanmaku'
 import { useFetchGenericDanmaku } from '@/common/danmaku/queries/useFetchGenericDanmaku'
 import { episodeToString, isProvider } from '@/common/danmaku/utils'
+import { useInjectService } from '@/common/hooks/useInjectService'
+import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import { playerRpcClient } from '@/common/rpcClient/background/client'
 import type { DanmakuMountMode } from '@/common/telemetry/events'
 import { getTrackingService } from '@/common/telemetry/getTrackingService'
@@ -29,6 +31,7 @@ const useMountDanmaku = () => {
 
   const { getActiveFrame, updateFrame } = useStore.use.frame()
   const { mount } = useStore.use.danmaku()
+  const providerConfigService = useInjectService(ProviderConfigService)
 
   return useMutation({
     mutationFn: async ({ episodes }: MountVariables) => {
@@ -54,7 +57,7 @@ const useMountDanmaku = () => {
 
       return activeFrame.frameId
     },
-    onSuccess: (mountedFrameId, { episodes, mode }) => {
+    onSuccess: async (mountedFrameId, { episodes, mode }) => {
       mount(episodes)
       updateFrame(mountedFrameId, { mounted: true })
 
@@ -66,9 +69,17 @@ const useMountDanmaku = () => {
         (sum, episode) => sum + episode.commentCount,
         0
       )
+      // Provider episodes carry the season's config id; map it to the manifest
+      // so custom providers (which share one source type) stay distinguishable.
+      // Local imports have no season, hence no manifest.
+      const providerConfigId =
+        'season' in firstEpisode ? firstEpisode.season.providerConfigId : null
+      const config = providerConfigId
+        ? await providerConfigService.get(providerConfigId)
+        : null
       getTrackingService().track('danmakuMount', {
         mode,
-        providerType: String(firstEpisode.provider),
+        manifestId: config?.manifestId ?? null,
         commentCount,
       })
     },

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -136,10 +136,13 @@ export const useLoadDanmaku = () => {
   )
 
   const loadMutation = useMutation({
-    mutationFn: async (data: DanmakuFetchDto) => {
-      return fetchMutation.mutateAsync(data, {
+    mutationFn: async ({
+      mode = 'manual',
+      ...data
+    }: DanmakuFetchDto & { mode?: DanmakuMountMode }) => {
+      return fetchMutation.mutateAsync(data as DanmakuFetchDto, {
         onSuccess: (cache) => {
-          mountDanmaku([cache])
+          mountDanmaku([cache], mode)
         },
         onError: (err) => {
           toast.error(err.message)
@@ -149,10 +152,13 @@ export const useLoadDanmaku = () => {
   })
 
   const loadGenericMutation = useMutation({
-    mutationFn: async (data: MacCMSFetchData) => {
-      return fetchGenericMutation.mutateAsync(data, {
+    mutationFn: async ({
+      mode = 'manual',
+      ...data
+    }: MacCMSFetchData & { mode?: DanmakuMountMode }) => {
+      return fetchGenericMutation.mutateAsync(data as MacCMSFetchData, {
         onSuccess: (cache) => {
-          mountDanmaku([cache])
+          mountDanmaku([cache], mode)
         },
         onError: (err) => {
           toast.error(err.message)

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -57,13 +57,17 @@ const useMountDanmaku = () => {
       mount(episodes)
       updateFrame(mountedFrameId, { mounted: true })
 
+      const firstEpisode = episodes[0]
+      if (!firstEpisode) {
+        return
+      }
       const commentCount = episodes.reduce(
         (sum, episode) => sum + episode.commentCount,
         0
       )
       getTrackingService().track('danmakuMount', {
         mode,
-        providerType: String(episodes[0].provider),
+        providerType: String(firstEpisode.provider),
         commentCount,
       })
     },

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -65,9 +65,14 @@ const useMountDanmaku = () => {
         (sum, episode) => sum + episode.commentCount,
         0
       )
+      // Custom providers all share one source type, so the manifest is what
+      // distinguishes them. Local imports have no season, hence no manifest.
+      const manifestId = isSourceEpisode(firstEpisode)
+        ? (firstEpisode.season.manifestId ?? null)
+        : null
       getTrackingService().track('danmakuMount', {
         mode,
-        providerType: String(firstEpisode.provider),
+        manifestId,
         commentCount,
       })
     },

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -13,8 +13,15 @@ import { useFetchDanmaku } from '@/common/danmaku/queries/useFetchDanmaku'
 import { useFetchGenericDanmaku } from '@/common/danmaku/queries/useFetchGenericDanmaku'
 import { episodeToString, isSourceEpisode } from '@/common/danmaku/utils'
 import { playerRpcClient } from '@/common/rpcClient/background/client'
+import type { DanmakuMountMode } from '@/common/telemetry/events'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { concatArr } from '@/common/utils/utils'
 import { useStore } from '@/content/controller/store/store'
+
+interface MountVariables {
+  episodes: GenericEpisode[]
+  mode: DanmakuMountMode
+}
 
 const useMountDanmaku = () => {
   const { toast } = useToast()
@@ -23,7 +30,7 @@ const useMountDanmaku = () => {
   const { mount } = useStore.use.danmaku()
 
   return useMutation({
-    mutationFn: async (episodes: GenericEpisode[]) => {
+    mutationFn: async ({ episodes }: MountVariables) => {
       const activeFrame = getActiveFrame()
       if (!activeFrame) {
         throw new Error('No active frame to mount danmaku')
@@ -46,9 +53,19 @@ const useMountDanmaku = () => {
 
       return activeFrame.frameId
     },
-    onSuccess: (mountedFrameId, danmaku) => {
-      mount(danmaku)
+    onSuccess: (mountedFrameId, { episodes, mode }) => {
+      mount(episodes)
       updateFrame(mountedFrameId, { mounted: true })
+
+      const commentCount = episodes.reduce(
+        (sum, episode) => sum + episode.commentCount,
+        0
+      )
+      getTrackingService().track('danmakuMount', {
+        mode,
+        providerType: String(episodes[0].provider),
+        commentCount,
+      })
     },
     onError: (err) => {
       toast.error(err.message)
@@ -74,44 +91,49 @@ export const useLoadDanmaku = () => {
     isSourceEpisode(episodes[0]) &&
     episodes[0].season.manifestId === 'dandanplay'
 
-  const mountDanmaku = useEventCallback((episodes: GenericEpisode[]) => {
-    return mountMutation.mutateAsync(episodes, {
-      // This is called in addition to the onSuccess of mountMutation
-      onSuccess: () => {
-        if (episodes.length === 1) {
-          const episode = episodes[0]
-          toast.success(
-            t(
-              'danmaku.alert.mounted',
-              'Danmaku Mounted: {{name}} ({{count}})',
-              {
-                name: episodeToString(episode),
-                count: episode.commentCount,
-              }
-            ),
-            {
-              actionFn:
-                isSourceEpisode(episode) &&
-                episode.season.manifestId === 'dandanplay'
-                  ? refreshComments
-                  : undefined,
-              actionLabel: t('danmaku.refresh', 'Refresh Danmaku'),
+  const mountDanmaku = useEventCallback(
+    (episodes: GenericEpisode[], mode: DanmakuMountMode = 'manual') => {
+      return mountMutation.mutateAsync(
+        { episodes, mode },
+        {
+          // This is called in addition to the onSuccess of mountMutation
+          onSuccess: () => {
+            if (episodes.length === 1) {
+              const episode = episodes[0]
+              toast.success(
+                t(
+                  'danmaku.alert.mounted',
+                  'Danmaku Mounted: {{name}} ({{count}})',
+                  {
+                    name: episodeToString(episode),
+                    count: episode.commentCount,
+                  }
+                ),
+                {
+                  actionFn:
+                    isSourceEpisode(episode) &&
+                    episode.season.manifestId === 'dandanplay'
+                      ? refreshComments
+                      : undefined,
+                  actionLabel: t('danmaku.refresh', 'Refresh Danmaku'),
+                }
+              )
+            } else {
+              toast.success(
+                t(
+                  'danmaku.alert.mountedMultiple',
+                  'Mounted {{count}} selected danmaku',
+                  {
+                    count: episodes.length,
+                  }
+                )
+              )
             }
-          )
-        } else {
-          toast.success(
-            t(
-              'danmaku.alert.mountedMultiple',
-              'Mounted {{count}} selected danmaku',
-              {
-                count: episodes.length,
-              }
-            )
-          )
+          },
         }
-      },
-    })
-  })
+      )
+    }
+  )
 
   const loadMutation = useMutation({
     mutationFn: async (data: DanmakuFetchDto) => {

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useUnmountDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useUnmountDanmaku.ts
@@ -3,7 +3,14 @@ import { useTranslation } from 'react-i18next'
 
 import { useToast } from '@/common/components/Toast/toastStore'
 import { playerRpcClient } from '@/common/rpcClient/background/client'
+import type { DanmakuMountMode } from '@/common/telemetry/events'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { useStore } from '@/content/controller/store/store'
+
+interface UnmountVariables {
+  frameId?: number
+  mode?: DanmakuMountMode
+}
 
 export const useUnmountDanmaku = () => {
   const { toast } = useToast()
@@ -14,11 +21,12 @@ export const useUnmountDanmaku = () => {
   const { unmount } = useStore.use.danmaku()
 
   return useMutation({
-    mutationFn: async (frameId: number | void) => {
-      const frame = frameId ?? activeFrame?.frameId
+    mutationFn: async (variables: UnmountVariables = {}) => {
+      const frame = variables.frameId ?? activeFrame?.frameId
 
-      if (frame === undefined)
+      if (frame === undefined) {
         throw new Error('Trying to unmount danmaku without an active frame')
+      }
 
       await playerRpcClient.player['relay:command:unmount']({
         frameId: frame,
@@ -26,10 +34,15 @@ export const useUnmountDanmaku = () => {
 
       return true
     },
-    onSuccess: (_, frameId) => {
-      if (frameId) updateFrame(frameId, { mounted: false })
+    onSuccess: (_, variables) => {
+      if (variables?.frameId) {
+        updateFrame(variables.frameId, { mounted: false })
+      }
       unmount()
       toast.info(t('danmaku.alert.unmounted', 'Danmaku Unmounted'))
+      getTrackingService().track('danmakuUnmount', {
+        mode: variables?.mode ?? 'manual',
+      })
     },
     onError: (err) => {
       toast.error(err.message)

--- a/packages/danmaku-anywhere/src/content/controller/controllerRpc/useManualDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/controllerRpc/useManualDanmaku.ts
@@ -20,7 +20,7 @@ export const useManualDanmaku = () => {
 
   const handleUnsetDanmaku = useEventCallback(() => {
     Logger.debug('Requested to unmount danmaku')
-    return unmountMutation.mutateAsync()
+    return unmountMutation.mutateAsync({})
   })
 
   return {

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
@@ -12,6 +12,7 @@ import type {
   PlayerRelayEvents,
   VideoInfo,
 } from '@/common/rpcClient/background/types'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { reparentPopover } from '@/content/common/reparentPopover'
 import { CONTROLLER_ROOT_ID } from '@/content/controller/common/constants/rootId'
 import { useActiveConfig } from '@/content/controller/common/context/useActiveConfig'
@@ -122,7 +123,7 @@ export const FrameManager = () => {
     const activeFrame = useStore.getState().frame.activeFrame
     if (activeFrame?.frameId === frameId) {
       if (activeFrame.mounted) {
-        unmountDanmaku.mutate(frameId)
+        unmountDanmaku.mutate({ frameId })
       }
     }
     updateFrame(frameId, {
@@ -134,6 +135,7 @@ export const FrameManager = () => {
   })
 
   const handleOcclusionStatus = useEventCallback((status: OcclusionStatus) => {
+    getTrackingService().track('occlusionStatus', { reason: status.reason })
     const message = occlusionStatusText(status.reason)
     if (status.reason === 'downloading') {
       toast.info(message)

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/FrameManager.tsx
@@ -12,6 +12,7 @@ import type {
   PlayerRelayEvents,
   VideoInfo,
 } from '@/common/rpcClient/background/types'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { reparentPopover } from '@/content/common/reparentPopover'
 import { CONTROLLER_ROOT_ID } from '@/content/controller/common/constants/rootId'
 import { useActiveConfig } from '@/content/controller/common/context/useActiveConfig'
@@ -123,7 +124,7 @@ export const FrameManager = () => {
     const activeFrame = useStore.getState().frame.activeFrame
     if (activeFrame?.frameId === frameId) {
       if (activeFrame.mounted) {
-        unmountDanmaku.mutate(frameId)
+        unmountDanmaku.mutate({ frameId })
       }
     }
     updateFrame(frameId, {
@@ -135,6 +136,7 @@ export const FrameManager = () => {
   })
 
   const handleOcclusionStatus = useEventCallback((status: OcclusionStatus) => {
+    getTrackingService().track('occlusionStatus', { reason: status.reason })
     const message = occlusionStatusText(status.reason)
     if (status.reason === 'downloading') {
       toast.info(message)

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/useMigrateDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/useMigrateDanmaku.ts
@@ -31,7 +31,7 @@ export const useMigrateDanmaku = () => {
       prevActiveFrameId.current &&
       allFrames.get(prevActiveFrameId.current)?.mounted
     ) {
-      unmountDanmaku.mutate(prevActiveFrameId.current)
+      unmountDanmaku.mutate({ frameId: prevActiveFrameId.current })
     }
 
     if (episodes && episodes.length > 0) {

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useIntegrationPolicy.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useIntegrationPolicy.ts
@@ -103,7 +103,7 @@ export const useIntegrationPolicy = () => {
           )
         }
         if (useStore.getState().danmaku.isMounted) {
-          unmountDanmaku.mutate()
+          unmountDanmaku.mutate({ mode: 'auto' })
         }
 
         setMediaInfo(state)
@@ -135,7 +135,7 @@ export const useIntegrationPolicy = () => {
                   'Matched local danmaku'
                 )
               )
-              void mountDanmaku([matched])
+              void mountDanmaku([matched], 'auto')
             } else {
               loadMutation.mutate(
                 {

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useIntegrationPolicy.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useIntegrationPolicy.ts
@@ -144,6 +144,7 @@ export const useIntegrationPolicy = () => {
                   options: {
                     forceUpdate: false,
                   },
+                  mode: 'auto',
                 },
                 {
                   onError: () => {

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useMatchEpisode.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/integration/hooks/useMatchEpisode.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { MatchEpisodeInput } from '@/common/anime/dto'
 import { useToast } from '@/common/components/Toast/toastStore'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { PopupTab, usePopup } from '@/content/controller/store/popupStore'
 
 export const useMatchEpisode = () => {
@@ -27,6 +28,9 @@ export const useMatchEpisode = () => {
       )
     },
     onSuccess: (result, v) => {
+      getTrackingService().track('episodeMatch', {
+        result: result.data.status,
+      })
       switch (result.data.status) {
         case 'success': {
           break

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingButton/components/FabContextMenu.tsx
@@ -59,7 +59,7 @@ export const FabContextMenu = (props: FabContextMenuProps) => {
       hotkey: getKeyCombo('refreshComments'),
     },
     {
-      action: () => unmountMutation.mutate(),
+      action: () => unmountMutation.mutate({}),
       disabled: () => !isMounted,
       icon: () => <Eject fontSize="small" />,
       label: () => t('danmaku.unmount', 'Unmount'),

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/components/InfoBar.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/components/InfoBar.tsx
@@ -26,7 +26,7 @@ export const InfoBar = () => {
   const { refreshComments, canRefresh, loadMutation } = useLoadDanmaku()
 
   const handleUnmount = () => {
-    unmountMutation.mutate()
+    unmountMutation.mutate({})
   }
 
   const { titles, title } = useMemo(() => {

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -64,6 +64,7 @@ export class DanmakuManagerService {
   private occlusionQuality: OcclusionQuality = 'medium'
   private occlusionModel: OcclusionModel = 'people'
   private occlusionStatusListener?: (status: OcclusionStatus) => void
+  private occlusionRunning = false
   private debug = false
 
   constructor(
@@ -297,6 +298,7 @@ export class DanmakuManagerService {
     const shouldRun = this.occlusion && this.isMounted && this.video !== null
     if (!shouldRun) {
       this.occlusionService.reset()
+      this.occlusionRunning = false
       return
     }
     void this.configureOcclusion()
@@ -314,6 +316,7 @@ export class DanmakuManagerService {
       // leave a stale model running while the UI shows a different one.
       this.logger.error(e)
       this.occlusionService.reset()
+      this.occlusionRunning = false
       return
     }
     // A newer update may have superseded this resolve while it was in flight
@@ -344,10 +347,15 @@ export class DanmakuManagerService {
     })
     this.occlusionService.start(this.video)
 
-    getTrackingService().track('occlusionStart', {
-      model: this.occlusionModel,
-      quality: this.occlusionQuality,
-    })
+    // Only on a genuine off->on activation: configureOcclusion re-runs on any
+    // style change (updateConfig), which must not re-emit occlusionStart.
+    if (!this.occlusionRunning) {
+      this.occlusionRunning = true
+      getTrackingService().track('occlusionStart', {
+        model: this.occlusionModel,
+        quality: this.occlusionQuality,
+      })
+    }
   }
 
   resize() {

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -14,6 +14,7 @@ import type {
 import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import type { SegmentationStats } from '@/common/rpcClient/background/types'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { injectCss } from '@/content/common/injectCss'
 import { DanmakuComponent } from '@/content/player/components/DanmakuComponent'
 import { DanmakuLayoutService } from '@/content/player/danmakuLayout/DanmakuLayout.service'
@@ -342,6 +343,11 @@ export class DanmakuManagerService {
       onStatus: (status) => this.occlusionStatusListener?.(status),
     })
     this.occlusionService.start(this.video)
+
+    getTrackingService().track('occlusionStart', {
+      model: this.occlusionModel,
+      quality: this.occlusionQuality,
+    })
   }
 
   resize() {

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -65,6 +65,8 @@ export class DanmakuManagerService {
   private occlusionModel: OcclusionModel = 'people'
   private occlusionStatusListener?: (status: OcclusionStatus) => void
   private occlusionRunning = false
+  private runningModel?: OcclusionModel
+  private runningQuality?: OcclusionQuality
   private debug = false
 
   constructor(
@@ -347,10 +349,17 @@ export class DanmakuManagerService {
     })
     this.occlusionService.start(this.video)
 
-    // Only on a genuine off->on activation: configureOcclusion re-runs on any
-    // style change (updateConfig), which must not re-emit occlusionStart.
-    if (!this.occlusionRunning) {
+    // configureOcclusion re-runs on any style change (updateConfig). Emit only
+    // on a genuine off->on activation, or when the model/quality actually
+    // changed, not on every unrelated reconfigure.
+    if (
+      !this.occlusionRunning ||
+      this.runningModel !== this.occlusionModel ||
+      this.runningQuality !== this.occlusionQuality
+    ) {
       this.occlusionRunning = true
+      this.runningModel = this.occlusionModel
+      this.runningQuality = this.occlusionQuality
       getTrackingService().track('occlusionStart', {
         model: this.occlusionModel,
         quality: this.occlusionQuality,

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -14,6 +14,7 @@ import type {
 import { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import type { SegmentationStats } from '@/common/rpcClient/background/types'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { injectCss } from '@/content/common/injectCss'
 import { DanmakuComponent } from '@/content/player/components/DanmakuComponent'
 import { DanmakuLayoutService } from '@/content/player/danmakuLayout/DanmakuLayout.service'
@@ -368,6 +369,11 @@ export class DanmakuManagerService {
       onActive: () => this.occlusionActiveListener?.(),
     })
     this.occlusionService.start(this.video)
+
+    getTrackingService().track('occlusionStart', {
+      model: this.occlusionModel,
+      quality: this.occlusionQuality,
+    })
   }
 
   resize() {

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -69,6 +69,8 @@ export class DanmakuManagerService {
   private occlusionDisengagedListener?: () => void
   private occlusionEngaged = false
   private occlusionRunning = false
+  private runningModel?: OcclusionModel
+  private runningQuality?: OcclusionQuality
   private debug = false
 
   constructor(
@@ -373,10 +375,17 @@ export class DanmakuManagerService {
     })
     this.occlusionService.start(this.video)
 
-    // Only on a genuine off->on activation: configureOcclusion re-runs on any
-    // style change (updateConfig), which must not re-emit occlusionStart.
-    if (!this.occlusionRunning) {
+    // configureOcclusion re-runs on any style change (updateConfig). Emit only
+    // on a genuine off->on activation, or when the model/quality actually
+    // changed, not on every unrelated reconfigure.
+    if (
+      !this.occlusionRunning ||
+      this.runningModel !== this.occlusionModel ||
+      this.runningQuality !== this.occlusionQuality
+    ) {
       this.occlusionRunning = true
+      this.runningModel = this.occlusionModel
+      this.runningQuality = this.occlusionQuality
       getTrackingService().track('occlusionStart', {
         model: this.occlusionModel,
         quality: this.occlusionQuality,

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -68,6 +68,7 @@ export class DanmakuManagerService {
   private occlusionActiveListener?: () => void
   private occlusionDisengagedListener?: () => void
   private occlusionEngaged = false
+  private occlusionRunning = false
   private debug = false
 
   constructor(
@@ -320,6 +321,7 @@ export class DanmakuManagerService {
         this.occlusionDisengagedListener?.()
       }
       this.occlusionService.reset()
+      this.occlusionRunning = false
       return
     }
     this.occlusionEngaged = true
@@ -338,6 +340,7 @@ export class DanmakuManagerService {
       // leave a stale model running while the UI shows a different one.
       this.logger.error(e)
       this.occlusionService.reset()
+      this.occlusionRunning = false
       return
     }
     // A newer update may have superseded this resolve while it was in flight
@@ -370,10 +373,15 @@ export class DanmakuManagerService {
     })
     this.occlusionService.start(this.video)
 
-    getTrackingService().track('occlusionStart', {
-      model: this.occlusionModel,
-      quality: this.occlusionQuality,
-    })
+    // Only on a genuine off->on activation: configureOcclusion re-runs on any
+    // style change (updateConfig), which must not re-emit occlusionStart.
+    if (!this.occlusionRunning) {
+      this.occlusionRunning = true
+      getTrackingService().track('occlusionStart', {
+        model: this.occlusionModel,
+        quality: this.occlusionQuality,
+      })
+    }
   }
 
   resize() {

--- a/packages/danmaku-anywhere/src/content/player/index.ts
+++ b/packages/danmaku-anywhere/src/content/player/index.ts
@@ -1,6 +1,10 @@
+import { DA_ENV } from '@/common/constants'
 import { uiContainer } from '@/common/ioc/uiIoc'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { createTrackingService } from '@/common/telemetry/getTrackingService'
 import { PlayerScript } from '@/content/player/PlayerScript.service'
+
+createTrackingService(DA_ENV, 'player')
 
 const { data: frameId } = await chromeRpcClient.getFrameId()
 const player = uiContainer.get(PlayerScript)

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/components/CloudBackupSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/components/CloudBackupSection.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router'
 import { useToast } from '@/common/components/Toast/toastStore'
 import { useAuthSession } from '@/common/hooks/user/useAuthSession'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import {
   SettingsGroup,
   SettingsGroupLabel,
@@ -50,6 +51,7 @@ export function CloudBackupSection({
       toast.success(
         t('optionsPage.backup.cloudCreateSuccess', 'Cloud backup created')
       )
+      getTrackingService().track('cloudBackupCreate', {})
       void refetch()
     },
     onError: (error) => {
@@ -69,6 +71,7 @@ export function CloudBackupSection({
       onRestoringChange?.(true)
     },
     onSuccess: ({ data }) => {
+      getTrackingService().track('cloudBackupRestore', {})
       importMutation.mutate(data)
     },
     onError: (error) => {

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/components/LocalBackupSection.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/components/LocalBackupSection.tsx
@@ -6,6 +6,7 @@ import { type ChangeEvent, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '@/common/components/Toast/toastStore'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { createDownload } from '@/common/utils/utils'
 import {
   SettingsGroup,
@@ -44,6 +45,7 @@ export function LocalBackupSection({
             'Backup exported successfully'
           )
         )
+        getTrackingService().track('backupExport', {})
       })
     },
   })

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/useBackupImport.ts
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/backup/useBackupImport.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '@/common/components/Toast/toastStore'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 
 export function useBackupImport(options?: { onSettled?: () => void }) {
   const { t } = useTranslation()
@@ -16,6 +17,7 @@ export function useBackupImport(options?: { onSettled?: () => void }) {
           'Backup imported successfully'
         )
       )
+      getTrackingService().track('backupImport', {})
     },
     onError: (error) => {
       toast.error(

--- a/packages/danmaku-anywhere/src/popup/pages/options/pages/player/PlayerOptions.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/options/pages/player/PlayerOptions.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useExtensionOptions } from '@/common/options/extensionOptions/useExtensionOptions'
 import { settingConfigs } from '@/common/settings/settingConfigs'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { OptionsPageToolBar } from '@/popup/component/OptionsPageToolbar'
 import { OptionsPageLayout } from '@/popup/layout/OptionsPageLayout'
 import { DeclarativeToggleSetting } from '@/popup/pages/options/components/DeclarativeToggleSetting'
@@ -12,6 +13,19 @@ import {
 export const PlayerOptions = () => {
   const { t } = useTranslation()
   const { data, partialUpdate, isLoading } = useExtensionOptions()
+
+  const handleUpdate = (update: Parameters<typeof partialUpdate>[0]) => {
+    const nextShowSkipButton = update.playerOptions?.showSkipButton
+    if (
+      nextShowSkipButton !== undefined &&
+      nextShowSkipButton !== data.playerOptions.showSkipButton
+    ) {
+      getTrackingService().track('skipButtonToggle', {
+        enabled: nextShowSkipButton,
+      })
+    }
+    return partialUpdate(update)
+  }
 
   return (
     <OptionsPageLayout>
@@ -27,7 +41,7 @@ export const PlayerOptions = () => {
             key={config.id}
             config={config}
             state={data}
-            onUpdate={partialUpdate}
+            onUpdate={handleUpdate}
             isLoading={isLoading}
           />
         ))}

--- a/packages/danmaku-anywhere/src/popup/pages/providers/pages/ManifestEditorPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/pages/ManifestEditorPage.tsx
@@ -18,6 +18,7 @@ import { useToast } from '@/common/components/Toast/toastStore'
 import { useEditProviderConfig } from '@/common/options/providerConfig/useProviderConfig'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import type { ManifestValidationIssue } from '@/common/rpcClient/background/types'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import { tryCatchSync } from '@/common/utils/tryCatch'
 import { docsLink } from '@/common/utils/utils'
 import { OptionsPageToolBar } from '@/popup/component/OptionsPageToolbar'
@@ -204,6 +205,9 @@ function ManifestEditor({
       {
         onError: (error) => toast.error(error.message),
         onSuccess: () => {
+          getTrackingService().track('manifestSave', {
+            mode: isNew ? 'create' : 'update',
+          })
           if (!isNew) {
             finish()
             return

--- a/packages/danmaku-anywhere/src/popup/pages/providers/pages/ProvidersPage.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/pages/ProvidersPage.tsx
@@ -25,6 +25,7 @@ import {
   useProviderConfig,
 } from '@/common/options/providerConfig/useProviderConfig'
 import type { ProviderManifestInfo } from '@/common/rpcClient/background/types'
+import { getTrackingService } from '@/common/telemetry/getTrackingService'
 import {
   createConfigFromManifest,
   groupInstalled,
@@ -186,6 +187,7 @@ export const ProvidersPage = (): ReactElement => {
         await deleteManifest.mutateAsync(manifestId, {
           onSuccess: () => {
             toast.success(t('providers.alert.deleted', 'Provider deleted'))
+            getTrackingService().track('manifestDelete', {})
           },
           onError: (error) => {
             toast.error(error.message)


### PR DESCRIPTION
## Summary
- New first-party telemetry pipeline alongside Microsoft Clarity (Clarity keeps receiving the same custom events for replay filtering). Extension contexts relay typed events to the background, which buffers and POSTs batches to a new backend route that forwards to Axiom.
- **Backend** `POST /v1/intake`: envelope-only zod validation, batch-length + per-item + payload size caps, per-IP rate limit, `receivedAt`/`country` enrichment, fail-open `ctx.waitUntil` forward to Axiom. Unknown event names are forwarded, not rejected (adding an event never needs a backend deploy). `AXIOM_TOKEN` secret + `AXIOM_DATASET` var + `INTAKE_RATE_LIMITER` wired for dev/staging/production.
- **Extension**: compile-time event catalog (`src/common/telemetry/events.ts`) typing `track()`; `track()` fans out to Clarity and a new background `TelemetryManager` (single consent gate on `enableAnalytics`, in-memory buffer, flush at 20 events / 30s, drop-on-failure). Noop under e2e/standalone. Daily heartbeat alarm (the adoption denominator) flushes eagerly so the worker doesn't suspend before it sends. Relay RPC entry; player-frame gets a relay-only tracking service.
- **Instrumentation** (first pass): occlusion toggle/start/status, skip-button toggle, danmaku mount/unmount (manual vs auto), episode match, style update, provider-config CRUD/toggle, manifest save/delete, backup export/import/cloud. `parseUrl` carries hostname only.

## Test plan
- Verified: lint (tsc + biome) pass · extension unit tests pass (background/telemetry/alarm/providerConfig, incl. new `TelemetryManager.test.ts` for size/timer/consent/drop-on-failure/immediate-background-flush and an `AlarmManager` heartbeat test) · backend full suite 74 passed (incl. new `intake.test.ts`: envelope rejection, caps, rate limit, unknown-event passthrough, mocked-Axiom fail-open) · e2e mount + integration specs pass (Noop service under e2e; 2 initial failures were flaky parallel timeouts, green on re-run)
- [ ] Backend: `cd backend/proxy && pnpm test` (intake route)
- [ ] Extension: `pnpm --filter @mr-quin/danmaku-anywhere test` then e2e `pnpm exec playwright test e2e/specs/integration e2e/specs/mount`
- No new e2e coverage added: per the approved spec, e2e/standalone use the existing Noop service and must stay telemetry-silent; existing specs continue to pass.

## Notes
- **Staging only**: prod ships via this PR being merged (CI deploys); I have not touched prod. `AXIOM_TOKEN_STG` / `AXIOM_TOKEN` secrets must exist in the secret store before deploy; `AXIOM_DATASET` is `da-events` with `environment` as a field (staging filterable, not a separate dataset).
- **Migrated events reach Axiom too**: the shared `track()` now relays the existing migrated payloads (e.g. `integrationPolicyMediaChange` carries `mediaInfo` + the integration `policy` object; `search`/`searchSeason` carry the keyword). These already flow to Clarity; only `parseUrl` was reduced to hostname per the spec. Flagging for a privacy confirm: if the policy object / watch-title should be trimmed before Axiom (the spec says "integration-policy name at most"), that scrubbing can be added at the call sites.
- Buffer is in service-worker memory (offline persistence is out of scope per spec); at most one partial batch of UI events is lost on worker kill. The heartbeat is flushed eagerly to avoid systematically losing the denominator.