### PR TITLE
(extension) normalize scrolling modes 2/3 to rtl [DA-653]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/integration/unknown-mode-drop.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/unknown-mode-drop.spec.ts
@@ -13,6 +13,8 @@ import { applyProfile } from '../../setup/profile'
  * comments and silently drops the malformed one. Guards the parser throwing on
  * an unrecognized mode, which would break rendering of the whole batch. The
  * console-error baseline asserts no error surfaces from the dropped comment.
+ * Also verifies that mode-2 (an rtl scrolling variant) is normalized and rendered
+ * rather than dropped.
  */
 
 const ORIGIN = 'https://da-test.invalid'
@@ -22,10 +24,12 @@ const MOUNT_PATTERN = `${ORIGIN}/*`
 const EPISODE_TITLE = 'DA Integration Test'
 const VALID_TEXT = 'valid-comment'
 const INVALID_TEXT = 'unknown-mode-comment'
-// Both sit at the same timestamp, so a dropped-vs-rendered comparison is fair.
+const MODE_2_TEXT = 'mode-2-comment'
+// All three sit at the same timestamp, so a dropped-vs-rendered comparison is fair.
 const COMMENTS = [
   { p: '12,99,16777215,bad', m: INVALID_TEXT },
   { p: '12,1,16777215,e2e-1', m: VALID_TEXT },
+  { p: '12,2,16777215,e2e-2', m: MODE_2_TEXT },
 ]
 const SEEK_TIME_S = 15
 
@@ -83,4 +87,8 @@ test('unknown comment mode is dropped without breaking the batch', async ({
   await expect(
     integrationPage.commentElements().filter({ hasText: INVALID_TEXT })
   ).toHaveCount(0)
+
+  await expect(
+    integrationPage.commentElements().filter({ hasText: MODE_2_TEXT })
+  ).toBeVisible()
 })

--- a/packages/danmaku-converter/src/canonical/comment/types.ts
+++ b/packages/danmaku-converter/src/canonical/comment/types.ts
@@ -8,6 +8,14 @@ export enum CommentMode {
   bottom = 4,
 }
 
+// Modes 1/2/3 are all right-to-left scrolling variants per the danmaku spec; normalize to mode 1.
+export function normalizeCommentMode(n: number): number {
+  if (n === 2 || n === 3) {
+    return 1
+  }
+  return n
+}
+
 export const zCommentEntity = z.object({
   /**
    * Comment id, if available
@@ -49,7 +57,10 @@ export const zCommentImport = z
         z
           .tuple([
             zTime, // time
-            z.coerce.number<string>().pipe(z.enum(CommentMode)),
+            z.coerce
+              .number<string>()
+              .transform(normalizeCommentMode)
+              .pipe(z.enum(CommentMode)),
             zRgb888, // decimal color
           ])
           .rest(z.string())

--- a/packages/danmaku-converter/src/canonical/comment/utils.test.ts
+++ b/packages/danmaku-converter/src/canonical/comment/utils.test.ts
@@ -30,4 +30,22 @@ describe('comment entity conversion', () => {
   it('should return null for an unknown mode', () => {
     expect(parseCommentEntityP('658.73,99,16777215,0')).toBeNull()
   })
+
+  it('should normalize mode 2 to rtl', () => {
+    expect(parseCommentEntityP('12,2,16777215,uid')).toEqual({
+      time: 12,
+      mode: 'rtl',
+      color: '#ffffff',
+      uid: 'uid',
+    })
+  })
+
+  it('should normalize mode 3 to rtl', () => {
+    expect(parseCommentEntityP('12,3,16777215,uid')).toEqual({
+      time: 12,
+      mode: 'rtl',
+      color: '#ffffff',
+      uid: 'uid',
+    })
+  })
 })

--- a/packages/danmaku-converter/src/canonical/comment/utils.ts
+++ b/packages/danmaku-converter/src/canonical/comment/utils.ts
@@ -1,6 +1,6 @@
 import { hexToRgb888, rgb888ToHex } from '../../utils/index.js'
 import type { CommentOptions } from './types.js'
-import { CommentMode } from './types.js'
+import { CommentMode, normalizeCommentMode } from './types.js'
 
 export const parseCommentGradient = (s: string) => {
   const [gr, flag] = s.split(',')
@@ -15,20 +15,20 @@ export const parseCommentGradient = (s: string) => {
   }
 }
 
-// convert string to object
 // returns null on an unrecognized mode so callers can drop the comment instead of throwing
 export const parseCommentEntityP = (p: string): CommentOptions | null => {
   const [time, mode, color, uid = ''] = p.split(',')
+  const modeNum = normalizeCommentMode(Number.parseInt(mode))
 
-  if (!CommentMode[Number.parseInt(mode)]) {
+  if (!CommentMode[modeNum]) {
     return null
   }
 
   return {
     time: Number.parseFloat(time),
-    mode: CommentMode[Number.parseInt(mode)] as keyof typeof CommentMode,
+    mode: CommentMode[modeNum] as keyof typeof CommentMode,
     color: rgb888ToHex(Number.parseInt(color)),
-    uid, // uid may include string
+    uid,
   }
 }
 

--- a/packages/danmaku-converter/src/canonical/import/import.test.ts
+++ b/packages/danmaku-converter/src/canonical/import/import.test.ts
@@ -74,6 +74,22 @@ describe('commentSchema', () => {
     expect(() => zCommentImport.parse(invalidTime)).toThrow()
     expect(() => zCommentImport.parse(invalidColor)).toThrow()
   })
+
+  it('normalizes mode 2 to 1 (rtl)', () => {
+    const result = zCommentImport.parse({ p: '12.5,2,16777215', m: 'test' })
+    expect(result.p).toBe('12.5,1,16777215')
+  })
+
+  it('normalizes mode 3 to 1 (rtl)', () => {
+    const result = zCommentImport.parse({ p: '12.5,3,16777215', m: 'test' })
+    expect(result.p).toBe('12.5,1,16777215')
+  })
+
+  it('rejects comment with unknown mode', () => {
+    expect(() =>
+      zCommentImport.parse({ p: '12.5,99,16777215', m: 'test' })
+    ).toThrow()
+  })
 })
 
 // Updated assert function for the `imported` array structure


### PR DESCRIPTION
## Summary
- Per the danmaku spec, modes 1, 2, and 3 are all right-to-left scrolling variants. Before this change, modes 2 and 3 were treated as unrecognized and silently dropped (DA-644 behavior). This PR folds them to mode 1 (rtl) at parse time via a shared \`normalizeCommentMode\` helper.
- Genuinely unknown modes (7, 8, 99, etc.) are still dropped.
- Two parse boundaries are covered: \`parseCommentEntityP\` (live danmaku) and \`zCommentImport\` (backup import schema). The ddp provider path flows through \`parseCommentEntityP\` and is covered for free.

## Test plan
- Verified: lint pass (tsc + biome) · tests pass (47/47 in \`@danmaku-anywhere/danmaku-converter\`) · e2e spec extended (not run locally; requires e2e rebuild)
- Unit tests: \`packages/danmaku-converter/src/canonical/comment/utils.test.ts\` — mode 2 and 3 both produce \`rtl\`; existing mode-99 test preserved
- Unit tests: \`packages/danmaku-converter/src/canonical/import/import.test.ts\` — mode 2 and 3 both normalize in the import schema; mode 99 still throws
- [ ] Run \`pnpm --filter @danmaku-anywhere/danmaku-converter test\` (47 tests)
- [ ] Run \`pnpm --filter @mr-quin/danmaku-anywhere test:e2e -- --grep "unknown comment mode"\` (requires e2e build)