### PR TITLE
(extension) cookieReplay: capture Set-Cookie via webRequest for Youku [DA-547]

### DIFF
--- a/packages/danmaku-anywhere/src/background/index.ts
+++ b/packages/danmaku-anywhere/src/background/index.ts
@@ -1,6 +1,7 @@
 import { configureApiStore } from '@danmaku-anywhere/danmaku-provider'
 import { AlarmManager } from '@/background/alarm/AlarmManager'
 import { ContextMenuManager } from '@/background/contextMenu/ContextMenuManager'
+import { setupCookieReplay } from '@/background/netRequest/cookieReplay'
 import { NetRequestManager } from '@/background/netRequest/NetrequestManager'
 import { PortsManager } from '@/background/ports/PortsManager'
 import { RpcManager } from '@/background/rpc/RpcManager'
@@ -31,6 +32,7 @@ container.get(ScriptingManager).setup()
 container.get(MountConfigTabReloader).setup()
 container.get(RpcManager).setup()
 container.get(NetRequestManager).setup()
+setupCookieReplay()
 container.get(AlarmManager).setup()
 container.get(PortsManager).setup()
 

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.test.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for cookieReplay: the webRequest listener that captures Set-Cookie
+ * headers (stripped by fetch) and exposes them to extensionFetchLike via
+ * consumeSetCookies / getCookiesForHost.
+ *
+ * Verifies: header capture keyed by URL, per-host cookie jar population,
+ * multi-value Set-Cookie joining, cookie overwrite, and tab-id filtering.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  consumeSetCookies as ConsumeFn,
+  getCookiesForHost as GetCookiesFn,
+  setupCookieReplay as SetupFn,
+} from './cookieReplay'
+
+type HeadersReceivedListener = (
+  details: chrome.webRequest.OnHeadersReceivedDetails
+) => chrome.webRequest.BlockingResponse | undefined
+
+// Each test gets a fresh module instance (module-level maps start empty).
+describe('cookieReplay', () => {
+  let setupCookieReplay: typeof SetupFn
+  let consumeSetCookies: typeof ConsumeFn
+  let getCookiesForHost: typeof GetCookiesFn
+
+  let addListener: ReturnType<typeof vi.fn>
+  let capturedListener: HeadersReceivedListener
+
+  function makeDetails(
+    overrides: Record<string, unknown> = {}
+  ): chrome.webRequest.OnHeadersReceivedDetails {
+    return {
+      requestId: '1',
+      url: 'https://acs.youku.com/weakget',
+      method: 'GET',
+      frameId: 0,
+      parentFrameId: -1,
+      tabId: -1,
+      type: 'xmlhttprequest',
+      timeStamp: Date.now(),
+      statusCode: 200,
+      statusLine: 'HTTP/1.1 200 OK',
+      responseHeaders: [],
+      ...overrides,
+    } as unknown as chrome.webRequest.OnHeadersReceivedDetails
+  }
+
+  beforeEach(async () => {
+    vi.resetModules()
+    addListener = vi.fn().mockImplementation((listener) => {
+      capturedListener = listener
+    })
+    vi.stubGlobal('chrome', {
+      webRequest: {
+        onHeadersReceived: { addListener },
+      },
+    })
+    const mod = await import('./cookieReplay')
+    setupCookieReplay = mod.setupCookieReplay
+    consumeSetCookies = mod.consumeSetCookies
+    getCookiesForHost = mod.getCookiesForHost
+    setupCookieReplay()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('registers a listener on onHeadersReceived with correct filter', () => {
+    expect(addListener).toHaveBeenCalledOnce()
+    const [, filter, extraInfoSpec] = addListener.mock.calls[0]
+    expect(filter.urls).toContain('<all_urls>')
+    expect(extraInfoSpec).toContain('responseHeaders')
+    expect(extraInfoSpec).toContain('extraHeaders')
+  })
+
+  it('captures Set-Cookie from SW traffic (tabId === -1)', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/weakget',
+        tabId: -1,
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=abc123; Partitioned; Secure' },
+        ],
+      })
+    )
+
+    expect(consumeSetCookies('https://acs.youku.com/weakget')).toBe(
+      '_m_h5_tk=abc123; Partitioned; Secure'
+    )
+  })
+
+  it('ignores traffic from real tabs (tabId !== -1)', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/page',
+        tabId: 42,
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=should_not_capture' },
+        ],
+      })
+    )
+
+    expect(consumeSetCookies('https://acs.youku.com/page')).toBeNull()
+    expect(getCookiesForHost('acs.youku.com')).toBeNull()
+  })
+
+  it('joins multiple Set-Cookie headers with "; "', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://example.com/api',
+        responseHeaders: [
+          { name: 'set-cookie', value: 'a=1; Path=/' },
+          { name: 'set-cookie', value: 'b=2; Path=/' },
+        ],
+      })
+    )
+
+    expect(consumeSetCookies('https://example.com/api')).toBe(
+      'a=1; Path=/; b=2; Path=/'
+    )
+  })
+
+  it('returns null for a URL that was never captured', () => {
+    expect(consumeSetCookies('https://not-captured.example.com/')).toBeNull()
+  })
+
+  it('populates the per-host cookie jar for getCookiesForHost', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/weakget',
+        responseHeaders: [
+          {
+            name: 'set-cookie',
+            value:
+              '_m_h5_tk=HASH_TIMESTAMP; Partitioned; SameSite=None; Secure',
+          },
+          {
+            name: 'set-cookie',
+            value: '_m_h5_tk_enc=ENC_VALUE; Partitioned; SameSite=None; Secure',
+          },
+        ],
+      })
+    )
+
+    const cookieHeader = getCookiesForHost('acs.youku.com')
+    expect(cookieHeader).toContain('_m_h5_tk=HASH_TIMESTAMP')
+    expect(cookieHeader).toContain('_m_h5_tk_enc=ENC_VALUE')
+  })
+
+  it('overwrites a cookie in the jar when the same name arrives again', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/first',
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=OLD_TOKEN; Secure' },
+        ],
+      })
+    )
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/second',
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=NEW_TOKEN; Secure' },
+        ],
+      })
+    )
+
+    expect(getCookiesForHost('acs.youku.com')).toBe('_m_h5_tk=NEW_TOKEN')
+  })
+
+  it('returns null from getCookiesForHost for unknown hosts', () => {
+    expect(getCookiesForHost('unknown.example.com')).toBeNull()
+  })
+
+  it('skips headers with no value', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://example.com/empty',
+        responseHeaders: [{ name: 'set-cookie', value: '' }],
+      })
+    )
+
+    expect(consumeSetCookies('https://example.com/empty')).toBeNull()
+  })
+
+  it('is case-insensitive to header name casing', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://example.com/caps',
+        responseHeaders: [{ name: 'Set-Cookie', value: 'x=1' }],
+      })
+    )
+
+    expect(consumeSetCookies('https://example.com/caps')).toBe('x=1')
+  })
+})

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.test.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.test.ts
@@ -2,9 +2,6 @@
  * Tests for cookieReplay: the webRequest listener that captures Set-Cookie
  * headers (stripped by fetch) and exposes them to extensionFetchLike via
  * consumeSetCookies / getCookiesForHost.
- *
- * Verifies: header capture keyed by URL, per-host cookie jar population,
- * multi-value Set-Cookie joining, cookie overwrite, and tab-id filtering.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -152,6 +149,28 @@ describe('cookieReplay', () => {
     const cookieHeader = getCookiesForHost('acs.youku.com')
     expect(cookieHeader).toContain('_m_h5_tk=HASH_TIMESTAMP')
     expect(cookieHeader).toContain('_m_h5_tk_enc=ENC_VALUE')
+  })
+
+  it('removes a cookie from the jar when Max-Age=0 arrives with a non-empty dummy value', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/step1',
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=abc123; Secure' },
+        ],
+      })
+    )
+    expect(getCookiesForHost('acs.youku.com')).toBe('_m_h5_tk=abc123')
+
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/step2',
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=deleted; Max-Age=0; Path=/' },
+        ],
+      })
+    )
+    expect(getCookiesForHost('acs.youku.com')).toBeNull()
   })
 
   it('removes a cookie from the jar when an empty-value Set-Cookie arrives', () => {

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.test.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.test.ts
@@ -91,6 +91,11 @@ describe('cookieReplay', () => {
     )
   })
 
+  it('is idempotent: calling setupCookieReplay twice registers the listener only once', () => {
+    setupCookieReplay()
+    expect(addListener).toHaveBeenCalledTimes(1)
+  })
+
   it('ignores traffic from real tabs (tabId !== -1)', () => {
     capturedListener(
       makeDetails({
@@ -147,6 +152,28 @@ describe('cookieReplay', () => {
     const cookieHeader = getCookiesForHost('acs.youku.com')
     expect(cookieHeader).toContain('_m_h5_tk=HASH_TIMESTAMP')
     expect(cookieHeader).toContain('_m_h5_tk_enc=ENC_VALUE')
+  })
+
+  it('removes a cookie from the jar when an empty-value Set-Cookie arrives', () => {
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/step1',
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=abc123; Secure' },
+        ],
+      })
+    )
+    expect(getCookiesForHost('acs.youku.com')).toBe('_m_h5_tk=abc123')
+
+    capturedListener(
+      makeDetails({
+        url: 'https://acs.youku.com/step2',
+        responseHeaders: [
+          { name: 'set-cookie', value: '_m_h5_tk=; Max-Age=0; Path=/' },
+        ],
+      })
+    )
+    expect(getCookiesForHost('acs.youku.com')).toBeNull()
   })
 
   it('overwrites a cookie in the jar when the same name arrives again', () => {

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
@@ -65,9 +65,7 @@ export function setupCookieReplay(): void {
   isSetUp = true
   chrome.webRequest.onHeadersReceived.addListener(
     (details): chrome.webRequest.BlockingResponse => {
-      // tabId === -1 means the request originated from the extension service
-      // worker, not from a tab. Skip page traffic so normal browsing doesn't
-      // populate the cookie cache.
+      // tabId === -1: SW request, not a user tab.
       if (details.tabId !== -1 || !details.responseHeaders) {
         return {}
       }
@@ -93,7 +91,7 @@ export function setupCookieReplay(): void {
           jar = new Map()
           cookieJarByHost.set(host, jar)
         }
-        if (parsed.value === '') {
+        if (parsed.value === '' || /\bmax-age=0\b/i.test(h.value)) {
           jar.delete(parsed.name)
         } else {
           jar.set(parsed.name, parsed.value)

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
@@ -10,6 +10,7 @@ interface Captured {
 
 const setCookieByUrl = new Map<string, Captured>()
 const cookieJarByHost = new Map<string, Map<string, string>>()
+let isSetUp = false
 
 export function consumeSetCookies(url: string): string | null {
   const entry = setCookieByUrl.get(url)
@@ -58,6 +59,10 @@ export function setupCookieReplay(): void {
   if (typeof chrome === 'undefined' || !chrome.webRequest) {
     return
   }
+  if (isSetUp) {
+    return
+  }
+  isSetUp = true
   chrome.webRequest.onHeadersReceived.addListener(
     (details): chrome.webRequest.BlockingResponse => {
       // tabId === -1 means the request originated from the extension service
@@ -88,7 +93,11 @@ export function setupCookieReplay(): void {
           jar = new Map()
           cookieJarByHost.set(host, jar)
         }
-        jar.set(parsed.name, parsed.value)
+        if (parsed.value === '') {
+          jar.delete(parsed.name)
+        } else {
+          jar.set(parsed.name, parsed.value)
+        }
       }
 
       if (captured.length > 0) {

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
@@ -1,0 +1,98 @@
+// fetch() strips Set-Cookie (forbidden response header). This module
+// captures it from webRequest and replays it for manifest engine use.
+
+const CAPTURE_TTL_MS = 60_000
+
+interface Captured {
+  cookies: string[]
+  insertedAt: number
+}
+
+const setCookieByUrl = new Map<string, Captured>()
+const cookieJarByHost = new Map<string, Map<string, string>>()
+
+export function consumeSetCookies(url: string): string | null {
+  const entry = setCookieByUrl.get(url)
+  if (!entry || entry.cookies.length === 0) {
+    return null
+  }
+  return entry.cookies.join('; ')
+}
+
+export function getCookiesForHost(host: string): string | null {
+  const jar = cookieJarByHost.get(host)
+  if (!jar || jar.size === 0) {
+    return null
+  }
+  return Array.from(jar, ([name, value]) => `${name}=${value}`).join('; ')
+}
+
+function pruneStale(now: number): void {
+  for (const [url, entry] of setCookieByUrl) {
+    if (now - entry.insertedAt > CAPTURE_TTL_MS) {
+      setCookieByUrl.delete(url)
+    }
+  }
+}
+
+interface ParsedSetCookie {
+  name: string
+  value: string
+}
+
+function parseSetCookie(line: string): ParsedSetCookie | null {
+  const semi = line.indexOf(';')
+  const nv = semi === -1 ? line : line.slice(0, semi)
+  const eq = nv.indexOf('=')
+  if (eq === -1) {
+    return null
+  }
+  return { name: nv.slice(0, eq).trim(), value: nv.slice(eq + 1).trim() }
+}
+
+export function setupCookieReplay(): void {
+  if (typeof chrome === 'undefined' || !chrome.webRequest) {
+    return
+  }
+  chrome.webRequest.onHeadersReceived.addListener(
+    (details): chrome.webRequest.BlockingResponse => {
+      // tabId === -1 means the request originated from the extension service
+      // worker, not from a tab. Skip page traffic so normal browsing doesn't
+      // populate the cookie cache.
+      if (details.tabId !== -1 || !details.responseHeaders) {
+        return {}
+      }
+      const now = Date.now()
+      pruneStale(now)
+
+      const url = new URL(details.url)
+      const host = url.hostname
+      const captured: string[] = []
+
+      for (const h of details.responseHeaders) {
+        if (h.name.toLowerCase() !== 'set-cookie' || !h.value) {
+          continue
+        }
+        captured.push(h.value)
+
+        const parsed = parseSetCookie(h.value)
+        if (!parsed) {
+          continue
+        }
+        let jar = cookieJarByHost.get(host)
+        if (!jar) {
+          jar = new Map()
+          cookieJarByHost.set(host, jar)
+        }
+        jar.set(parsed.name, parsed.value)
+      }
+
+      if (captured.length > 0) {
+        setCookieByUrl.set(details.url, { cookies: captured, insertedAt: now })
+      }
+      return {}
+    },
+    { urls: ['<all_urls>'] },
+    ['responseHeaders', 'extraHeaders']
+  )
+}

--- a/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
+++ b/packages/danmaku-anywhere/src/background/netRequest/cookieReplay.ts
@@ -47,7 +47,11 @@ function parseSetCookie(line: string): ParsedSetCookie | null {
   if (eq === -1) {
     return null
   }
-  return { name: nv.slice(0, eq).trim(), value: nv.slice(eq + 1).trim() }
+  const name = nv.slice(0, eq).trim()
+  if (!name) {
+    return null
+  }
+  return { name, value: nv.slice(eq + 1).trim() }
 }
 
 export function setupCookieReplay(): void {

--- a/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
@@ -18,7 +18,9 @@ export const extensionFetchLike: FetchLike = async (input, init) => {
   try {
     const urlHost = new URL(input).hostname
     const capturedCookies = getCookiesForHost(urlHost)
-    if (capturedCookies && !rewrite?.['Cookie']) {
+    const hasCookie =
+      rewrite && Object.keys(rewrite).some((k) => k.toLowerCase() === 'cookie')
+    if (capturedCookies && !hasCookie) {
       effectiveRewrite = { ...rewrite, Cookie: capturedCookies }
     }
   } catch {

--- a/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
@@ -5,12 +5,9 @@ import {
 } from '@/background/netRequest/cookieReplay'
 import { setSessionHeader } from '@/background/netRequest/setSessionHeader'
 
-// `fetch` silently drops forbidden request headers like Origin / Referer /
-// User-Agent, so when a manifest step declares `rewriteHeaders` we install a
-// short-lived `chrome.declarativeNetRequest` session rule for the call.
-//
-// We also inject any cookies captured by the cookieReplay listener for the
-// target host (Partitioned cookies are not auto-attached by the SW fetcher).
+// fetch() drops forbidden request headers, so rewriteHeaders steps use a
+// short-lived DNR session rule. Captured cookies are also injected since
+// Partitioned cookies are not auto-attached on service-worker fetch() calls.
 export const extensionFetchLike: FetchLike = async (input, init) => {
   const rewrite = init?.rewriteHeaders
   let effectiveRewrite = rewrite
@@ -37,9 +34,11 @@ export const extensionFetchLike: FetchLike = async (input, init) => {
     const headers = new Map<string, string>()
     res.headers.forEach((value, key) => headers.set(key, value))
     if (!headers.has('set-cookie')) {
-      // Use res.url (final URL after redirects) since the listener keys on
-      // the URL that actually received the Set-Cookie response.
-      const captured = consumeSetCookies(res.url)
+      // Try the final URL first; fall back to input if a redirect moved the response.
+      let captured = consumeSetCookies(res.url)
+      if (captured === null && input !== res.url) {
+        captured = consumeSetCookies(input)
+      }
       if (captured !== null) {
         headers.set('set-cookie', captured)
       }

--- a/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
@@ -1,20 +1,47 @@
 import type { FetchLike } from '@mr-quin/dango'
+import {
+  consumeSetCookies,
+  getCookiesForHost,
+} from '@/background/netRequest/cookieReplay'
 import { setSessionHeader } from '@/background/netRequest/setSessionHeader'
 
 // `fetch` silently drops forbidden request headers like Origin / Referer /
 // User-Agent, so when a manifest step declares `rewriteHeaders` we install a
 // short-lived `chrome.declarativeNetRequest` session rule for the call.
+//
+// We also inject any cookies captured by the cookieReplay listener for the
+// target host (Partitioned cookies are not auto-attached by the SW fetcher).
 export const extensionFetchLike: FetchLike = async (input, init) => {
   const rewrite = init?.rewriteHeaders
+  let effectiveRewrite = rewrite
+
+  try {
+    const urlHost = new URL(input).hostname
+    const capturedCookies = getCookiesForHost(urlHost)
+    if (capturedCookies && !rewrite?.['Cookie']) {
+      effectiveRewrite = { ...rewrite, Cookie: capturedCookies }
+    }
+  } catch {
+    // non-parseable URL: skip cookie injection
+  }
+
   const dnr =
-    rewrite && Object.keys(rewrite).length > 0
-      ? await setSessionHeader(input, rewrite)
+    effectiveRewrite && Object.keys(effectiveRewrite).length > 0
+      ? await setSessionHeader(input, effectiveRewrite)
       : null
   try {
     const { rewriteHeaders: _, ...requestInit } = init ?? {}
     const res = await fetch(input, requestInit as RequestInit)
     const headers = new Map<string, string>()
     res.headers.forEach((value, key) => headers.set(key, value))
+    if (!headers.has('set-cookie')) {
+      // Use res.url (final URL after redirects) since the listener keys on
+      // the URL that actually received the Set-Cookie response.
+      const captured = consumeSetCookies(res.url)
+      if (captured !== null) {
+        headers.set('set-cookie', captured)
+      }
+    }
     return {
       status: res.status,
       text: () => res.text(),


### PR DESCRIPTION
## Summary
- Adds `cookieReplay.ts`: a `webRequest.onHeadersReceived` listener that captures `Set-Cookie` response headers (which `fetch()` strips as a forbidden header) and makes them available via two interfaces: a per-URL TTL cache (`consumeSetCookies`) and a per-host cookie jar (`getCookiesForHost`).
- Updates `extensionFetchLike` to splice captured `Set-Cookie` back into the response headers map (so the Youku manifest's `extractHeaders` JSONata can read `_m_h5_tk`), and to inject captured cookies as a `Cookie` request header via DNR on subsequent same-host requests (working around the `Partitioned` attribute that prevents auto-attachment in the SW context).
- No `chrome.cookies` permission added: the injection path goes through the existing `setSessionHeader` DNR mechanism.

## Test plan
- Verified: lint (tsc + biome) pass. Tests: `pnpm --filter '...[origin/master]' test` (69 files, 658 tests, all pass). browser-verify: 8,979 real danmaku comments fetched for Youku Detective Conan episode 1, zero SW console errors, confirming both halves (Set-Cookie capture and Cookie injection) work end-to-end.
- e2e: not included. The Youku pipeline's segment URLs are HMAC-signed with a live timestamp, making fixture-based mocking possible (via URL pattern matching) but requiring verification that `chrome.webRequest.onHeadersReceived` fires for Playwright `route.fulfill()` responses in the SW context. The browser-verify pass is the authoritative end-to-end validation here.
- [ ] `pnpm --filter @mr-quin/danmaku-anywhere test` to run unit tests
- [ ] Manual: load a Youku episode in the extension and confirm danmaku loads without T0410 in the SW console

## Notes
- The `cookieJarByHost` map is session-scoped (lives for the SW lifetime) and not TTL-pruned. This is intentional: cookie values are small, the number of distinct extension-facing hostnames is bounded, and a stale cookie is self-healing on next SW restart.
- The `consumeSetCookies` per-URL cache is TTL-pruned at 60 seconds on each `onHeadersReceived` fire. It is not consumed-and-deleted because retried requests need the same value.