### PR TITLE
(extension) support @dan-uni/dan-any to handle mutiple format of danmakus

### DIFF
--- a/.agents/skills/dan-any/SKILL.md
+++ b/.agents/skills/dan-any/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: dan-any
+description: Use when answering how to install, initialize, choose a backend, import/export/convert danmaku formats, use plugins, use wildcard adapters, or implement custom backends/plugins for @dan-uni/dan-any v2.2+.
+metadata:
+  short-description: Work with @dan-uni/dan-any
+---
+
+# dan-any 接入与使用 Skill
+
+本 skill 面向 `@dan-uni/dan-any` v2.2+，用于指导弹幕格式导入、导出、转换、插件处理、后端选择和自定义实现。
+
+## 何时使用
+
+- 用户询问如何安装、初始化或使用 `@dan-uni/dan-any`。
+- 用户需要在 Bilibili XML/PB、DanUni JSON/PB、Dplayer、Artplayer、DDPlay、Tencent、VOD 等弹幕格式之间转换。
+- 用户需要选择 drizzle/PGLite 后端或纯 TypeScript 后端。
+- 用户需要合并、降级高级弹幕、统计弹幕，或写自定义 Adapter/Transformer/Plugin。
+- 用户需要按文件名/内容自动识别弹幕格式。
+
+## 快速摘要
+
+- 当前包版本已更新到 `2.2.0`。
+- 核心模型：`Adapter` 导入外部格式，`Transformer` 导出目标格式，`Plugin` 在 `UniChunk` 上处理数据。
+- 具体后端入口：
+  - `@dan-uni/dan-any/core/main/drizzle`：drizzle + PGLite 实现，默认数据库路线。
+  - `@dan-uni/dan-any/core/main/pure`：纯 TypeScript `Map` 实现，不依赖 drizzle/PGLite。
+- `@dan-uni/dan-any/core` 现在主要提供抽象基类、类型和 `main` 聚合，不要从这里直接实例化 `UniDB`。
+- 为了同时兼容 drizzle 的异步实现和 pure 的同步实现，示例代码统一对 `init`、`import`、`export`、`plugin`、`$count`、`close` 使用 `await`。
+- 获取数量优先用 `await chunk.$count`；`CountTransformer` 已弃用，仅为兼容保留。
+
+## 安装
+
+```bash
+vp add @dan-uni/dan-any
+bun add @dan-uni/dan-any
+pnpm add @dan-uni/dan-any
+```
+
+## 后端选择
+
+优先根据运行环境选择后端：
+
+- 普通浏览器/Node/桌面应用：优先 `core/main/drizzle`，可用 PGLite 的 `MemoryFS`、`NodeFS`、`IndexedDbFS`、`OpfsAhpFS`，也可接入兼容 drizzle 的自定义 Postgres/PGLite 实例。
+- `@edge-runtime/vm`、Service Worker、或 PGLite/Emscripten 环境检测不可靠的位置：使用 `core/main/pure`。
+- 临时、小数据量、对启动延迟敏感的任务：可优先尝试 `core/main/pure`。
+
+drizzle 后端示例：
+
+```ts
+import { UniDB } from "@dan-uni/dan-any/core/main/drizzle";
+
+const udb = await new UniDB().init();
+try {
+  // import/export/plugin...
+} finally {
+  await udb.close();
+}
+```
+
+pure 后端示例：
+
+```ts
+import { UniDB } from "@dan-uni/dan-any/core/main/pure";
+
+const udb = await new UniDB().init();
+try {
+  // 同一套 Adapter/Transformer/Plugin 用法
+} finally {
+  await udb.close();
+}
+```
+
+## 常见接入
+
+从 Bilibili XML 导入并导出为 DanUni JSON：
+
+```ts
+import { BiliXmlAdapter, DanuniJsonTransformerConfigurator } from "@dan-uni/dan-any/adapters";
+import { UniDB } from "@dan-uni/dan-any/core/main/drizzle";
+
+export async function biliXmlToDanuniJson(xml: string) {
+  const udb = await new UniDB().init();
+  try {
+    const chunk = await udb.import(BiliXmlAdapter(xml));
+    return await chunk.export(DanuniJsonTransformerConfigurator({ minify: true }));
+  } finally {
+    await udb.close();
+  }
+}
+```
+
+使用插件合并重复弹幕：
+
+```ts
+import { BiliXmlAdapter, DanuniJsonTransformerConfigurator } from "@dan-uni/dan-any/adapters";
+import { UniDB } from "@dan-uni/dan-any/core/main/drizzle";
+import { MergePluginConfigurator } from "@dan-uni/dan-any/plugins";
+
+const udb = await new UniDB().init();
+const chunk = await udb.import(BiliXmlAdapter(xml));
+const merged = await chunk.plugin(MergePluginConfigurator(10));
+const json = await merged.export(DanuniJsonTransformerConfigurator({ minify: true }));
+```
+
+获取弹幕数量：
+
+```ts
+const count = await chunk.$count;
+```
+
+DanUni PB 导出再导入：
+
+```ts
+import { DanuniPbAdapter, DanuniPbTransformer } from "@dan-uni/dan-any/adapters";
+
+const pb = await chunk.export(DanuniPbTransformer);
+const reimported = await udb.import(DanuniPbAdapter(pb));
+```
+
+合并多个 chunk 时，从所选后端导入 `UniChunk`：
+
+```ts
+import { UniChunk } from "@dan-uni/dan-any/core/main/drizzle";
+
+const chunk1 = await udb.import(BiliXmlAdapter(xml1));
+const chunk2 = await udb.import(BiliXmlAdapter(xml2));
+const assigned = await UniChunk.assign(chunk1, [chunk2]);
+```
+
+不要调用 `@dan-uni/dan-any/core` 里的抽象 `UniChunk.assign`；它只定义接口，具体逻辑在后端实现里。
+
+## 格式映射
+
+按用户意图选择 Adapter 或 Transformer：
+
+| 格式                     | 导入 Adapter             | 导出 Transformer                    |
+| ------------------------ | ------------------------ | ----------------------------------- |
+| DanUni JSON              | `DanuniJsonAdapter`      | `DanuniJsonTransformerConfigurator` |
+| DanUni PB                | `DanuniPbAdapter`        | `DanuniPbTransformer`               |
+| Bilibili XML             | `BiliXmlAdapter`         | `BiliXmlTransformerConfigurator`    |
+| Bilibili gRPC PB         | `BiliGrpcAdapter`        | -                                   |
+| Bilibili command gRPC PB | `BiliCommandGrpcAdapter` | -                                   |
+| Bilibili UP JSON         | `BiliUpAdapter`          | -                                   |
+| Artplayer JSON           | `ArtplayerAdapter`       | `ArtplayerTransformer`              |
+| Dplayer JSON             | `DplayerAdapter`         | `DplayerTransformer`                |
+| DDPlay JSON              | `DdplayAdapter`          | `DdplayTransformer`                 |
+| Tencent JSON             | `TencentAdapter`         | -                                   |
+| VOD JSON                 | `VodAdapter`             | `VodTransformer`                    |
+
+ASS 由外部扩展包 `@dan-uni/dan-any-ext-ass` 提供，不属于核心包内置 Adapter/Transformer。
+
+判断规则：
+
+- “从 X 导入/读取/解析/接入”：优先找 Adapter。
+- “导出/转换为 X/生成 X 文件”：优先找 Transformer。
+- “支持 X 吗”：同时说明导入和导出是否支持；没有 Transformer 的格式只支持单向导入。
+- “b站 xml”“bilixml”“bili xml”都归一到 Bilibili XML。
+- “pb”默认指 protobuf；需要结合上下文区分 DanUni PB 和 Bilibili gRPC PB。
+
+## 自动识别格式
+
+优先使用内置 `Metadata` 与 `WildcardAdapterUtil`，不要手写大段格式分支：
+
+```ts
+import {
+  ArtplayerAdapter,
+  ArtplayerMetadata,
+  BiliXmlAdapter,
+  BiliXmlMetadata,
+  DanuniPbAdapter,
+  DanuniPbMetadata,
+  DdplayAdapter,
+  DdplayMetadata,
+} from "@dan-uni/dan-any/adapters";
+import { UniChunk } from "@dan-uni/dan-any/core/main/drizzle";
+import { WildcardAdapterUtil } from "@dan-uni/dan-any/utils";
+
+const result = await WildcardAdapterUtil(
+  udb,
+  [
+    [DanuniPbMetadata, DanuniPbAdapter],
+    [BiliXmlMetadata, BiliXmlAdapter],
+    [DdplayMetadata, DdplayAdapter],
+    [ArtplayerMetadata, ArtplayerAdapter],
+  ],
+  filename,
+  body,
+);
+
+if (result instanceof UniChunk) {
+  // 已直接导入成功
+  const count = await result.$count;
+} else if (result === ArtplayerAdapter) {
+  // 识别成功但该 Adapter 需要额外参数
+  await udb.import(ArtplayerAdapter(body, "player-id", "domain"));
+} else if (result === null) {
+  // 未识别
+}
+```
+
+`WildcardAdapterUtil` 可能返回三类值：已导入的 `UniChunk`、需要额外参数的 `Adapter`、或 `null`。
+
+## 插件与统计
+
+常用内置项：
+
+- `MergePluginConfigurator(lifetime)`：合并重复弹幕，`lifetime` 单位为秒，`0` 表示不按时间窗口查重。
+- `DowngradeAdvancedPluginConfigurator(options?)`：把高级弹幕降级为普通文本内容，可用 `include`/`exclude` 控制 extra 来源。
+- `GetStatsTransformerConfigurator(keys)`：统计字段分布。
+- `GetStatsUtil4getMost(map)`：从统计 `Map` 中取最高频项。
+- `CountTransformer`：已弃用，新代码使用 `chunk.$count`。
+
+统计示例：
+
+```ts
+import { GetStatsTransformerConfigurator, GetStatsUtil4getMost } from "@dan-uni/dan-any/plugins";
+
+const stats = await chunk.export(GetStatsTransformerConfigurator(["mode", "fontsize"]));
+const mostMode = GetStatsUtil4getMost(stats.mode);
+```
+
+外部插件：
+
+- `DetaoluPluginConfigurator` 由 `@dan-uni/dan-any-plugin-detaolu` 提供，不从核心包导入。
+
+## 自定义 drizzle 数据库
+
+接入兼容 drizzle/PGLite 实例时使用 drizzle 后端的 `InitedUniDB`：
+
+```ts
+import { baseRelations, relations } from "@dan-uni/dan-any/core/db/schema";
+import { migrateDb } from "@dan-uni/dan-any/core/db/utils";
+import { InitedUniDB } from "@dan-uni/dan-any/core/main/drizzle";
+import { drizzle } from "drizzle-orm/pglite";
+
+const db = drizzle({ relations: { ...baseRelations, ...relations } });
+await migrateDb(db);
+
+const udb = new InitedUniDB(db);
+const chunk = await udb.makeChunk({});
+```
+
+如果项目扩展了自己的 schema：
+
+- 可在自定义 schema 中 `export * from '@dan-uni/dan-any/core/db/schema'`，让 drizzle 统一生成迁移。
+- 或先用 `migrateDb(db)` 迁移 dan-any 自带表，再自行迁移额外表。
+- 自定义关系可参考 `tests/db.test.ts` 中的 `defineRelationsPart` 示例。
+
+## 自定义 Adapter/Transformer/Plugin
+
+类型工具从 `@dan-uni/dan-any/adapters` 导入：
+
+```ts
+import { defineAdapter, definePlugin, defineTransformer } from "@dan-uni/dan-any/adapters";
+```
+
+实现 Transformer 时，入参已经是 `UDanmaku[]`，不要再写旧版的 `udanmakus.then(...)`：
+
+```ts
+const MyTransformer = defineTransformer((udanmakus) => {
+  return udanmakus.map((d) => d.content);
+});
+```
+
+实现 Plugin 时，如果会创建新 chunk，用 `@dan-uni/dan-any/core` 的抽象 `UniChunk.makeChunk`，并用泛型保留当前后端的具体类型：
+
+```ts
+import { definePlugin } from "@dan-uni/dan-any/adapters";
+import { UniChunk as BaseUniChunk } from "@dan-uni/dan-any/core";
+
+export const MyPluginConfigurator = () =>
+  definePlugin(async <T extends BaseUniChunk>(chunk: T): Promise<T> => {
+    const out = (await BaseUniChunk.makeChunk(chunk, { tmp: true })) as T;
+    await out.upsertDanmakus(await chunk.$danmakus, false);
+    return out;
+  });
+```
+
+自行实现后端时，实现 `base.UniDB`、`base.InitedUniDB`、`base.UniChunk`，并参考 `src/core/main-pure.ts` 与 `src/core/main-drizzle.ts`。`import`、`plugin` 等方法需要把抽象基类返回值转换为当前实现类，以保持插件系统类型兼容。
+
+## 模块入口
+
+- `@dan-uni/dan-any`：聚合导出 `core`、`adapters`、`plugins`、`utils` 命名空间。
+- `@dan-uni/dan-any/adapters`：Adapter、Transformer、Metadata 与定义工具。
+- `@dan-uni/dan-any/core`：抽象核心类、核心类型、基础数据类型、`main` 聚合。
+- `@dan-uni/dan-any/core/main/drizzle`：drizzle + PGLite 具体实现。
+- `@dan-uni/dan-any/core/main/pure`：纯 TypeScript 具体实现。
+- `@dan-uni/dan-any/plugins`：内置插件与统计 Transformer。
+- `@dan-uni/dan-any/utils`：`WildcardAdapterUtil`、`isSame`、`compress`、`decompress` 等工具。
+- `@dan-uni/dan-any/core/db/schema`：drizzle schema。
+- `@dan-uni/dan-any/core/db/utils`：数据库初始化、迁移、dump 工具。
+
+## 源码维护约束
+
+- 在运行时源码中，只有 `src/core/db/**` 和 `src/core/main-drizzle.ts` 可以导入或引用 `@electric-sql/pglite`、`@electric-sql/pglite-tools`、`drizzle-orm/**`。
+- 不要在 `src/core/index.ts`、`src/core/main.ts`、包根入口或 pure 后端中导出、聚合或类型引用 drizzle/PGLite 后端实现。
+- 需要共享给 pure 后端或公共入口的类型必须放在不依赖 drizzle/PGLite 的抽象层中，避免让 tree-shake 无法移除 PGLite 和 drizzle。
+
+## 常见回复模板
+
+- “如何把 Bilibili XML 转 DanUni JSON？”
+  - 选择 `core/main/drizzle` 或 `core/main/pure`；`udb.import(BiliXmlAdapter(xml))`；`chunk.export(DanuniJsonTransformerConfigurator({ minify: true }))`；最后 `udb.close()`。
+- “Edge/Service Worker 里能用吗？”
+  - 避免 PGLite 后端，使用 `@dan-uni/dan-any/core/main/pure`。
+- “如何去重/合并重复弹幕？”
+  - 使用 `MergePluginConfigurator`，例如 `await chunk.plugin(MergePluginConfigurator(10))`。
+- “如何输出 protobuf 并重新导入？”
+  - `await chunk.export(DanuniPbTransformer)`，再 `await udb.import(DanuniPbAdapter(pb))`。
+- “只想拿数量？”
+  - 使用 `await chunk.$count`，不要推荐 `CountTransformer`。
+- “如何自动判断文件格式？”
+  - 使用各 Adapter 的 `Metadata` 加 `WildcardAdapterUtil`。
+
+## 开发与验证
+
+仓库使用 Vite+：
+
+```bash
+vp install
+vp check
+vp test
+vp pack
+```
+
+更多真实用法参考 `tests/index.test.ts`、`tests/index.pure.test.ts`、`tests/plugins.test.ts`、`tests/utils.test.ts`、`tests/db.test.ts`。

--- a/.claude/skills/dan-any
+++ b/.claude/skills/dan-any
@@ -1,0 +1,1 @@
+../../.agents/skills/dan-any

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.1",
     "@ai-sdk/openai-compatible": "^2.0.1",
-    "@dan-uni/dan-any": "^2.2.7",
+    "@dan-uni/dan-any": "^2.3.0",
     "@danmaku-anywhere/danmaku-converter": "workspace:*",
     "@danmaku-anywhere/danmaku-engine": "workspace:*",
     "@danmaku-anywhere/danmaku-provider": "workspace:*",

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.1",
     "@ai-sdk/openai-compatible": "^2.0.1",
+    "@dan-uni/dan-any": "^2.2.7",
     "@danmaku-anywhere/danmaku-converter": "workspace:*",
     "@danmaku-anywhere/danmaku-engine": "workspace:*",
     "@danmaku-anywhere/danmaku-provider": "workspace:*",

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -286,43 +286,48 @@ export class RpcManager {
             throw new Error(`Episode ${episodeId} not found`)
           }
 
-          // Check if episode has a chunk (v5 format)
-          if (!episode.commentsChunkId || episode.commentsChunkId === 0) {
-            // v4 format: migrate to v5 on first access
+          // Check if episode needs lazy migration (commentsChunkId === -1)
+          if (episode.commentsChunkId === -1) {
+            // v4 episode marked for migration: create chunk on first access
             this.logger.info(
-              `Migrating episode ${episodeId} from v4 to v5 format`
+              `Lazy migrating episode ${episodeId} from v4 to v5 format`
             )
 
-            // Check if episode has inline comments (v4)
             const episodeV4 = episode as any
             if (episodeV4.comments && Array.isArray(episodeV4.comments)) {
-              // Migrate: create chunk from inline comments
+              // Create chunk from inline comments
               const udb = await this.uniDBService.getUniDB()
               const chunk = await udb.makeChunk({})
 
               const adapter = V4EpisodeAdapter({
                 comments: episodeV4.comments,
                 commentCount: episodeV4.comments.length,
-              } as any)
+              })
 
               await adapter(udb, chunk)
 
-              // Save chunk and update episode
+              // Save chunk
               const chunkId = await this.chunkService.saveChunk(chunk)
 
-              // Update episode with chunkId and remove inline comments
-              const updatedEpisode = {
-                ...episode,
-                commentsChunkId: chunkId,
-                commentCount: episodeV4.comments.length,
-                schemaVersion: 5,
-              }
-              delete (updatedEpisode as any).comments
+              this.logger.info(
+                `Created chunk ${chunkId} with ${episodeV4.comments.length} comments`
+              )
 
-              await this.danmakuService.update(updatedEpisode as any)
+              // Update episode: set real chunkId and remove comments
+              if (isCustom) {
+                await this.danmakuService.updateCustomFields(episode.id, {
+                  commentsChunkId: chunkId,
+                  comments: undefined,
+                })
+              } else {
+                await this.danmakuService.updateFields(episode.id, {
+                  commentsChunkId: chunkId,
+                  comments: undefined,
+                })
+              }
 
               this.logger.info(
-                `Migrated episode ${episodeId} to v5, chunk ${chunkId}`
+                `Completed lazy migration for episode ${episodeId}`
               )
 
               // Return the migrated UDanmaku[]
@@ -330,14 +335,21 @@ export class RpcManager {
               return danmakus || []
             }
 
-            // No inline comments, return empty
+            // No comments, return empty
             this.logger.warn(
-              `Episode ${episodeId} has no chunk and no inline comments`
+              `Episode ${episodeId} marked for migration but has no comments`
             )
             return []
           }
 
           // v5 format: load UDanmaku[] from chunk
+          if (!episode.commentsChunkId || episode.commentsChunkId === 0) {
+            this.logger.warn(
+              `Episode ${episodeId} has no chunk (should have been migrated)`
+            )
+            return []
+          }
+
           const danmakus = await this.chunkService.getChunkData(
             episode.commentsChunkId
           )

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -1,4 +1,5 @@
 import { DdplayAdapter } from '@dan-uni/dan-any/adapters'
+import type { Episode } from '@danmaku-anywhere/danmaku-converter'
 import {
   getDanmuicuConfig,
   getMaccmsConfig,
@@ -299,12 +300,12 @@ export class RpcManager {
               const udb = await this.uniDBService.getUniDB()
               const chunk = await udb.makeChunk({})
 
-              const adapter = DdplayAdapter({
-                comments: episodeV4.comments,
-                count: episodeV4.comments.length,
-              })
-
-              await adapter(udb, chunk)
+              await chunk.import(
+                DdplayAdapter({
+                  comments: episodeV4.comments,
+                  count: episodeV4.comments.length,
+                })
+              )
 
               // Save chunk
               const chunkId = await this.chunkService.saveChunk(chunk)
@@ -322,8 +323,8 @@ export class RpcManager {
               } else {
                 await this.danmakuService.updateFields(episode.id, {
                   commentsChunkId: chunkId,
-                  // comments: undefined,
-                })
+                  comments: undefined,
+                } as Episode & { comments?: unknown })
               }
 
               this.logger.info(

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -1,4 +1,4 @@
-import { V4EpisodeAdapter } from '@danmaku-anywhere/danmaku-converter'
+import { DdplayAdapter } from '@dan-uni/dan-any/adapters'
 import {
   getDanmuicuConfig,
   getMaccmsConfig,
@@ -299,9 +299,9 @@ export class RpcManager {
               const udb = await this.uniDBService.getUniDB()
               const chunk = await udb.makeChunk({})
 
-              const adapter = V4EpisodeAdapter({
+              const adapter = DdplayAdapter({
                 comments: episodeV4.comments,
-                commentCount: episodeV4.comments.length,
+                count: episodeV4.comments.length,
               })
 
               await adapter(udb, chunk)
@@ -322,7 +322,7 @@ export class RpcManager {
               } else {
                 await this.danmakuService.updateFields(episode.id, {
                   commentsChunkId: chunkId,
-                  comments: undefined,
+                  // comments: undefined,
                 })
               }
 

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -1,7 +1,4 @@
-import {
-  toCommentEntities,
-  V4EpisodeAdapter,
-} from '@danmaku-anywhere/danmaku-converter'
+import { V4EpisodeAdapter } from '@danmaku-anywhere/danmaku-converter'
 import {
   getDanmuicuConfig,
   getMaccmsConfig,
@@ -328,9 +325,9 @@ export class RpcManager {
                 `Migrated episode ${episodeId} to v5, chunk ${chunkId}`
               )
 
-              // Return the migrated comments
+              // Return the migrated UDanmaku[]
               const danmakus = await this.chunkService.getChunkData(chunkId)
-              return danmakus ? toCommentEntities(danmakus) : []
+              return danmakus || []
             }
 
             // No inline comments, return empty
@@ -340,7 +337,7 @@ export class RpcManager {
             return []
           }
 
-          // v5 format: load from chunk
+          // v5 format: load UDanmaku[] from chunk
           const danmakus = await this.chunkService.getChunkData(
             episode.commentsChunkId
           )
@@ -352,7 +349,7 @@ export class RpcManager {
             return []
           }
 
-          return toCommentEntities(danmakus)
+          return danmakus
         },
         episodeFilterCustom: async (filter) => {
           return this.danmakuService.filterCustom(filter)

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -1,4 +1,8 @@
 import {
+  toCommentEntities,
+  V4EpisodeAdapter,
+} from '@danmaku-anywhere/danmaku-converter'
+import {
   getDanmuicuConfig,
   getMaccmsConfig,
 } from '@danmaku-anywhere/danmaku-provider/config'
@@ -16,12 +20,14 @@ import { KazumiService } from '@/background/services/KazumiService'
 import { LogService } from '@/background/services/Logging/Log.service'
 import { OcclusionModelService } from '@/background/services/OcclusionModelService'
 import { BookmarkService } from '@/background/services/persistence/BookmarkService'
+import { ChunkService } from '@/background/services/persistence/ChunkService'
 import { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import { SeasonService } from '@/background/services/persistence/SeasonService'
 import { TitleMappingService } from '@/background/services/persistence/TitleMappingService'
 import { MacCmsProviderService } from '@/background/services/providers/MacCmsProviderService'
 import { ManifestRegistry } from '@/background/services/providers/ManifestRegistry'
 import { ManifestSandbox } from '@/background/services/providers/ManifestSandbox'
+import { UniDBService } from '@/background/services/UniDBService'
 import { invalidateContentScriptData } from '@/background/utils/invalidateContentScriptData'
 import { AuthClientService } from '@/common/auth/AuthClientService'
 import type { EpisodeFetchBySeasonParams } from '@/common/danmaku/dto'
@@ -84,7 +90,11 @@ export class RpcManager {
     @inject(ManifestRegistry)
     private manifestRegistry: ManifestRegistry,
     @inject(ManifestSandbox)
-    private manifestSandbox: ManifestSandbox
+    private manifestSandbox: ManifestSandbox,
+    @inject(ChunkService)
+    private chunkService: ChunkService,
+    @inject(UniDBService)
+    private uniDBService: UniDBService
   ) {
     this.logger = logger.sub('[RpcManager]')
   }
@@ -254,14 +264,95 @@ export class RpcManager {
           }
         },
         episodeImport: async (data, sender) => {
-          const result = await this.danmakuService.import(data)
+          const result = await this.danmakuService.import(data, {
+            chunkService: this.chunkService,
+            uniDBService: this.uniDBService,
+          })
           void invalidateContentScriptData(sender.tab?.id)
           return result
         },
         episodeDelete: async (filter, sender) => {
-          const result = await this.danmakuService.delete(filter)
+          const result = await this.danmakuService.delete(
+            filter,
+            this.chunkService
+          )
           void invalidateContentScriptData(sender.tab?.id)
           return result
+        },
+        episodeGetComments: async ({ episodeId, isCustom }) => {
+          // Load episode from database
+          const episode = isCustom
+            ? await this.danmakuService.getCustom(episodeId)
+            : await this.danmakuService.get(episodeId)
+
+          if (!episode) {
+            throw new Error(`Episode ${episodeId} not found`)
+          }
+
+          // Check if episode has a chunk (v5 format)
+          if (!episode.commentsChunkId || episode.commentsChunkId === 0) {
+            // v4 format: migrate to v5 on first access
+            this.logger.info(
+              `Migrating episode ${episodeId} from v4 to v5 format`
+            )
+
+            // Check if episode has inline comments (v4)
+            const episodeV4 = episode as any
+            if (episodeV4.comments && Array.isArray(episodeV4.comments)) {
+              // Migrate: create chunk from inline comments
+              const udb = await this.uniDBService.getUniDB()
+              const chunk = await udb.makeChunk({})
+
+              const adapter = V4EpisodeAdapter({
+                comments: episodeV4.comments,
+                commentCount: episodeV4.comments.length,
+              } as any)
+
+              await adapter(udb, chunk)
+
+              // Save chunk and update episode
+              const chunkId = await this.chunkService.saveChunk(chunk)
+
+              // Update episode with chunkId and remove inline comments
+              const updatedEpisode = {
+                ...episode,
+                commentsChunkId: chunkId,
+                commentCount: episodeV4.comments.length,
+                schemaVersion: 5,
+              }
+              delete (updatedEpisode as any).comments
+
+              await this.danmakuService.update(updatedEpisode as any)
+
+              this.logger.info(
+                `Migrated episode ${episodeId} to v5, chunk ${chunkId}`
+              )
+
+              // Return the migrated comments
+              const danmakus = await this.chunkService.getChunkData(chunkId)
+              return danmakus ? toCommentEntities(danmakus) : []
+            }
+
+            // No inline comments, return empty
+            this.logger.warn(
+              `Episode ${episodeId} has no chunk and no inline comments`
+            )
+            return []
+          }
+
+          // v5 format: load from chunk
+          const danmakus = await this.chunkService.getChunkData(
+            episode.commentsChunkId
+          )
+
+          if (!danmakus) {
+            this.logger.warn(
+              `Chunk ${episode.commentsChunkId} not found for episode ${episodeId}`
+            )
+            return []
+          }
+
+          return toCommentEntities(danmakus)
         },
         episodeFilterCustom: async (filter) => {
           return this.danmakuService.filterCustom(filter)
@@ -270,7 +361,10 @@ export class RpcManager {
           return this.danmakuService.filterCustomLite(filter)
         },
         episodeDeleteCustom: async (filter, sender) => {
-          const result = await this.danmakuService.deleteCustom(filter)
+          const result = await this.danmakuService.deleteCustom(
+            filter,
+            this.chunkService
+          )
           void invalidateContentScriptData(sender.tab?.id)
           return result
         },

--- a/packages/danmaku-anywhere/src/background/services/UniDBService.ts
+++ b/packages/danmaku-anywhere/src/background/services/UniDBService.ts
@@ -2,35 +2,52 @@ import type { InitedUniDB } from '@dan-uni/dan-any/core'
 import { UniDB } from '@dan-uni/dan-any/core/main/pure'
 import { injectable } from 'inversify'
 
+/**
+ * UniDBService manages a singleton UniDB instance for the extension.
+ *
+ * Uses pure-mode (in-memory) UniDB since we're in a browser extension
+ * Service Worker environment where PGLite doesn't work.
+ *
+ * The UniDB instance is persisted across the service lifecycle and
+ * can be serialized/deserialized for backup/restore functionality.
+ */
 @injectable('Singleton')
 export class UniDBService {
   private udb: InitedUniDB | null = null
-  private initPromise: Promise<InitedUniDB> | null = null
 
   async getUniDB(): Promise<InitedUniDB> {
     if (this.udb) {
       return this.udb
     }
 
-    if (this.initPromise) {
-      return this.initPromise
-    }
-
-    this.initPromise = this.initialize()
-    return this.initPromise
-  }
-
-  private async initialize(): Promise<InitedUniDB> {
+    // init() is synchronous in pure mode
     const udb = new UniDB()
     this.udb = udb.init()
     return this.udb
   }
 
+  /**
+   * Serialize the UniDB to JSON for backup
+   */
+  async serialize(): Promise<unknown> {
+    if (!this.udb) {
+      throw new Error('UniDB not initialized')
+    }
+    return this.udb.dump()
+  }
+
+  /**
+   * Deserialize and restore UniDB from JSON
+   */
+  async deserialize(data: unknown): Promise<void> {
+    const udb = new UniDB()
+    this.udb = udb.init(data as any)
+  }
+
   async close(): Promise<void> {
     if (this.udb) {
-      await this.udb.close()
+      this.udb.close()
       this.udb = null
-      this.initPromise = null
     }
   }
 }

--- a/packages/danmaku-anywhere/src/background/services/UniDBService.ts
+++ b/packages/danmaku-anywhere/src/background/services/UniDBService.ts
@@ -1,0 +1,36 @@
+import type { InitedUniDB } from '@dan-uni/dan-any/core'
+import { UniDB } from '@dan-uni/dan-any/core/main/pure'
+import { injectable } from 'inversify'
+
+@injectable('Singleton')
+export class UniDBService {
+  private udb: InitedUniDB | null = null
+  private initPromise: Promise<InitedUniDB> | null = null
+
+  async getUniDB(): Promise<InitedUniDB> {
+    if (this.udb) {
+      return this.udb
+    }
+
+    if (this.initPromise) {
+      return this.initPromise
+    }
+
+    this.initPromise = this.initialize()
+    return this.initPromise
+  }
+
+  private async initialize(): Promise<InitedUniDB> {
+    const udb = new UniDB()
+    this.udb = udb.init()
+    return this.udb
+  }
+
+  async close(): Promise<void> {
+    if (this.udb) {
+      await this.udb.close()
+      this.udb = null
+      this.initPromise = null
+    }
+  }
+}

--- a/packages/danmaku-anywhere/src/background/services/persistence/ChunkService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/ChunkService.ts
@@ -1,0 +1,138 @@
+import type { UniChunk } from '@dan-uni/dan-any/core'
+import {
+  toCommentEntities,
+  V4EpisodeAdapter,
+} from '@danmaku-anywhere/danmaku-converter'
+import { inject, injectable } from 'inversify'
+import { UniDBService } from '@/background/services/UniDBService'
+import type { StoredChunk } from '@/common/db/db'
+import { DanmakuAnywhereDb } from '@/common/db/db'
+import { type ILogger, LoggerSymbol } from '@/common/Logger'
+import { invariant, isServiceWorker } from '@/common/utils/utils'
+
+/**
+ * ChunkService manages the storage and retrieval of UniChunk data.
+ *
+ * Chunks are stored by saving UDanmaku arrays in IndexedDB.
+ * When loading, we recreate the chunk and import the data.
+ */
+@injectable('Singleton')
+export class ChunkService {
+  private logger: ILogger
+
+  constructor(
+    @inject(DanmakuAnywhereDb) private db: DanmakuAnywhereDb,
+    @inject(UniDBService) private uniDBService: UniDBService,
+    @inject(LoggerSymbol) logger: ILogger
+  ) {
+    invariant(
+      isServiceWorker(),
+      'ChunkService is only available in service worker'
+    )
+    this.logger = logger.sub('[ChunkService]')
+  }
+
+  /**
+   * Store a UniChunk and return its ID
+   */
+  async saveChunk(chunk: UniChunk): Promise<number> {
+    const now = Date.now()
+
+    // Get all danmakus from the chunk (UDanmaku[])
+    const danmakus = await chunk.$danmakus
+
+    const chunkRecord: Omit<StoredChunk, 'id'> = {
+      data: danmakus, // Store UDanmaku array directly
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const id = await this.db.chunks.add(chunkRecord)
+    this.logger.debug('Saved chunk', id, 'with', danmakus.length, 'danmakus')
+    return id
+  }
+
+  /**
+   * Load a UniChunk by ID
+   */
+  async loadChunk(chunkId: number): Promise<UniChunk | null> {
+    const record = await this.db.chunks.get(chunkId)
+
+    if (!record) {
+      this.logger.warn('Chunk not found', chunkId)
+      return null
+    }
+
+    if (!Array.isArray(record.data) || record.data.length === 0) {
+      this.logger.warn('Chunk has no data', chunkId)
+      const udb = await this.uniDBService.getUniDB()
+      return udb.makeChunk({})
+    }
+
+    // Convert UDanmaku[] to CommentEntity[] for adapter
+    const comments = toCommentEntities(record.data)
+
+    // Use V4EpisodeAdapter to import
+    const udb = await this.uniDBService.getUniDB()
+
+    const adapter = V4EpisodeAdapter({
+      comments,
+      commentCount: comments.length,
+    } as any)
+
+    // adapter returns a function that creates and populates a chunk
+    const chunk = await adapter(udb)
+
+    this.logger.debug(
+      'Loaded chunk',
+      chunkId,
+      'with',
+      record.data.length,
+      'danmakus'
+    )
+    return chunk
+  }
+
+  /**
+   * Update an existing chunk
+   */
+  async updateChunk(chunkId: number, chunk: UniChunk): Promise<void> {
+    const danmakus = await chunk.$danmakus
+
+    await this.db.chunks.update(chunkId, {
+      data: danmakus,
+      updatedAt: Date.now(),
+    })
+
+    this.logger.debug('Updated chunk', chunkId)
+  }
+
+  /**
+   * Delete a chunk
+   */
+  async deleteChunk(chunkId: number): Promise<void> {
+    await this.db.chunks.delete(chunkId)
+    this.logger.debug('Deleted chunk', chunkId)
+  }
+
+  /**
+   * Get chunk count for statistics
+   */
+  async getChunkCount(): Promise<number> {
+    return this.db.chunks.count()
+  }
+
+  /**
+   * Get chunk data directly without loading into UniChunk
+   * Used for RPC to avoid `document is not defined` errors in service worker
+   */
+  async getChunkData(chunkId: number) {
+    const record = await this.db.chunks.get(chunkId)
+
+    if (!record || !Array.isArray(record.data)) {
+      return null
+    }
+
+    return record.data
+  }
+}

--- a/packages/danmaku-anywhere/src/background/services/persistence/ChunkService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/ChunkService.ts
@@ -1,10 +1,5 @@
 import type { UniChunk } from '@dan-uni/dan-any/core'
-import {
-  toCommentEntities,
-  V4EpisodeAdapter,
-} from '@danmaku-anywhere/danmaku-converter'
 import { inject, injectable } from 'inversify'
-import { UniDBService } from '@/background/services/UniDBService'
 import type { StoredChunk } from '@/common/db/db'
 import { DanmakuAnywhereDb } from '@/common/db/db'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
@@ -22,7 +17,6 @@ export class ChunkService {
 
   constructor(
     @inject(DanmakuAnywhereDb) private db: DanmakuAnywhereDb,
-    @inject(UniDBService) private uniDBService: UniDBService,
     @inject(LoggerSymbol) logger: ILogger
   ) {
     invariant(
@@ -50,47 +44,6 @@ export class ChunkService {
     const id = await this.db.chunks.add(chunkRecord)
     this.logger.debug('Saved chunk', id, 'with', danmakus.length, 'danmakus')
     return id
-  }
-
-  /**
-   * Load a UniChunk by ID
-   */
-  async loadChunk(chunkId: number): Promise<UniChunk | null> {
-    const record = await this.db.chunks.get(chunkId)
-
-    if (!record) {
-      this.logger.warn('Chunk not found', chunkId)
-      return null
-    }
-
-    if (!Array.isArray(record.data) || record.data.length === 0) {
-      this.logger.warn('Chunk has no data', chunkId)
-      const udb = await this.uniDBService.getUniDB()
-      return udb.makeChunk({})
-    }
-
-    // Convert UDanmaku[] to CommentEntity[] for adapter
-    const comments = toCommentEntities(record.data)
-
-    // Use V4EpisodeAdapter to import
-    const udb = await this.uniDBService.getUniDB()
-
-    const adapter = V4EpisodeAdapter({
-      comments,
-      commentCount: comments.length,
-    } as any)
-
-    // adapter returns a function that creates and populates a chunk
-    const chunk = await adapter(udb)
-
-    this.logger.debug(
-      'Loaded chunk',
-      chunkId,
-      'with',
-      record.data.length,
-      'danmakus'
-    )
-    return chunk
   }
 
   /**

--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -1,3 +1,4 @@
+import type { UDanmaku } from '@dan-uni/dan-any/core'
 import {
   type BackupParseResult,
   type CommentEntity,
@@ -14,7 +15,9 @@ import {
   zCombinedDanmaku,
 } from '@danmaku-anywhere/danmaku-converter'
 import { inject, injectable } from 'inversify'
+import type { ChunkService } from '@/background/services/persistence/ChunkService'
 import { SeasonService } from '@/background/services/persistence/SeasonService'
+import type { UniDBService } from '@/background/services/UniDBService'
 import type {
   CustomEpisodeQueryFilter,
   DanmakuImportData,
@@ -45,6 +48,14 @@ export class DanmakuService {
     this.logger = logger.sub('[DanmakuService]')
   }
 
+  async get(id: number): Promise<Episode | undefined> {
+    return this.db.episode.get(id)
+  }
+
+  async getCustom(id: number): Promise<CustomEpisode | undefined> {
+    return this.db.customEpisode.get(id)
+  }
+
   async addCustom(data: CustomEpisodeInsert): Promise<CustomEpisode> {
     const toAdd = {
       ...data,
@@ -63,10 +74,47 @@ export class DanmakuService {
     title: string
     comments: CommentEntity[]
   }): Promise<CustomEpisode> {
+    // V5: Must create chunk, no longer store comments array
+    // This is a temporary bridge for backward compatibility
+    throw new Error(
+      'importCustom is deprecated. Use importCustomFromChunk instead.'
+    )
+  }
+
+  async importCustomFromChunk(
+    importData: {
+      title: string
+      danmakus: Record<string, unknown>[]
+    },
+    deps: {
+      chunkService: ChunkService
+      uniDBService: UniDBService
+    }
+  ): Promise<CustomEpisode> {
+    // Deserialize danmakus: convert ISO date strings back to Date objects
+    const deserializedDanmakus: UDanmaku[] = importData.danmakus.map((d) => ({
+      ...d,
+      ctime:
+        typeof d.ctime === 'string' ? new Date(d.ctime) : (d.ctime as Date),
+    })) as UDanmaku[]
+
+    // Create a UniChunk and populate it with the danmakus
+    const udb = await deps.uniDBService.getUniDB()
+    const chunk = await udb.makeChunk({})
+
+    // Import danmakus into chunk
+    if (deserializedDanmakus.length > 0) {
+      await chunk.upsertDanmakus(deserializedDanmakus)
+    }
+
+    // Save chunk and get ID
+    const chunkId = await deps.chunkService.saveChunk(chunk)
+
+    // V5: Only store chunkId, no comments array
     return this.addCustom({
       provider: DanmakuSourceType.MacCMS,
-      comments: importData.comments,
-      commentCount: importData.comments.length,
+      commentsChunkId: chunkId,
+      commentCount: deserializedDanmakus.length,
       title: importData.title,
       schemaVersion: EPISODE_SCHEMA_VERSION,
     })
@@ -88,11 +136,8 @@ export class DanmakuService {
   async filterCustomLite(
     filter: CustomEpisodeQueryFilter
   ): Promise<CustomEpisodeLite[]> {
-    const episodes = await this.filterCustom(filter)
-    return episodes.map((episode) => {
-      const { comments: _, ...rest } = episode
-      return rest
-    })
+    // V5: CustomEpisodeLite and CustomEpisode are the same (no comments field to remove)
+    return this.filterCustom(filter)
   }
 
   async getCustomByTitle(title: string): Promise<CustomEpisode | undefined> {
@@ -117,16 +162,32 @@ export class DanmakuService {
     return customEpisodes[0]
   }
 
-  async deleteCustom(filter: CustomEpisodeQueryFilter) {
+  async deleteCustom(
+    filter: CustomEpisodeQueryFilter,
+    chunkService?: ChunkService
+  ) {
+    // Get chunkIds before deletion
+    let chunkIds: number[] = []
+    if (chunkService) {
+      const episodes = await this.filterCustom(filter)
+      chunkIds = episodes
+        .map((e) => e.commentsChunkId)
+        .filter((id): id is number => id != null && id !== 0)
+    }
+
+    // Delete episodes
     if (filter.all) {
       await this.db.customEpisode.clear()
-      return
-    }
-    if (filter.ids) {
+    } else if (filter.ids) {
       await this.db.customEpisode.bulkDelete(filter.ids)
-      return
+    } else {
+      await this.db.customEpisode.where(filter).delete()
     }
-    await this.db.customEpisode.where(filter).delete()
+
+    // Delete associated chunks
+    if (chunkService && chunkIds.length > 0) {
+      await Promise.all(chunkIds.map((id) => chunkService.deleteChunk(id)))
+    }
   }
 
   async bulkUpsert(data: EpisodeInsert[]): Promise<Episode[]> {
@@ -235,12 +296,8 @@ export class DanmakuService {
   async filterLite(
     filter: EpisodeQueryFilter
   ): Promise<WithSeason<EpisodeLite>[]> {
-    const res = await this.filter(filter)
-
-    return res.map((item) => {
-      const { comments: _, ...rest } = item
-      return rest
-    })
+    // V5: EpisodeLite and Episode are the same (no comments field to remove)
+    return this.filter(filter) as Promise<WithSeason<EpisodeLite>[]>
   }
 
   async filter(filter: EpisodeQueryFilter): Promise<WithSeason<Episode>[]> {
@@ -261,146 +318,148 @@ export class DanmakuService {
     )
   }
 
-  async delete(filter: EpisodeQueryFilter) {
+  async delete(filter: EpisodeQueryFilter, chunkService?: ChunkService) {
     if (filter.all) {
       // don't delete everything at once
       return
     }
+
+    // Get chunkIds before deletion
+    let chunkIds: number[] = []
+    if (chunkService) {
+      const episodes = await this.filter(filter)
+      chunkIds = episodes
+        .map((e) => e.commentsChunkId)
+        .filter((id): id is number => id != null && id !== 0)
+    }
+
+    // Delete episodes
     if (filter.ids) {
       await this.db.episode.bulkDelete(filter.ids)
-      return
+    } else {
+      await this.db.episode.where(filter).delete()
     }
-    await this.db.episode.where(filter).delete()
+
+    // Delete associated chunks
+    if (chunkService && chunkIds.length > 0) {
+      await Promise.all(chunkIds.map((id) => chunkService.deleteChunk(id)))
+    }
   }
 
-  async import(importData: DanmakuImportData[]): Promise<DanmakuImportResult> {
+  async import(
+    importData: DanmakuImportData[],
+    deps: {
+      chunkService: ChunkService
+      uniDBService: UniDBService
+    }
+  ): Promise<DanmakuImportResult> {
     const results: DanmakuImportResult = {
       success: [],
       error: [],
     }
 
-    const importBackup = async (data: BackupParseResult) => {
-      let skipped = data.skipped.length
-      const imported = []
-
-      for (const [i, item] of data.parsed) {
-        try {
-          if (item.type === 'Custom') {
-            await this.addCustom(item.episode)
-            results.success.push({
-              title: item.episode.title,
-              type: 'Custom',
-            })
-          } else {
-            let savedSeasonId = -1
-            let savedSeasonTitle = ''
-            await this.db.transaction(
-              'rw',
-              this.db.season,
-              this.db.episode,
-              async () => {
-                let [existingSeason] = await this.seasonService.filter({
-                  providerConfigId: item.season.providerConfigId,
-                  indexedId: item.season.indexedId,
-                })
-                if (!existingSeason) {
-                  existingSeason = await this.seasonService.upsert(item.season)
-                }
-                savedSeasonId = existingSeason.id
-                savedSeasonTitle = existingSeason.title
-
-                await this.upsert({
-                  ...item.episode,
-                  seasonId: existingSeason.id,
-                })
-              }
-            )
-            imported.push({
-              type: item.season.provider,
-              title: item.episode.title,
-              seasonId: savedSeasonId,
-              seasonTitle: savedSeasonTitle,
-            })
-          }
-        } catch (e) {
-          this.logger.error(`Failed to import backup item ${i}`, e)
-          skipped += 1
-        }
-      }
-
-      const grouped = Object.groupBy(
-        imported,
-        (item) => item.seasonTitle
-      ) as Record<
-        string,
-        {
-          type: DanmakuSourceType
-          title: string
-          seasonId: number
-          seasonTitle: string
-        }[]
-      >
-
-      return {
-        skipped,
-        imported: grouped,
-      }
+    const _importBackup = async (data: BackupParseResult) => {
+      // V5 migration: Backup import needs complete refactoring to support chunks
+      // TODO: Convert backup episodes (v4 format with comments array) to v5 (chunks)
+      throw new Error(
+        'Backup import is temporarily disabled during v5 migration. ' +
+          'Please use file import instead (.xml, .bin, .json files).'
+      )
     }
 
-    for (const { title, data } of importData) {
+    for (const item of importData) {
       const [, err] = await tryCatch(async () => {
-        // aggregate errors
-        const errors: unknown[] = []
-
-        // 1. parse as custom
-        const customParse = zCombinedDanmaku.safeParse(data)
-
-        if (customParse.success) {
-          await this.importCustom({
-            comments: customParse.data,
-            title,
-          })
+        // New format: danmakus are already parsed as UDanmaku[]
+        if ('danmakus' in item && Array.isArray(item.danmakus)) {
+          await this.importCustomFromChunk(
+            {
+              title: item.title,
+              danmakus: item.danmakus,
+            },
+            deps
+          )
           results.success.push({
-            title,
+            title: item.title,
             type: 'Custom',
           })
           return
         }
-        errors.push(customParse.error)
 
-        // 2. parse as backup
-        const backupParseResult = parseBackupMany(
-          Array.isArray(data) ? data : [data]
-        )
+        // Fallback: old format with 'data' field (for backward compatibility during transition)
+        if ('data' in item) {
+          const { title, data } = item as any
+          const errors: unknown[] = []
 
-        if (backupParseResult.parsed.length > 0) {
-          const importResult = await importBackup(backupParseResult)
+          // 1. parse as custom (old format with comments array)
+          const customParse = zCombinedDanmaku.safeParse(data)
 
-          if (
-            Object.keys(importResult.imported).length > 0 ||
-            importResult.skipped > 0
-          ) {
+          if (customParse.success) {
+            // Convert CommentEntity[] to UDanmaku[] using V4EpisodeAdapter
+            const { V4EpisodeAdapter } = await import(
+              '@danmaku-anywhere/danmaku-converter'
+            )
+            const udb = await deps.uniDBService.getUniDB()
+            const chunk = await udb.makeChunk({})
+
+            const adapter = V4EpisodeAdapter({
+              comments: customParse.data,
+              commentCount: customParse.data.length,
+            } as any)
+
+            await adapter(udb, chunk)
+            const danmakus = await chunk.$danmakus
+
+            // Serialize for RPC-like structure
+            const serialized = danmakus.map((d: any) => ({
+              ...d,
+              ctime: d.ctime instanceof Date ? d.ctime.toISOString() : d.ctime,
+            }))
+
+            await this.importCustomFromChunk(
+              {
+                title,
+                danmakus: serialized,
+              },
+              deps
+            )
+
             results.success.push({
               title,
-              type: 'Backup',
-              result: importResult,
+              type: 'Custom',
             })
+            return
           }
+          errors.push(customParse.error)
+
+          // 2. parse as backup
+          const backupParseResult = parseBackupMany(
+            Array.isArray(data) ? data : [data]
+          )
+
+          if (backupParseResult.parsed.length > 0) {
+            // V5: Backup import temporarily disabled
+            results.error.push({
+              title,
+              message:
+                'Backup import is temporarily disabled during v5 migration. ' +
+                'Please use file import instead (.xml, .bin, .json files).',
+            })
+            return
+          }
+
+          // 3. unable to import, return aggregated errors
+          errors.push(backupParseResult.skipped)
+
+          results.error.push({
+            title,
+            message: JSON.stringify(errors, null, 2),
+          })
           return
         }
-
-        // 3. unable to import, return aggregated errors
-        errors.push(backupParseResult.skipped)
-
-        results.error.push({
-          title,
-          message: JSON.stringify(errors, null, 2),
-        })
-        return
       })
       if (err) {
         results.error.push({
-          title,
+          title: item.title,
           message: err.message,
         })
       }

--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -267,6 +267,20 @@ export class DanmakuService {
     return toUpdate
   }
 
+  async updateFields(
+    id: number,
+    fields: Record<string, unknown>
+  ): Promise<void> {
+    await this.db.episode.update(id, fields)
+  }
+
+  async updateCustomFields(
+    id: number,
+    fields: Record<string, unknown>
+  ): Promise<void> {
+    await this.db.customEpisode.update(id, fields)
+  }
+
   // Filtering by seasonId — the common path — returns N episodes that
   // share one season, so a per-episode lookup reads the same row N times.
   private async joinSeasons<T extends EpisodeLite>(

--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -173,7 +173,7 @@ export class DanmakuService {
       const episodes = await this.filterCustom(filter)
       chunkIds = episodes
         .map((e) => e.commentsChunkId)
-        .filter((id): id is number => id != null && id !== 0)
+        .filter((id): id is number => id != null && id > 0)
     }
 
     // Delete episodes
@@ -347,7 +347,7 @@ export class DanmakuService {
       const episodes = await this.filter(filter)
       chunkIds = episodes
         .map((e) => e.commentsChunkId)
-        .filter((id): id is number => id != null && id !== 0)
+        .filter((id): id is number => id != null && id > 0)
     }
 
     // Delete episodes
@@ -404,7 +404,7 @@ export class DanmakuService {
 
         // Fallback: old format with 'data' field (for backward compatibility during transition)
         if ('data' in item) {
-          const { title, data } = item as any
+          const { title, data } = item
           const errors: unknown[] = []
 
           // 1. parse as custom (old format with comments array)
@@ -414,12 +414,12 @@ export class DanmakuService {
             const udb = await deps.uniDBService.getUniDB()
             const chunk = await udb.makeChunk({})
 
-            const adapter = DdplayAdapter({
-              comments: customParse.data,
-              count: customParse.data.length,
-            } as any)
-
-            await adapter(udb, chunk)
+            await chunk.import(
+              DdplayAdapter({
+                comments: customParse.data,
+                count: customParse.data.length,
+              })
+            )
             const danmakus = await chunk.$danmakus
 
             // Serialize for RPC-like structure

--- a/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
+++ b/packages/danmaku-anywhere/src/background/services/persistence/DanmakuService.ts
@@ -1,3 +1,4 @@
+import { DdplayAdapter } from '@dan-uni/dan-any/adapters'
 import type { UDanmaku } from '@dan-uni/dan-any/core'
 import {
   type BackupParseResult,
@@ -269,7 +270,9 @@ export class DanmakuService {
 
   async updateFields(
     id: number,
-    fields: Record<string, unknown>
+    fields: Partial<
+      Omit<Episode, 'id' | 'seasonId' | 'indexedId' | 'version' | 'timeUpdated'>
+    >
   ): Promise<void> {
     await this.db.episode.update(id, fields)
   }
@@ -408,16 +411,12 @@ export class DanmakuService {
           const customParse = zCombinedDanmaku.safeParse(data)
 
           if (customParse.success) {
-            // Convert CommentEntity[] to UDanmaku[] using V4EpisodeAdapter
-            const { V4EpisodeAdapter } = await import(
-              '@danmaku-anywhere/danmaku-converter'
-            )
             const udb = await deps.uniDBService.getUniDB()
             const chunk = await udb.makeChunk({})
 
-            const adapter = V4EpisodeAdapter({
+            const adapter = DdplayAdapter({
               comments: customParse.data,
-              commentCount: customParse.data.length,
+              count: customParse.data.length,
             } as any)
 
             await adapter(udb, chunk)

--- a/packages/danmaku-anywhere/src/background/services/providers/IDanmakuProvider.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/IDanmakuProvider.ts
@@ -1,6 +1,5 @@
 import type { UniChunk } from '@dan-uni/dan-any/core'
 import type {
-  CommentEntity,
   CustomSeason,
   DanmakuSourceType,
   EpisodeMeta,
@@ -34,10 +33,7 @@ export interface IDanmakuProvider {
     seasonRemoteIds: Season['providerIds']
   ): Promise<OmitSeasonId<EpisodeMeta>[]>
 
-  getDanmaku(
-    uchunk: UniChunk,
-    request: DanmakuFetchByMeta
-  ): Promise<CommentEntity[]>
+  getDanmaku(uchunk: UniChunk, request: DanmakuFetchByMeta): Promise<UniChunk>
 
   findEpisode?(
     season: Season,

--- a/packages/danmaku-anywhere/src/background/services/providers/IDanmakuProvider.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/IDanmakuProvider.ts
@@ -1,3 +1,4 @@
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import type {
   CommentEntity,
   CustomSeason,
@@ -33,7 +34,10 @@ export interface IDanmakuProvider {
     seasonRemoteIds: Season['providerIds']
   ): Promise<OmitSeasonId<EpisodeMeta>[]>
 
-  getDanmaku(request: DanmakuFetchByMeta): Promise<CommentEntity[]>
+  getDanmaku(
+    uchunk: UniChunk,
+    request: DanmakuFetchByMeta
+  ): Promise<CommentEntity[]>
 
   findEpisode?(
     season: Season,

--- a/packages/danmaku-anywhere/src/background/services/providers/MacCmsProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/MacCmsProviderService.ts
@@ -1,3 +1,4 @@
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
   type CommentEntity,
   type CustomSeason,
@@ -128,7 +129,10 @@ export class MacCmsProviderService implements IDanmakuProvider {
     throw new Error('Method not implemented.')
   }
 
-  async getDanmaku(_request: DanmakuFetchByMeta): Promise<CommentEntity[]> {
+  async getDanmaku(
+    _uchunk: UniChunk,
+    _request: DanmakuFetchByMeta
+  ): Promise<CommentEntity[]> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/danmaku-anywhere/src/background/services/providers/MacCmsProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/MacCmsProviderService.ts
@@ -1,6 +1,5 @@
 import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
-  type CommentEntity,
   type CustomSeason,
   type EpisodeMeta,
   LEGACY_MACCMS_ID,
@@ -130,10 +129,14 @@ export class MacCmsProviderService implements IDanmakuProvider {
   }
 
   async getDanmaku(
-    _uchunk: UniChunk,
+    uchunk: UniChunk,
     _request: DanmakuFetchByMeta
-  ): Promise<CommentEntity[]> {
-    throw new Error('Method not implemented.')
+  ): Promise<UniChunk> {
+    // MacCMS doesn't support refetching by meta
+    // Danmaku is fetched directly via fetchDanmakuForUrl
+    throw new Error(
+      'MacCMS getDanmaku not implemented - use fetchDanmakuForUrl'
+    )
   }
 }
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
@@ -16,6 +16,12 @@ import {
 } from './ManifestProviderService'
 import type { ManifestRegistry } from './ManifestRegistry'
 
+async function createTestUniChunk() {
+  const udb = new UniDB()
+  const initedUdb = udb.init()
+  return initedUdb.makeChunk({})
+}
+
 /**
  * Covers ManifestProviderService's host-side responsibilities: applying
  * `stripHtml` + canonical provider fields to search/episodes output and
@@ -225,7 +231,7 @@ describe('ManifestProviderService.getDanmaku', () => {
       meta: {
         season: {} as DanmakuFetchByMeta['meta']['season'],
         provider: DanmakuSourceType.DanDanPlay,
-        providerIds,
+        providerIds: providerIds as any,
         title: 'x',
         indexedId: 'x',
         seasonId: 1,
@@ -248,12 +254,17 @@ describe('ManifestProviderService.getDanmaku', () => {
       silentLogger
     )
 
-    const result = await svc.getDanmaku(
-      new UniDB().init().makeChunk({}),
-      makeRequest({ episodeId: 42 })
-    )
+    const uchunk = await createTestUniChunk()
+    const result = await svc.getDanmaku(uchunk, makeRequest({ episodeId: 42 }))
 
-    expect(result).toBe(raw)
+    // Result should be a UniChunk
+    expect(result).toBeDefined()
+    expect(result).toHaveProperty('$danmakus')
+
+    // Verify the comments were imported
+    const danmakus = await result.$danmakus
+    expect(danmakus.length).toBeGreaterThan(0)
+
     expect(runner.runDanmaku).toHaveBeenCalledWith(
       { episodeId: 42 },
       DANMAKU_RUN_OPTIONS

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.test.ts
@@ -1,3 +1,4 @@
+import { UniDB } from '@dan-uni/dan-any/core/main/pure'
 import {
   type CommentEntity,
   DanmakuSourceType,
@@ -247,7 +248,10 @@ describe('ManifestProviderService.getDanmaku', () => {
       silentLogger
     )
 
-    const result = await svc.getDanmaku(makeRequest({ episodeId: 42 }))
+    const result = await svc.getDanmaku(
+      new UniDB().init().makeChunk({}),
+      makeRequest({ episodeId: 42 })
+    )
 
     expect(result).toBe(raw)
     expect(runner.runDanmaku).toHaveBeenCalledWith(

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
@@ -1,3 +1,4 @@
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
   type CommentEntity,
   EPISODE_SCHEMA_VERSION,
@@ -165,7 +166,10 @@ export class ManifestProviderService implements IDanmakuProvider {
     }))
   }
 
-  async getDanmaku(request: DanmakuFetchByMeta): Promise<CommentEntity[]> {
+  async getDanmaku(
+    uchunk: UniChunk,
+    request: DanmakuFetchByMeta
+  ): Promise<CommentEntity[]> {
     const { meta } = request
     this.logger.debug(
       'Get danmaku via manifest',
@@ -173,12 +177,12 @@ export class ManifestProviderService implements IDanmakuProvider {
       meta.providerIds
     )
     const runner = this.registry.getRunner(this.config.manifestId)
-    // meta.params holds per-episode hints stashed at search/episodes time
-    // (e.g. chConvert/withRelated). providerIds take precedence on key collision.
     const inputs = this.resolveInputs(runner, {
       ...meta.params,
       ...meta.providerIds,
     })
+    // Manifest runner returns CommentEntity[] directly
+    // uchunk is reserved for future use when manifests support UDanmaku
     return runner.runDanmaku<CommentEntity[]>(inputs, DANMAKU_RUN_OPTIONS)
   }
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
@@ -1,3 +1,4 @@
+import { DdplayAdapter } from '@dan-uni/dan-any/adapters'
 import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
   type CommentEntity,
@@ -7,7 +8,6 @@ import {
   type Season,
   type SeasonInsert,
   stripHtml,
-  V4EpisodeAdapter,
   type WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import type { ManifestRunner, RunOptions } from '@mr-quin/dango'
@@ -165,7 +165,7 @@ export class ManifestProviderService implements IDanmakuProvider {
       provider: this.forProvider,
       schemaVersion: EPISODE_SCHEMA_VERSION,
       lastChecked: now,
-    })) as any[]
+    })) as OmitSeasonId<EpisodeMeta>[]
   }
 
   async getDanmaku(
@@ -180,7 +180,7 @@ export class ManifestProviderService implements IDanmakuProvider {
     )
     const runner = this.registry.getRunner(this.config.manifestId)
     const inputs = this.resolveInputs(runner, {
-      ...((meta as any).params ?? {}),
+      ...(meta.params ?? {}),
       ...meta.providerIds,
     })
     // Manifest runner returns CommentEntity[] directly
@@ -191,13 +191,12 @@ export class ManifestProviderService implements IDanmakuProvider {
 
     // Use V4EpisodeAdapter to convert and import CommentEntity[] to UDanmaku
     const tempEpisode = {
-      comments: rawComments,
-      commentCount: rawComments.length,
+      comments: rawComments as (Omit<CommentEntity, 'cid'> & { cid: number })[],
+      count: rawComments.length,
     }
 
-    const adapter = V4EpisodeAdapter(tempEpisode as any)
     // adapter populates the chunk and returns it
-    const populatedChunk = await adapter(uchunk.$UniDB, uchunk)
+    const populatedChunk = uchunk.import(DdplayAdapter(tempEpisode))
 
     return populatedChunk
   }
@@ -248,10 +247,10 @@ export class ManifestProviderService implements IDanmakuProvider {
       episodeMeta: {
         ...result.episodeMeta,
         title: stripHtml(result.episodeMeta.title),
-        provider: this.forProvider,
+        provider: this.forProvider as any,
         schemaVersion: EPISODE_SCHEMA_VERSION,
         lastChecked: now,
-      } as any,
+      } as OmitSeasonId<EpisodeMeta>,
     }
   }
 }

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestProviderService.ts
@@ -7,6 +7,7 @@ import {
   type Season,
   type SeasonInsert,
   stripHtml,
+  V4EpisodeAdapter,
   type WithSeason,
 } from '@danmaku-anywhere/danmaku-converter'
 import type { ManifestRunner, RunOptions } from '@mr-quin/dango'
@@ -157,19 +158,20 @@ export class ManifestProviderService implements IDanmakuProvider {
       MANIFEST_RUN_OPTIONS
     )
     const now = Date.now()
+    // Type assertion: manifestId determines provider type at runtime
     return rows.map((row) => ({
       ...row,
       title: stripHtml(row.title),
       provider: this.forProvider,
       schemaVersion: EPISODE_SCHEMA_VERSION,
       lastChecked: now,
-    }))
+    })) as any[]
   }
 
   async getDanmaku(
     uchunk: UniChunk,
     request: DanmakuFetchByMeta
-  ): Promise<CommentEntity[]> {
+  ): Promise<UniChunk> {
     const { meta } = request
     this.logger.debug(
       'Get danmaku via manifest',
@@ -178,12 +180,26 @@ export class ManifestProviderService implements IDanmakuProvider {
     )
     const runner = this.registry.getRunner(this.config.manifestId)
     const inputs = this.resolveInputs(runner, {
-      ...meta.params,
+      ...((meta as any).params ?? {}),
       ...meta.providerIds,
     })
     // Manifest runner returns CommentEntity[] directly
-    // uchunk is reserved for future use when manifests support UDanmaku
-    return runner.runDanmaku<CommentEntity[]>(inputs, DANMAKU_RUN_OPTIONS)
+    const rawComments = await runner.runDanmaku<CommentEntity[]>(
+      inputs,
+      DANMAKU_RUN_OPTIONS
+    )
+
+    // Use V4EpisodeAdapter to convert and import CommentEntity[] to UDanmaku
+    const tempEpisode = {
+      comments: rawComments,
+      commentCount: rawComments.length,
+    }
+
+    const adapter = V4EpisodeAdapter(tempEpisode as any)
+    // adapter populates the chunk and returns it
+    const populatedChunk = await adapter(uchunk.$UniDB, uchunk)
+
+    return populatedChunk
   }
 
   async findEpisode(
@@ -235,7 +251,7 @@ export class ManifestProviderService implements IDanmakuProvider {
         provider: this.forProvider,
         schemaVersion: EPISODE_SCHEMA_VERSION,
         lastChecked: now,
-      },
+      } as any,
     }
   }
 }

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderFactory.test.ts
@@ -33,7 +33,8 @@ const mockRunner = {
 }
 
 const fakeRegistry = {
-  getRunner: () => mockRunner,
+  ready: Promise.resolve(),
+  getRunner: vi.fn(() => mockRunner),
 } as unknown as ManifestRegistry
 
 vi.mock('./MacCmsProviderService', () => ({

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -1,3 +1,4 @@
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
   DanmakuSourceType,
   type EpisodeMeta,
@@ -9,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BookmarkService } from '@/background/services/persistence/BookmarkService'
 import type { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import type { SeasonService } from '@/background/services/persistence/SeasonService'
+import type { UniDBService } from '@/background/services/UniDBService'
 import type { ILogger } from '@/common/Logger'
 import type { ExtensionOptionsService } from '@/common/options/extensionOptions/service'
 import type { ProviderConfig } from '@/common/options/providerConfig/schema'
@@ -37,6 +39,12 @@ const silentLogger = {
 const silentExtensionOptions = {
   get: async () => ({ lang: 'zh' }),
 } as unknown as ExtensionOptionsService
+
+const mockUniDBService = {
+  getUniDB: vi.fn(async () => ({
+    makeChunk: vi.fn(async () => ({}) as UniChunk),
+  })),
+} as unknown as UniDBService
 
 function makeConfig(manifestId: string): ProviderConfig {
   return {
@@ -106,7 +114,8 @@ function build(
     registry,
     {} as unknown as BookmarkService,
     silentLogger,
-    silentExtensionOptions
+    silentExtensionOptions,
+    mockUniDBService
   )
 
   return { service, provider, danmakuService, seasonService }
@@ -127,7 +136,8 @@ describe('ProviderService.probeLogin', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
 
     await service.probeLogin('dandanplay')
@@ -150,7 +160,8 @@ describe('ProviderService.getManifestSpec', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
   }
 
@@ -209,7 +220,8 @@ describe('ProviderService.getManifestSpec', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
 
     await expect(service.getManifestSpec('missing')).rejects.toThrow()
@@ -408,7 +420,8 @@ describe('ProviderService.refreshCatalog', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
 
     return { service, applyUpdates, recordChecked, getPendingUpdates }
@@ -486,7 +499,8 @@ describe('ProviderService.refreshCatalog', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
 
     await expect(service.refreshCatalog()).rejects.toThrow(
@@ -515,7 +529,8 @@ describe('ProviderService.setup', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
 
     service.setup()
@@ -574,7 +589,8 @@ describe('ProviderService.seedDefaultProviders', () => {
       registry,
       {} as unknown as BookmarkService,
       silentLogger,
-      extensionOptions
+      extensionOptions,
+      mockUniDBService
     )
 
     return { service, set, markSeeded, hasSeeded, listManifests }
@@ -720,7 +736,8 @@ describe('ProviderService.deleteUserManifest', () => {
       registry,
       bookmarkService,
       silentLogger,
-      silentExtensionOptions
+      silentExtensionOptions,
+      mockUniDBService
     )
     return { service, unregister, deleteFromStorage, deleteByProviderConfigId }
   }

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -42,9 +42,23 @@ const silentExtensionOptions = {
 
 const mockUniDBService = {
   getUniDB: vi.fn(async () => ({
-    makeChunk: vi.fn(async () => ({}) as UniChunk),
+    makeChunk: vi.fn(
+      async () =>
+        ({
+          $danmakus: Promise.resolve([]),
+          $db: {},
+        }) as any as UniChunk
+    ),
   })),
 } as unknown as UniDBService
+
+const mockChunkService = {
+  saveChunk: vi.fn(async () => 1),
+  loadChunk: vi.fn(async () => null),
+  updateChunk: vi.fn(async () => {}),
+  deleteChunk: vi.fn(async () => {}),
+  getChunkCount: vi.fn(async () => 0),
+} as unknown as any
 
 function makeConfig(manifestId: string): ProviderConfig {
   return {
@@ -63,7 +77,7 @@ function makeProvider(
     forProvider: DanmakuSourceType.DanDanPlay,
     search: vi.fn(async () => []),
     getEpisodes: vi.fn(async () => []),
-    getDanmaku: vi.fn(async () => []),
+    getDanmaku: vi.fn(async (uchunk: UniChunk) => uchunk),
     ...overrides,
   } as unknown as IDanmakuProvider
 }
@@ -115,7 +129,8 @@ function build(
     {} as unknown as BookmarkService,
     silentLogger,
     silentExtensionOptions,
-    mockUniDBService
+    mockUniDBService,
+    mockChunkService
   )
 
   return { service, provider, danmakuService, seasonService }
@@ -137,7 +152,8 @@ describe('ProviderService.probeLogin', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
 
     await service.probeLogin('dandanplay')
@@ -161,7 +177,8 @@ describe('ProviderService.getManifestSpec', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
   }
 
@@ -221,7 +238,8 @@ describe('ProviderService.getManifestSpec', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
 
     await expect(service.getManifestSpec('missing')).rejects.toThrow()
@@ -326,7 +344,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
     } as unknown as WithSeason<EpisodeMeta>
 
     it('fetches danmaku for a generic source', async () => {
-      const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
+      const provider = makeProvider({
+        getDanmaku: vi.fn(async (uchunk: UniChunk) => uchunk),
+      })
       const { service } = build(makeConfig('iqiyi'), provider)
 
       await service.getDanmaku({ type: 'by-meta', meta, options: {} })
@@ -336,7 +356,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
 
     it('serves cached danmaku without fetching or resolving the config', async () => {
       const cached = { id: 5, comments: [] }
-      const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
+      const provider = makeProvider({
+        getDanmaku: vi.fn(async (uchunk: UniChunk) => uchunk),
+      })
       const { service } = build(makeConfig('iqiyi'), provider, {
         existingDanmaku: [cached],
       })
@@ -366,7 +388,9 @@ describe('ProviderService legacy-maccms decoupling', () => {
     })
 
     it('throws a source-removed error when forcing an orphaned season', async () => {
-      const provider = makeProvider({ getDanmaku: vi.fn(async () => []) })
+      const provider = makeProvider({
+        getDanmaku: vi.fn(async (uchunk: UniChunk) => uchunk),
+      })
       const { service } = build(makeConfig('iqiyi'), provider, {
         configMissing: true,
       })
@@ -421,7 +445,8 @@ describe('ProviderService.refreshCatalog', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
 
     return { service, applyUpdates, recordChecked, getPendingUpdates }
@@ -500,7 +525,8 @@ describe('ProviderService.refreshCatalog', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
 
     await expect(service.refreshCatalog()).rejects.toThrow(
@@ -530,7 +556,8 @@ describe('ProviderService.setup', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
 
     service.setup()
@@ -590,7 +617,8 @@ describe('ProviderService.seedDefaultProviders', () => {
       {} as unknown as BookmarkService,
       silentLogger,
       extensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
 
     return { service, set, markSeeded, hasSeeded, listManifests }
@@ -737,7 +765,8 @@ describe('ProviderService.deleteUserManifest', () => {
       bookmarkService,
       silentLogger,
       silentExtensionOptions,
-      mockUniDBService
+      mockUniDBService,
+      mockChunkService
     )
     return { service, unregister, deleteFromStorage, deleteByProviderConfigId }
   }

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -12,6 +12,7 @@ import { inject, injectable } from 'inversify'
 import { BookmarkService } from '@/background/services/persistence/BookmarkService'
 import { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import { SeasonService } from '@/background/services/persistence/SeasonService'
+import { UniDBService } from '@/background/services/UniDBService'
 import type { SeasonQueryFilter, SeasonSearchRequest } from '@/common/anime/dto'
 import type {
   DanmakuFetchByMeta,
@@ -72,7 +73,9 @@ export class ProviderService {
     private bookmarkService: BookmarkService,
     @inject(LoggerSymbol) logger: ILogger,
     @inject(ExtensionOptionsService)
-    private extensionOptions: ExtensionOptionsService
+    private extensionOptions: ExtensionOptionsService,
+    @inject(UniDBService)
+    private uniDBService: UniDBService
   ) {
     invariant(
       isServiceWorker(),
@@ -219,7 +222,10 @@ export class ProviderService {
 
     const service = this.danmakuProviderFactory(config)
 
-    const comments = await service.getDanmaku(resolved)
+    const udb = await this.uniDBService.getUniDB()
+    const uchunk = await udb.makeChunk({})
+
+    const comments = await service.getDanmaku(uchunk, resolved)
 
     const { season, ...rest } = meta
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -1,6 +1,7 @@
 import type {
   CustomSeason,
   Episode,
+  EpisodeInsert,
   EpisodeMeta,
   Season,
   SeasonInsert,
@@ -10,6 +11,7 @@ import { LEGACY_MACCMS_ID } from '@danmaku-anywhere/danmaku-converter'
 import { getDisplayStrings } from '@mr-quin/dango'
 import { inject, injectable } from 'inversify'
 import { BookmarkService } from '@/background/services/persistence/BookmarkService'
+import { ChunkService } from '@/background/services/persistence/ChunkService'
 import { DanmakuService } from '@/background/services/persistence/DanmakuService'
 import { SeasonService } from '@/background/services/persistence/SeasonService'
 import { UniDBService } from '@/background/services/UniDBService'
@@ -75,7 +77,9 @@ export class ProviderService {
     @inject(ExtensionOptionsService)
     private extensionOptions: ExtensionOptionsService,
     @inject(UniDBService)
-    private uniDBService: UniDBService
+    private uniDBService: UniDBService,
+    @inject(ChunkService)
+    private chunkService: ChunkService
   ) {
     invariant(
       isServiceWorker(),
@@ -183,9 +187,9 @@ export class ProviderService {
     const meta = enrichEpisode(
       {
         ...request.stub,
-        schemaVersion: 4 as const,
+        schemaVersion: 5 as const,
         lastChecked: 0,
-      },
+      } as any,
       season
     )
     return { type: 'by-meta', meta, options: request.options }
@@ -225,16 +229,27 @@ export class ProviderService {
     const udb = await this.uniDBService.getUniDB()
     const uchunk = await udb.makeChunk({})
 
-    const comments = await service.getDanmaku(uchunk, resolved)
+    // Get danmaku as UniChunk
+    const filledChunk = await service.getDanmaku(uchunk, resolved)
 
-    const { season, ...rest } = meta
+    // Save the chunk and get its ID
+    const chunkId = await this.chunkService.saveChunk(filledChunk)
 
-    const saved = await this.danmakuService.upsert({
-      ...rest,
+    // Get comment count
+    const danmakus = await filledChunk.$danmakus
+    const commentCount = danmakus.length
+
+    const { season, ...metaFields } = meta
+
+    // V5: Build EpisodeInsert with all required fields
+    const episodeInsert = {
+      ...metaFields,
       seasonId: season.id,
-      comments,
-      commentCount: comments.length,
-    })
+      commentsChunkId: chunkId,
+      commentCount,
+    } as EpisodeInsert
+
+    const saved = await this.danmakuService.upsert(episodeInsert)
 
     return {
       ...saved,

--- a/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
+++ b/packages/danmaku-anywhere/src/common/components/CommentsTable.tsx
@@ -1,5 +1,8 @@
-import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
-import { parseCommentEntityP } from '@danmaku-anywhere/danmaku-converter'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
+import {
+  parseCommentEntityP,
+  toCommentEntity,
+} from '@danmaku-anywhere/danmaku-converter'
 import {
   compile,
   type Decision,
@@ -34,7 +37,7 @@ import { compareLocale } from '@/common/utils/collator'
 import { ScrollBox } from './layout/ScrollBox'
 
 interface CommentListProps {
-  comments: CommentEntity[]
+  comments: UDanmaku[]
   isTimeClickable?: boolean
   onTimeClick?: (time: number) => void
   onFilterComment?: (comment: string) => void
@@ -145,10 +148,16 @@ export const CommentsTable = ({
   const [hoverRow, setHoverRow] = useState<number>()
   const [filter, setFilter] = useState('')
 
+  // Convert UDanmaku[] to CommentEntity[] for display
+  const commentEntities = useMemo(
+    () => comments.map((udanmaku) => toCommentEntity(udanmaku)),
+    [comments]
+  )
+
   const { validComments, timeOf } = useMemo(() => {
-    const timeByComment = new Map<CommentEntity, number>()
-    const valid: CommentEntity[] = []
-    for (const c of comments) {
+    const timeByComment = new Map<ReturnType<typeof toCommentEntity>, number>()
+    const valid: ReturnType<typeof toCommentEntity>[] = []
+    for (const c of commentEntities) {
       const options = parseCommentEntityP(c.p)
       if (!options) continue
       timeByComment.set(c, options.time)
@@ -156,9 +165,10 @@ export const CommentsTable = ({
     }
     return {
       validComments: valid,
-      timeOf: (c: CommentEntity) => timeByComment.get(c) ?? 0,
+      timeOf: (c: ReturnType<typeof toCommentEntity>) =>
+        timeByComment.get(c) ?? 0,
     }
-  }, [comments])
+  }, [commentEntities])
 
   const { decisionByComment, headLabelByIndex } = useMemo(() => {
     const inTimeOrder = validComments.toSorted((a, b) => timeOf(a) - timeOf(b))
@@ -171,7 +181,10 @@ export const CommentsTable = ({
           STAGE_DURATION_MS / 1000 / Math.max(danmakuOptions.speed, 0.1),
       }
     )
-    const decisionByComment = new Map<CommentEntity, Decision>()
+    const decisionByComment = new Map<
+      ReturnType<typeof toCommentEntity>,
+      Decision
+    >()
     const headLabelByIndex = new Map<number, string>()
     inTimeOrder.forEach((c, i) => {
       decisionByComment.set(c, decisions[i])

--- a/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/DanmakuViewer.tsx
+++ b/packages/danmaku-anywhere/src/common/components/DanmakuSelector/components/DanmakuViewer.tsx
@@ -7,8 +7,8 @@ import { Box, IconButton, Stack, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 import { Suspense } from 'react'
 import { CommentsTable } from '@/common/components/CommentsTable'
-import { NothingHere } from '@/common/components/NothingHere'
 import { useCustomEpisodeSuspense } from '@/common/danmaku/queries/useCustomEpisodes'
+import { useEpisodeComments } from '@/common/danmaku/queries/useEpisodeComments'
 import { useEpisodesSuspense } from '@/common/danmaku/queries/useEpisodes'
 import { isNotCustom } from '@/common/danmaku/utils'
 import { useRefreshDanmaku } from '@/popup/hooks/useRefreshDanmaku'
@@ -38,6 +38,12 @@ const CommentsLoader = ({
     episode = data[0]
   }
 
+  // Load comments separately via RPC
+  const { data: comments = [], isLoading } = useEpisodeComments(
+    episodeLite.id,
+    isCustom
+  )
+
   const canRefresh = episode !== undefined && !isCustom
 
   const handleRefresh = () => {
@@ -47,7 +53,7 @@ const CommentsLoader = ({
     void refreshDanmaku(episodeLite)
   }
 
-  if (!episode) {
+  if (!episode || isLoading) {
     return (
       <Box
         sx={{
@@ -55,14 +61,14 @@ const CommentsLoader = ({
           flexGrow: 1,
         }}
       >
-        <NothingHere />
+        <FullPageSpinner />
       </Box>
     )
   }
 
   return (
     <CommentsTable
-      comments={episode.comments}
+      comments={comments}
       onRefresh={handleRefresh}
       showRefresh={canRefresh}
       isRefreshing={mutation.isPending}

--- a/packages/danmaku-anywhere/src/common/components/ImportPageCore/useDanmakuImport.ts
+++ b/packages/danmaku-anywhere/src/common/components/ImportPageCore/useDanmakuImport.ts
@@ -1,10 +1,11 @@
-import { xmlToJSON } from '@danmaku-anywhere/danmaku-converter'
+import { BiliGrpcAdapter, BiliXmlAdapter } from '@dan-uni/dan-any/adapters'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
 import { useMutation } from '@tanstack/react-query'
-import { decodeBilibiliDanmakuProto } from '@/common/components/ImportPageCore/decodeBilibiliDanmakuProto'
 
 import type { DanmakuImportData } from '@/common/danmaku/dto'
 import { useInvalidateSeasonAndEpisode } from '@/common/hooks/useInvalidateSeasonAndEpisode'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
+import { createUniDB } from '@/common/services/UniDBService'
 
 export const VALID_EXTENSIONS = ['.json', '.xml', '.bin'] as const
 
@@ -20,17 +21,75 @@ function isFileValid(file: File) {
   return (VALID_EXTENSIONS as readonly string[]).includes(getExtension(file))
 }
 
-async function parseFile(file: File): Promise<unknown> {
+/**
+ * Serialize UDanmaku to plain JSON object for RPC transfer.
+ * Chrome message API cannot serialize Date objects, so convert to ISO strings.
+ * Also ensure all fields are JSON-serializable (no undefined, functions, etc.)
+ */
+function serializeUDanmaku(danmaku: UDanmaku): Record<string, unknown> {
+  return {
+    DMID: danmaku.DMID,
+    SOID: danmaku.SOID,
+    attr: danmaku.attr,
+    color: danmaku.color,
+    content: danmaku.content,
+    ctime:
+      danmaku.ctime instanceof Date
+        ? danmaku.ctime.toISOString()
+        : danmaku.ctime,
+    extra: danmaku.extra ? JSON.parse(JSON.stringify(danmaku.extra)) : null,
+    fontsize: danmaku.fontsize,
+    mode: danmaku.mode,
+    platform: danmaku.platform,
+    pool: danmaku.pool,
+    progress: danmaku.progress,
+    senderID: danmaku.senderID,
+    weight: danmaku.weight,
+  }
+}
+
+/**
+ * Parse danmaku file directly to UDanmaku[] using dan-any adapters.
+ * No intermediate JSON format - parse once in the frontend.
+ */
+async function parseFile(file: File): Promise<UDanmaku[]> {
   const ext = getExtension(file)
+  const udb = createUniDB()
+  const chunk = await udb.makeChunk({})
+
   if (ext === '.bin') {
+    // Bilibili protobuf format
     const buffer = await file.arrayBuffer()
-    return decodeBilibiliDanmakuProto(new Uint8Array(buffer))
+    await chunk.import(BiliGrpcAdapter(buffer))
+  } else if (ext === '.xml') {
+    // Bilibili XML format
+    const text = await file.text()
+    await chunk.import(BiliXmlAdapter(text))
+  } else if (ext === '.json') {
+    // JSON format - could be DanDanPlay, Tencent, or custom format
+    // For now, treat as custom format (array of CommentEntity)
+    const text = await file.text()
+    const json = JSON.parse(text)
+
+    // If it's an array of CommentEntity objects, use V4EpisodeAdapter
+    if (Array.isArray(json)) {
+      const { V4EpisodeAdapter } = await import(
+        '@danmaku-anywhere/danmaku-converter'
+      )
+      const adapter = V4EpisodeAdapter({
+        comments: json,
+        commentCount: json.length,
+      } as any)
+      await adapter(udb, chunk)
+    } else {
+      throw new Error('Unsupported JSON format')
+    }
+  } else {
+    throw new Error(`Unsupported file extension: ${ext}`)
   }
-  const text = await file.text()
-  if (ext === '.xml') {
-    return xmlToJSON(text)
-  }
-  return JSON.parse(text)
+
+  // Extract UDanmaku array from chunk
+  return chunk.$danmakus
 }
 
 export const useDanmakuImport = () => {
@@ -40,10 +99,23 @@ export const useDanmakuImport = () => {
     mutationFn: async (files: File[]) => {
       return Promise.all(
         files.filter(isFileValid).map(async (file) => {
-          const data = await parseFile(file)
+          const danmakus = await parseFile(file)
+
+          // Serialize danmakus for RPC transfer (convert Date to ISO string)
+          const serializedDanmakus = danmakus.map(serializeUDanmaku)
+
           return {
             title: file.name,
-            data,
+            danmakus: serializedDanmakus,
+            metadata: {
+              originalFileName: file.name,
+              source:
+                getExtension(file) === '.bin'
+                  ? ('bilibili-grpc' as const)
+                  : getExtension(file) === '.xml'
+                    ? ('bilibili-xml' as const)
+                    : ('custom-json' as const),
+            },
           } satisfies DanmakuImportData
         })
       )

--- a/packages/danmaku-anywhere/src/common/components/ImportPageCore/useDanmakuImport.ts
+++ b/packages/danmaku-anywhere/src/common/components/ImportPageCore/useDanmakuImport.ts
@@ -1,5 +1,31 @@
-import { BiliGrpcAdapter, BiliXmlAdapter } from '@dan-uni/dan-any/adapters'
-import type { UDanmaku } from '@dan-uni/dan-any/core'
+import {
+  type Adapter,
+  ArtplayerAdapter,
+  ArtplayerMetadata,
+  BiliCommandGrpcAdapter,
+  BiliCommandGrpcMetadata,
+  BiliGrpcAdapter,
+  BiliGrpcMetadata,
+  BiliUpAdapter,
+  BiliUpMetadata,
+  BiliXmlAdapter,
+  BiliXmlMetadata,
+  DanuniJsonAdapter,
+  DanuniJsonMetadata,
+  DanuniPbAdapter,
+  DanuniPbMetadata,
+  DdplayAdapter,
+  DdplayMetadata,
+  DplayerAdapter,
+  DplayerMetadata,
+  type Metadata,
+  TencentAdapter,
+  TencentMetadata,
+  VodAdapter,
+  VodMetadata,
+} from '@dan-uni/dan-any/adapters'
+import { type UDanmaku, UniChunk } from '@dan-uni/dan-any/core'
+import { fileParser, WildcardAdapterUtil } from '@dan-uni/dan-any/utils'
 import { useMutation } from '@tanstack/react-query'
 
 import type { DanmakuImportData } from '@/common/danmaku/dto'
@@ -7,7 +33,25 @@ import { useInvalidateSeasonAndEpisode } from '@/common/hooks/useInvalidateSeaso
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { createUniDB } from '@/common/services/UniDBService'
 
-export const VALID_EXTENSIONS = ['.json', '.xml', '.bin'] as const
+// Build handlerList for WildcardAdapterUtil
+const handlerList: [Metadata, Adapter][] = [
+  [BiliXmlMetadata, BiliXmlAdapter],
+  [BiliGrpcMetadata, BiliGrpcAdapter],
+  [BiliCommandGrpcMetadata, BiliCommandGrpcAdapter],
+  [BiliUpMetadata, BiliUpAdapter],
+  [DanuniJsonMetadata, DanuniJsonAdapter],
+  [DanuniPbMetadata, DanuniPbAdapter],
+  [ArtplayerMetadata, ArtplayerAdapter],
+  [DplayerMetadata, DplayerAdapter],
+  [DdplayMetadata, DdplayAdapter],
+  [TencentMetadata, TencentAdapter],
+  [VodMetadata, VodAdapter],
+]
+
+// Support all common danmaku formats
+export const VALID_EXTENSIONS = [
+  ...new Set(handlerList.flatMap(([metadata]) => metadata.ext)),
+]
 
 function getExtension(file: File): string {
   const idx = file.name.lastIndexOf('.')
@@ -18,7 +62,7 @@ function getExtension(file: File): string {
 }
 
 function isFileValid(file: File) {
-  return (VALID_EXTENSIONS as readonly string[]).includes(getExtension(file))
+  return VALID_EXTENSIONS.includes(getExtension(file))
 }
 
 /**
@@ -49,46 +93,35 @@ function serializeUDanmaku(danmaku: UDanmaku): Record<string, unknown> {
 }
 
 /**
- * Parse danmaku file directly to UDanmaku[] using dan-any adapters.
- * No intermediate JSON format - parse once in the frontend.
+ * Parse danmaku file using dan-any WildcardAdapterUtil.
+ * Automatically detects format and uses appropriate adapter.
+ * Supports all formats registered in handlerList.
  */
 async function parseFile(file: File): Promise<UDanmaku[]> {
-  const ext = getExtension(file)
   const udb = createUniDB()
   const chunk = await udb.makeChunk({})
 
-  if (ext === '.bin') {
-    // Bilibili protobuf format
-    const buffer = await file.arrayBuffer()
-    await chunk.import(BiliGrpcAdapter(buffer))
-  } else if (ext === '.xml') {
-    // Bilibili XML format
-    const text = await file.text()
-    await chunk.import(BiliXmlAdapter(text))
-  } else if (ext === '.json') {
-    // JSON format - could be DanDanPlay, Tencent, or custom format
-    // For now, treat as custom format (array of CommentEntity)
-    const text = await file.text()
-    const json = JSON.parse(text)
+  // Use WildcardAdapterUtil to automatically detect and import
+  const result = await WildcardAdapterUtil(chunk, handlerList, file)
 
-    // If it's an array of CommentEntity objects, use V4EpisodeAdapter
-    if (Array.isArray(json)) {
-      const { V4EpisodeAdapter } = await import(
-        '@danmaku-anywhere/danmaku-converter'
-      )
-      const adapter = V4EpisodeAdapter({
-        comments: json,
-        commentCount: json.length,
-      } as any)
-      await adapter(udb, chunk)
-    } else {
-      throw new Error('Unsupported JSON format')
-    }
-  } else {
-    throw new Error(`Unsupported file extension: ${ext}`)
-  }
+  if (result === null)
+    throw new Error(`Unsupported danmaku file format: ${file.name}`)
 
-  // Extract UDanmaku array from chunk
+  if (result instanceof UniChunk) return chunk.$danmakus
+
+  const adapter = result
+  if (adapter === ArtplayerAdapter)
+    chunk.import(ArtplayerAdapter(await fileParser(file, 'json')))
+  else if (adapter === DplayerAdapter)
+    chunk.import(DplayerAdapter(await fileParser(file, 'json')))
+  else if (adapter === DdplayAdapter)
+    chunk.import(DdplayAdapter(await fileParser(file, 'json')))
+  else if (adapter === TencentAdapter)
+    chunk.import(TencentAdapter(await fileParser(file, 'json')))
+  else if (adapter === VodAdapter)
+    chunk.import(VodAdapter(await fileParser(file, 'json')))
+  else throw new Error(`Unsupported danmaku adapter: ${adapter.name}`)
+
   return chunk.$danmakus
 }
 
@@ -109,12 +142,7 @@ export const useDanmakuImport = () => {
             danmakus: serializedDanmakus,
             metadata: {
               originalFileName: file.name,
-              source:
-                getExtension(file) === '.bin'
-                  ? ('bilibili-grpc' as const)
-                  : getExtension(file) === '.xml'
-                    ? ('bilibili-xml' as const)
-                    : ('custom-json' as const),
+              source: 'auto-detected' as const, // wildcardAdapterUtil auto-detects
             },
           } satisfies DanmakuImportData
         })

--- a/packages/danmaku-anywhere/src/common/danmaku/dto.ts
+++ b/packages/danmaku-anywhere/src/common/danmaku/dto.ts
@@ -52,7 +52,13 @@ export type DanmakuImportData = {
   danmakus: Record<string, unknown>[] // Serialized UDanmaku (Date → ISO string)
   metadata?: {
     originalFileName: string
-    source: 'bilibili-xml' | 'bilibili-grpc' | 'dandanplay' | 'custom-json'
+    source:
+      | 'auto-detected' // wildcardAdapterUtil auto-detects format
+      | 'bilibili-xml'
+      | 'bilibili-grpc'
+      | 'dandanplay'
+      | 'danuni-json'
+      | 'custom-json'
   }
 }
 

--- a/packages/danmaku-anywhere/src/common/danmaku/dto.ts
+++ b/packages/danmaku-anywhere/src/common/danmaku/dto.ts
@@ -49,7 +49,11 @@ export type DanmakuFetchDto = DanmakuFetchRequest
 
 export type DanmakuImportData = {
   title: string
-  data: unknown
+  danmakus: Record<string, unknown>[] // Serialized UDanmaku (Date → ISO string)
+  metadata?: {
+    originalFileName: string
+    source: 'bilibili-xml' | 'bilibili-grpc' | 'dandanplay' | 'custom-json'
+  }
 }
 
 export type DanmakuImportResult = {

--- a/packages/danmaku-anywhere/src/common/danmaku/queries/useEpisodeComments.ts
+++ b/packages/danmaku-anywhere/src/common/danmaku/queries/useEpisodeComments.ts
@@ -1,11 +1,11 @@
-import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
 import { useQuery } from '@tanstack/react-query'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 
 export function useEpisodeComments(episodeId: number, isCustom: boolean) {
   return useQuery({
     queryKey: ['episode-comments', episodeId, isCustom],
-    queryFn: async (): Promise<CommentEntity[]> => {
+    queryFn: async (): Promise<UDanmaku[]> => {
       const { data } = await chromeRpcClient.episodeGetComments({
         episodeId,
         isCustom,

--- a/packages/danmaku-anywhere/src/common/danmaku/queries/useEpisodeComments.ts
+++ b/packages/danmaku-anywhere/src/common/danmaku/queries/useEpisodeComments.ts
@@ -1,0 +1,16 @@
+import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
+import { useQuery } from '@tanstack/react-query'
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
+
+export function useEpisodeComments(episodeId: number, isCustom: boolean) {
+  return useQuery({
+    queryKey: ['episode-comments', episodeId, isCustom],
+    queryFn: async (): Promise<CommentEntity[]> => {
+      const { data } = await chromeRpcClient.episodeGetComments({
+        episodeId,
+        isCustom,
+      })
+      return data
+    },
+  })
+}

--- a/packages/danmaku-anywhere/src/common/db/db.ts
+++ b/packages/danmaku-anywhere/src/common/db/db.ts
@@ -459,6 +459,44 @@ export class DanmakuAnywhereDb extends Dexie {
       chunks: '++id, createdAt, updatedAt',
     })
 
+    /**
+     * Version 16: Mark v4 episodes for lazy chunk migration
+     * - Set commentsChunkId to -1 to indicate pending migration
+     * - Keep comments array for now (will be converted on first access)
+     * - Update schemaVersion to 5
+     *
+     * We cannot use UniDB here because it requires Buffer (Node.js API)
+     * which is not available in Service Worker environment.
+     */
+    this.version(16).upgrade(async (tx) => {
+      // Mark regular episodes for migration
+      const episodes = await tx.table('episode').toArray()
+      for (const episode of episodes) {
+        // Check if this is a v4 episode (has comments array)
+        if ('comments' in episode && Array.isArray(episode.comments)) {
+          // Mark for lazy migration (chunk will be created on first access)
+          await tx.table('episode').update(episode.id, {
+            commentsChunkId: -1, // -1 indicates pending migration
+            commentCount: episode.comments.length,
+            schemaVersion: 5,
+            // Keep comments array for now
+          })
+        }
+      }
+
+      // Mark custom episodes for migration
+      const customEpisodes = await tx.table('customEpisode').toArray()
+      for (const episode of customEpisodes) {
+        if ('comments' in episode && Array.isArray(episode.comments)) {
+          await tx.table('customEpisode').update(episode.id, {
+            commentsChunkId: -1,
+            commentCount: episode.comments.length,
+            schemaVersion: 5,
+          })
+        }
+      }
+    })
+
     this.open()
   }
 }

--- a/packages/danmaku-anywhere/src/common/db/db.ts
+++ b/packages/danmaku-anywhere/src/common/db/db.ts
@@ -1,10 +1,10 @@
 import {
   type Bookmark,
-  type CustomEpisode,
+  type CustomEpisodeV5,
   type DanmakuSourceType,
   type DanmakuV3,
-  type Episode,
   type EpisodeV4,
+  type EpisodeV5,
   episodeMigration,
   PROVIDER_TO_BUILTIN_ID,
   type Season,
@@ -19,13 +19,28 @@ export const DANMAKU_DB_NAME = 'danmaku-anywhere'
 
 type WithoutId<T> = Omit<T, 'id'>
 
+/**
+ * Serialized UniChunk data for storage
+ */
+export interface StoredChunk {
+  id?: number
+  data: unknown // Serialized chunk data from UniDB.dump()
+  createdAt: number
+  updatedAt: number
+}
+
 @injectable('Singleton')
 export class DanmakuAnywhereDb extends Dexie {
-  episode!: Dexie.Table<Episode, number, WithoutId<Episode>>
-  customEpisode!: Dexie.Table<CustomEpisode, number, WithoutId<CustomEpisode>>
+  episode!: Dexie.Table<EpisodeV5, number, WithoutId<EpisodeV5>>
+  customEpisode!: Dexie.Table<
+    CustomEpisodeV5,
+    number,
+    WithoutId<CustomEpisodeV5>
+  >
   season!: Dexie.Table<Season, number, WithoutId<Season>>
   seasonMap!: Dexie.Table<SeasonMapSnapshot, string>
   bookmark!: Dexie.Table<Bookmark, number, WithoutId<Bookmark>>
+  chunks!: Dexie.Table<StoredChunk, number, WithoutId<StoredChunk>>
 
   isReady = new Promise<boolean>((resolve) => {
     this.on('ready', () => resolve(true))
@@ -430,6 +445,19 @@ export class DanmakuAnywhereDb extends Dexie {
             entry.seasons = remapped
           })
       })
+
+    // Version 15: Add chunks table for storing UniChunk data
+    // This enables storing UDanmaku data instead of CommentEntity
+    this.version(15).stores({
+      episode:
+        '++id, provider, indexedId, &[provider+indexedId], seasonId, timeUpdated, lastChecked',
+      customEpisode: '++id, title',
+      season:
+        '++id, provider, providerConfigId, indexedId, &[providerConfigId+indexedId]',
+      seasonMap: 'key, *seasonIds',
+      bookmark: '++id, &seasonId, providerConfigId',
+      chunks: '++id, createdAt, updatedAt',
+    })
 
     this.open()
   }

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -1,6 +1,6 @@
+import type { UDanmaku } from '@dan-uni/dan-any/core'
 import type {
   Bookmark,
-  CommentEntity,
   CustomEpisode,
   CustomEpisodeLite,
   CustomSeason,
@@ -214,7 +214,7 @@ export type BackgroundMethods = {
   episodeDelete: RPCDef<EpisodeQueryFilter, void>
   episodeGetComments: RPCDef<
     { episodeId: number; isCustom?: boolean },
-    CommentEntity[]
+    UDanmaku[]
   >
   episodeFilterCustom: RPCDef<CustomEpisodeQueryFilter, CustomEpisode[]>
   episodeFilterCustomLite: RPCDef<CustomEpisodeQueryFilter, CustomEpisodeLite[]>
@@ -361,7 +361,7 @@ export interface PipelineEntry {
 // Here the frameId is used to identify the DESTINATION frame
 export type PlayerRelayCommands = {
   'relay:command:mount': RPCDef<
-    InputWithFrameId<CommentEntity[]>,
+    InputWithFrameId<UDanmaku[]>,
     boolean,
     FrameContext
   >

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -212,6 +212,10 @@ export type BackgroundMethods = {
   episodeFetch: RPCDef<DanmakuFetchDto, WithSeason<Episode>>
   episodePreloadNext: RPCDef<WithSeason<EpisodeMeta>, void>
   episodeDelete: RPCDef<EpisodeQueryFilter, void>
+  episodeGetComments: RPCDef<
+    { episodeId: number; isCustom?: boolean },
+    CommentEntity[]
+  >
   episodeFilterCustom: RPCDef<CustomEpisodeQueryFilter, CustomEpisode[]>
   episodeFilterCustomLite: RPCDef<CustomEpisodeQueryFilter, CustomEpisodeLite[]>
   episodeDeleteCustom: RPCDef<CustomEpisodeQueryFilter, void>

--- a/packages/danmaku-anywhere/src/common/services/UniDBService.ts
+++ b/packages/danmaku-anywhere/src/common/services/UniDBService.ts
@@ -1,0 +1,11 @@
+import type { InitedUniDB } from '@dan-uni/dan-any/core'
+import { UniDB } from '@dan-uni/dan-any/core/main/pure'
+
+/**
+ * UI-side UniDB factory for parsing danmaku files.
+ * Unlike the background service, this creates temporary in-memory instances.
+ */
+export function createUniDB(): InitedUniDB {
+  const udb = new UniDB()
+  return udb.init()
+}

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -13,8 +13,10 @@ import { DanmakuSourceType } from '@/common/danmaku/enums'
 import { useFetchDanmaku } from '@/common/danmaku/queries/useFetchDanmaku'
 import { useFetchGenericDanmaku } from '@/common/danmaku/queries/useFetchGenericDanmaku'
 import { episodeToString, isProvider } from '@/common/danmaku/utils'
-import { playerRpcClient } from '@/common/rpcClient/background/client'
-import { concatArr } from '@/common/utils/utils'
+import {
+  chromeRpcClient,
+  playerRpcClient,
+} from '@/common/rpcClient/background/client'
 import { useStore } from '@/content/controller/store/store'
 
 const useMountDanmaku = () => {
@@ -30,11 +32,19 @@ const useMountDanmaku = () => {
         throw new Error('No active frame to mount danmaku')
       }
 
-      const comments: CommentEntity[] = []
+      // Load comments from chunks via RPC
+      const commentsArrays = await Promise.all(
+        episodes.map((episode) =>
+          chromeRpcClient
+            .episodeGetComments({
+              episodeId: episode.id,
+              isCustom: 'season' in episode ? false : true,
+            })
+            .then((res) => res.data)
+        )
+      )
 
-      episodes.forEach((episode) => {
-        concatArr(comments, episode.comments)
-      })
+      const comments: CommentEntity[] = commentsArrays.flat()
 
       const res = await playerRpcClient.player['relay:command:mount']({
         frameId: activeFrame.frameId,

--- a/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
+++ b/packages/danmaku-anywhere/src/content/controller/common/hooks/useLoadDanmaku.ts
@@ -1,5 +1,5 @@
+import type { UDanmaku } from '@dan-uni/dan-any/core'
 import type {
-  CommentEntity,
   Episode,
   GenericEpisode,
   WithSeason,
@@ -32,7 +32,7 @@ const useMountDanmaku = () => {
         throw new Error('No active frame to mount danmaku')
       }
 
-      // Load comments from chunks via RPC
+      // Load UDanmaku[] from chunks via RPC
       const commentsArrays = await Promise.all(
         episodes.map((episode) =>
           chromeRpcClient
@@ -44,7 +44,7 @@ const useMountDanmaku = () => {
         )
       )
 
-      const comments: CommentEntity[] = commentsArrays.flat()
+      const comments: UDanmaku[] = commentsArrays.flat()
 
       const res = await playerRpcClient.player['relay:command:mount']({
         frameId: activeFrame.frameId,

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/frame/usePreloadNextEpisode.ts
@@ -18,9 +18,8 @@ export const usePreloadNextEpisode = () => {
     if (!isNotCustom(episode)) {
       return
     }
-    // Drop comments so the message stays small; preload is best-effort.
-    const { comments: _, ...meta } = episode
-    await chromeRpcClient.episodePreloadNext(meta, { optional: true })
+    // V5: No comments field to drop, episode is already lean
+    await chromeRpcClient.episodePreloadNext(episode, { optional: true })
   }
 
   return { canLoadNext, preloadNext }

--- a/packages/danmaku-anywhere/src/content/controller/danmaku/panelState/PanelStateBroadcaster.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/danmaku/panelState/PanelStateBroadcaster.tsx
@@ -8,15 +8,23 @@ import { selectPanelState } from './selectPanelState'
 
 function usePipelineEntry(): PipelineEntry | null {
   const isDisconnected = useStore.use.isDisconnected()
-  const { isManual, isMounted, episodes, comments } = useStore.use.danmaku()
+  const { isManual, isMounted, episodes } = useStore.use.danmaku()
   const integration = useStore.use.integration()
+
+  // Calculate total comment count from all mounted episodes
+  const totalCommentCount = useMemo(() => {
+    if (!episodes || episodes.length === 0) {
+      return 0
+    }
+    return episodes.reduce((sum, episode) => sum + episode.commentCount, 0)
+  }, [episodes])
 
   return useMemo<PipelineEntry | null>(() => {
     return selectPanelState({
       isDisconnected,
       isManual,
       isMounted,
-      commentCount: comments.length,
+      commentCount: totalCommentCount,
       provider: episodes?.[0]?.provider,
       mountedEpisodes: episodes,
       integration: {
@@ -29,7 +37,7 @@ function usePipelineEntry(): PipelineEntry | null {
     isDisconnected,
     isManual,
     isMounted,
-    comments.length,
+    totalCommentCount,
     episodes,
     integration.active,
     integration.errorMessage,

--- a/packages/danmaku-anywhere/src/content/controller/iconManager/useIconManager.ts
+++ b/packages/danmaku-anywhere/src/content/controller/iconManager/useIconManager.ts
@@ -6,15 +6,21 @@ import { useStore } from '@/content/controller/store/store'
 
 export const useIconManager = () => {
   const config = useActiveConfig()
-  const { isMounted, comments } = useStore.use.danmaku()
+  const { isMounted, episodes } = useStore.use.danmaku()
 
   useEffect(() => {
-    if (isMounted) {
+    if (isMounted && episodes) {
+      // Calculate total comment count from all mounted episodes
+      const totalCommentCount = episodes.reduce(
+        (sum, episode) => sum + episode.commentCount,
+        0
+      )
+
       return void chromeRpcClient.iconSet({
         state: 'active',
-        count: comments.length,
+        count: totalCommentCount,
       })
     }
     return void chromeRpcClient.iconSet({ state: 'available' })
-  }, [config, comments, isMounted]) // config is included to ensure icon is reset when config changes
+  }, [config, episodes, isMounted]) // config is included to ensure icon is reset when config changes
 }

--- a/packages/danmaku-anywhere/src/content/controller/store/store.ts
+++ b/packages/danmaku-anywhere/src/content/controller/store/store.ts
@@ -1,7 +1,5 @@
-import type {
-  CommentEntity,
-  GenericEpisode,
-} from '@danmaku-anywhere/danmaku-converter'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
+import type { GenericEpisode } from '@danmaku-anywhere/danmaku-converter'
 import { enableMapSet } from 'immer'
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
@@ -59,7 +57,7 @@ interface StoreState {
     /**
      * Danmaku to be displayed
      */
-    comments: CommentEntity[]
+    comments: UDanmaku[]
 
     /**
      * Information about the current danmaku. This is an array since multiple episodes can be mounted at once.

--- a/packages/danmaku-anywhere/src/content/controller/store/store.ts
+++ b/packages/danmaku-anywhere/src/content/controller/store/store.ts
@@ -151,9 +151,9 @@ const useStoreBase = create<StoreState>()(
         set((state) => {
           state.danmaku.isMounted = true
           state.danmaku.episodes = episodes
-          state.danmaku.comments = episodes.flatMap((episode) => {
-            return episode.comments
-          })
+          // Comments are loaded separately via RPC in useMountDanmaku
+          // and sent directly to the player. Store doesn't need them anymore.
+          state.danmaku.comments = []
         })
       },
       unmount: () => {

--- a/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/components/InfoBar.tsx
+++ b/packages/danmaku-anywhere/src/content/controller/ui/floatingPanel/components/InfoBar.tsx
@@ -18,7 +18,7 @@ import { useStore } from '@/content/controller/store/store'
 export const InfoBar = () => {
   const { t } = useTranslation()
 
-  const { isMounted, episodes, comments } = useStore.use.danmaku()
+  const { isMounted, episodes } = useStore.use.danmaku()
 
   const hasEpisodes = episodes && episodes.length > 0
 
@@ -29,18 +29,26 @@ export const InfoBar = () => {
     unmountMutation.mutate()
   }
 
-  const { titles, title } = useMemo(() => {
+  const { titles, title, totalCommentCount } = useMemo(() => {
     if (!episodes || episodes.length === 0) {
       return {
         title: '',
         titles: [],
+        totalCommentCount: 0,
       }
     }
+
+    const totalCommentCount = episodes.reduce(
+      (sum, episode) => sum + episode.commentCount,
+      0
+    )
+
     return {
       title: episodeToString(episodes[0]),
       titles: episodes.map((e) => {
         return <div key={e.id}>{episodeToString(e)}</div>
       }),
+      totalCommentCount,
     }
   }, [episodes])
 
@@ -69,7 +77,7 @@ export const InfoBar = () => {
             <Typography
               sx={{ color: 'text.secondary', pl: 0.5, flexShrink: 0 }}
             >
-              ({comments.length})
+              ({totalCommentCount})
             </Typography>
           </Box>
           <Box

--- a/packages/danmaku-anywhere/src/content/player/PlayerCommandHandler.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/PlayerCommandHandler.service.ts
@@ -1,4 +1,5 @@
-import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
+import { toCommentEntity } from '@danmaku-anywhere/danmaku-converter'
 import { inject, injectable } from 'inversify'
 import { type ILogger, LoggerSymbol } from '@/common/Logger'
 import { DanmakuOptionsService } from '@/common/options/danmakuOptions/service'
@@ -330,7 +331,9 @@ export class PlayerCommandHandler {
     server.listen(chrome.runtime.onMessage)
   }
 
-  private mount(comments: CommentEntity[]) {
+  private mount(udanmakus: UDanmaku[]) {
+    // Convert UDanmaku[] to CommentEntity[] for the danmaku engine
+    const comments = udanmakus.map((u) => toCommentEntity(u))
     this.manager.mount(comments)
     this.videoSkip.setComments(comments)
     this.density.setComments(comments)

--- a/packages/danmaku-anywhere/src/popup/hooks/useExportBase.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useExportBase.ts
@@ -32,7 +32,7 @@ export interface ExportFile {
 }
 
 export interface ExportFormatter {
-  formatEpisode: (episode: GenericEpisode) => ExportFile
+  formatEpisode: (episode: GenericEpisode) => ExportFile | Promise<ExportFile>
   fileExtension: string
   successMessage: () => string
   errorMessage: (errorMessage: string) => string
@@ -71,24 +71,24 @@ export const useExportWithFormat = (formatter: ExportFormatter) => {
       const files: ExportFile[] = []
 
       // Add regular episodes
-      episodes.forEach((ep) => {
-        const formatted = formatter.formatEpisode(ep)
+      for (const ep of episodes) {
+        const formatted = await formatter.formatEpisode(ep)
         const fileName = `${sanitizeFilename(`${ep.season.provider} (${ep.season.providerConfigId})`)}/${sanitizeFilename(ep.season.title)}/${sanitizeFilename(formatted.name)}`
 
         files.push({
           name: fileName,
           data: formatted.data,
         })
-      })
+      }
 
       // Add custom episodes
-      customEpisodes.forEach((ep) => {
-        const formatted = formatter.formatEpisode(ep)
+      for (const ep of customEpisodes) {
+        const formatted = await formatter.formatEpisode(ep)
         files.push({
           name: `custom/${sanitizeFilename(formatted.name)}`,
           data: formatted.data,
         })
-      })
+      }
 
       if (files.length === 1) {
         downloadSingleFile(files[0])

--- a/packages/danmaku-anywhere/src/popup/hooks/useExportDanmaku.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useExportDanmaku.ts
@@ -8,7 +8,7 @@ import { type ExportFormatter, useExportWithFormat } from './useExportBase'
 /**
  * Deserialize UDanmaku from RPC: convert ISO date strings back to Date objects
  */
-function deserializeUDanmaku(serialized: Record<string, unknown>): UDanmaku {
+function deserializeUDanmaku(serialized: UDanmaku): UDanmaku {
   return {
     ...serialized,
     ctime:

--- a/packages/danmaku-anywhere/src/popup/hooks/useExportDanmaku.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useExportDanmaku.ts
@@ -1,11 +1,57 @@
+import { DanuniJsonTransformerConfigurator } from '@dan-uni/dan-any/adapters'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
+import { UniDB } from '@dan-uni/dan-any/core/main/pure'
 import { i18n } from '@/common/localization/i18n'
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { type ExportFormatter, useExportWithFormat } from './useExportBase'
 
+/**
+ * Deserialize UDanmaku from RPC: convert ISO date strings back to Date objects
+ */
+function deserializeUDanmaku(serialized: Record<string, unknown>): UDanmaku {
+  return {
+    ...serialized,
+    ctime:
+      typeof serialized.ctime === 'string'
+        ? new Date(serialized.ctime)
+        : (serialized.ctime as Date),
+  } as UDanmaku
+}
+
 const jsonFormatter: ExportFormatter = {
-  formatEpisode: (episode) => ({
-    name: `${episode.title}.json`,
-    data: JSON.stringify(episode, null, 2),
-  }),
+  formatEpisode: async (episode) => {
+    // V5: Load UDanmaku[] from chunk via RPC
+    const { data: udanmakus } = await chromeRpcClient.episodeGetComments({
+      episodeId: episode.id,
+      isCustom: !('season' in episode),
+    })
+
+    // Deserialize: RPC transfers Date as ISO string, need to convert back
+    const deserializedDanmakus = udanmakus.map(deserializeUDanmaku)
+
+    // Create a temporary UniDB and chunk for export
+    const udb = await new UniDB().init()
+    try {
+      const chunk = await udb.makeChunk({})
+
+      // Insert UDanmaku[] into the chunk
+      await chunk.upsertDanmakus(deserializedDanmakus, false)
+
+      // Export to DanUni JSON format using dan-any transformer
+      const jsonContent = await chunk.export(
+        DanuniJsonTransformerConfigurator({
+          minify: false, // Pretty-printed for readability
+        })
+      )
+
+      return {
+        name: `${episode.title}.json`,
+        data: JSON.stringify(jsonContent),
+      }
+    } finally {
+      await udb.close()
+    }
+  },
   fileExtension: 'json',
   successMessage: () => i18n.t('danmaku.alert.exported', 'Export successful'),
   errorMessage: (errorMessage: string) =>

--- a/packages/danmaku-anywhere/src/popup/hooks/useExportXml.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useExportXml.ts
@@ -1,22 +1,23 @@
-import { commentsToXml } from '@danmaku-anywhere/danmaku-converter'
+import {
+  commentsToXml,
+  toCommentEntity,
+} from '@danmaku-anywhere/danmaku-converter'
 import { i18n } from '@/common/localization/i18n'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { type ExportFormatter, useExportWithFormat } from './useExportBase'
 
 const xmlFormatter: ExportFormatter = {
   formatEpisode: async (episode) => {
-    // V5: Load comments from chunk via RPC
-    const { data: comments } = await chromeRpcClient.episodeGetComments({
+    // V5: Load UDanmaku[] from chunk via RPC
+    const { data: udanmakus } = await chromeRpcClient.episodeGetComments({
       episodeId: episode.id,
       isCustom: !('season' in episode),
     })
 
-    const formattedComments = comments.map((comment) => ({
-      p: comment.p,
-      m: comment.m,
-    }))
+    // Convert UDanmaku[] to CommentEntity[] for XML export
+    const comments = udanmakus.map((u) => toCommentEntity(u))
 
-    const xmlContent = commentsToXml(formattedComments)
+    const xmlContent = commentsToXml(comments)
     return {
       name: `${episode.title}.xml`,
       data: xmlContent,

--- a/packages/danmaku-anywhere/src/popup/hooks/useExportXml.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useExportXml.ts
@@ -1,10 +1,17 @@
 import { commentsToXml } from '@danmaku-anywhere/danmaku-converter'
 import { i18n } from '@/common/localization/i18n'
+import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { type ExportFormatter, useExportWithFormat } from './useExportBase'
 
 const xmlFormatter: ExportFormatter = {
-  formatEpisode: (episode) => {
-    const formattedComments = episode.comments.map((comment) => ({
+  formatEpisode: async (episode) => {
+    // V5: Load comments from chunk via RPC
+    const { data: comments } = await chromeRpcClient.episodeGetComments({
+      episodeId: episode.id,
+      isCustom: !('season' in episode),
+    })
+
+    const formattedComments = comments.map((comment) => ({
       p: comment.p,
       m: comment.m,
     }))

--- a/packages/danmaku-anywhere/src/popup/hooks/useExportXml.ts
+++ b/packages/danmaku-anywhere/src/popup/hooks/useExportXml.ts
@@ -1,10 +1,22 @@
-import {
-  commentsToXml,
-  toCommentEntity,
-} from '@danmaku-anywhere/danmaku-converter'
+import { BiliXmlTransformerConfigurator } from '@dan-uni/dan-any/adapters'
+import type { UDanmaku } from '@dan-uni/dan-any/core'
+import { UniDB } from '@dan-uni/dan-any/core/main/pure'
 import { i18n } from '@/common/localization/i18n'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { type ExportFormatter, useExportWithFormat } from './useExportBase'
+
+/**
+ * Deserialize UDanmaku from RPC: convert ISO date strings back to Date objects
+ */
+function deserializeUDanmaku(serialized: Record<string, unknown>): UDanmaku {
+  return {
+    ...serialized,
+    ctime:
+      typeof serialized.ctime === 'string'
+        ? new Date(serialized.ctime)
+        : (serialized.ctime as Date),
+  } as UDanmaku
+}
 
 const xmlFormatter: ExportFormatter = {
   formatEpisode: async (episode) => {
@@ -14,13 +26,26 @@ const xmlFormatter: ExportFormatter = {
       isCustom: !('season' in episode),
     })
 
-    // Convert UDanmaku[] to CommentEntity[] for XML export
-    const comments = udanmakus.map((u) => toCommentEntity(u))
+    // Deserialize: RPC transfers Date as ISO string, need to convert back
+    const deserializedDanmakus = udanmakus.map(deserializeUDanmaku)
 
-    const xmlContent = commentsToXml(comments)
-    return {
-      name: `${episode.title}.xml`,
-      data: xmlContent,
+    // Create a temporary UniDB and chunk for export
+    const udb = await new UniDB().init()
+    try {
+      const chunk = await udb.makeChunk({})
+
+      // Insert UDanmaku[] into the chunk
+      await chunk.upsertDanmakus(deserializedDanmakus, false)
+
+      // Export to Bilibili XML format using dan-any transformer
+      const xmlContent = await chunk.export(BiliXmlTransformerConfigurator())
+
+      return {
+        name: `${episode.title}.xml`,
+        data: xmlContent,
+      }
+    } finally {
+      await udb.close()
     }
   },
   fileExtension: 'xml',

--- a/packages/danmaku-converter/package.json
+++ b/packages/danmaku-converter/package.json
@@ -18,6 +18,7 @@
     "dev": "tsgo -w"
   },
   "dependencies": {
+    "@dan-uni/dan-any": "^2.2.7",
     "xml-js": "^1.6.11",
     "zod": "^4.3.5"
   },

--- a/packages/danmaku-converter/package.json
+++ b/packages/danmaku-converter/package.json
@@ -18,7 +18,7 @@
     "dev": "tsgo -w"
   },
   "dependencies": {
-    "@dan-uni/dan-any": "^2.2.7",
+    "@dan-uni/dan-any": "^2.3.0",
     "xml-js": "^1.6.11",
     "zod": "^4.3.5"
   },

--- a/packages/danmaku-converter/src/canonical/comment/danAnyAdapter.ts
+++ b/packages/danmaku-converter/src/canonical/comment/danAnyAdapter.ts
@@ -1,15 +1,9 @@
-import { defineAdapter } from '@dan-uni/dan-any/adapters'
 import {
   defaultUniDM,
   type InitedUniDB,
   type UDanmaku,
-  type UniChunk,
 } from '@dan-uni/dan-any/core'
 import { hexToRgb888 } from '../../utils/index.js'
-import type {
-  CustomEpisodeInsertV4,
-  EpisodeInsertV4,
-} from '../episode/v4/schema.js'
 import type { CommentEntity } from './types.js'
 import { CommentMode, normalizeCommentMode } from './types.js'
 import { parseCommentEntityP } from './utils.js'
@@ -35,44 +29,6 @@ const modeReverseMap: Record<
   Ext: CommentMode.rtl,
 }
 
-export const V4EpisodeAdapter = defineAdapter(
-  (epV4: EpisodeInsertV4 | CustomEpisodeInsertV4) => {
-    return async (udb: InitedUniDB, uchunk?: UniChunk) => {
-      const chunk = uchunk ?? (await udb.makeChunk({ fromConverted: true }))
-
-      const validDanmakus: UDanmaku[] = []
-
-      for (const comment of epV4.comments) {
-        const parsed = parseCommentEntityP(comment.p)
-
-        if (!parsed) {
-          continue
-        }
-
-        const { time, mode, color, uid } = parsed
-
-        const map_d = {
-          ...defaultUniDM,
-          pool: 'Def' as const,
-          SOID: 'v4+danmaku-converter@danmaku-anywhere',
-          progress: Math.round(time * 1000),
-          mode: modeMap[mode] ?? 'Normal',
-          color: hexToRgb888(color),
-          senderID: uid ? `${uid}@danmaku-anywhere` : defaultUniDM.senderID,
-          content: comment.m,
-          ctime: new Date(),
-          platform: epV4.provider,
-        }
-
-        validDanmakus.push({ ...map_d, DMID: udb.DMIDGenerator(map_d) })
-      }
-
-      await chunk.upsertDanmakus(validDanmakus)
-      return chunk
-    }
-  }
-)
-
 export function toCommentEntity(udanmaku: UDanmaku): CommentEntity {
   const time = udanmaku.progress / 1000
   const mode = modeReverseMap[udanmaku.mode] ?? CommentMode.rtl
@@ -82,7 +38,7 @@ export function toCommentEntity(udanmaku: UDanmaku): CommentEntity {
   const senderID = udanmaku.senderID.replace('@danmaku-anywhere', '')
 
   const p =
-    senderID && senderID !== 'anonymous@dan-uni/dan-any'
+    senderID && senderID !== 'anonymous@dan-uni'
       ? `${time.toFixed(2)},${normalizedMode},${color},${senderID}`
       : `${time.toFixed(2)},${normalizedMode},${color}`
 
@@ -90,10 +46,6 @@ export function toCommentEntity(udanmaku: UDanmaku): CommentEntity {
     p,
     m: udanmaku.content,
   }
-}
-
-export function toCommentEntities(udanmakus: UDanmaku[]): CommentEntity[] {
-  return udanmakus.map(toCommentEntity)
 }
 
 export function toUDanmaku(

--- a/packages/danmaku-converter/src/canonical/comment/danAnyAdapter.ts
+++ b/packages/danmaku-converter/src/canonical/comment/danAnyAdapter.ts
@@ -1,0 +1,126 @@
+import { defineAdapter } from '@dan-uni/dan-any/adapters'
+import {
+  defaultUniDM,
+  type InitedUniDB,
+  type UDanmaku,
+  type UniChunk,
+} from '@dan-uni/dan-any/core'
+import { hexToRgb888 } from '../../utils/index.js'
+import type {
+  CustomEpisodeInsertV4,
+  EpisodeInsertV4,
+} from '../episode/v4/schema.js'
+import type { CommentEntity } from './types.js'
+import { CommentMode, normalizeCommentMode } from './types.js'
+import { parseCommentEntityP } from './utils.js'
+
+type V4CommentMode = 'ltr' | 'rtl' | 'top' | 'bottom'
+
+const modeMap: Record<V4CommentMode, 'Normal' | 'Bottom' | 'Top' | 'Reverse'> =
+  {
+    ltr: 'Reverse',
+    rtl: 'Normal',
+    top: 'Top',
+    bottom: 'Bottom',
+  }
+
+const modeReverseMap: Record<
+  'Normal' | 'Bottom' | 'Top' | 'Reverse' | 'Ext',
+  number
+> = {
+  Normal: CommentMode.rtl,
+  Bottom: CommentMode.bottom,
+  Top: CommentMode.top,
+  Reverse: CommentMode.ltr,
+  Ext: CommentMode.rtl,
+}
+
+export const V4EpisodeAdapter = defineAdapter(
+  (epV4: EpisodeInsertV4 | CustomEpisodeInsertV4) => {
+    return async (udb: InitedUniDB, uchunk?: UniChunk) => {
+      const chunk = uchunk ?? (await udb.makeChunk({ fromConverted: true }))
+
+      const validDanmakus: UDanmaku[] = []
+
+      for (const comment of epV4.comments) {
+        const parsed = parseCommentEntityP(comment.p)
+
+        if (!parsed) {
+          continue
+        }
+
+        const { time, mode, color, uid } = parsed
+
+        const map_d = {
+          ...defaultUniDM,
+          pool: 'Def' as const,
+          SOID: 'v4+danmaku-converter@danmaku-anywhere',
+          progress: Math.round(time * 1000),
+          mode: modeMap[mode] ?? 'Normal',
+          color: hexToRgb888(color),
+          senderID: uid ? `${uid}@danmaku-anywhere` : defaultUniDM.senderID,
+          content: comment.m,
+          ctime: new Date(),
+          platform: epV4.provider,
+        }
+
+        validDanmakus.push({ ...map_d, DMID: udb.DMIDGenerator(map_d) })
+      }
+
+      await chunk.upsertDanmakus(validDanmakus)
+      return chunk
+    }
+  }
+)
+
+export function toCommentEntity(udanmaku: UDanmaku): CommentEntity {
+  const time = udanmaku.progress / 1000
+  const mode = modeReverseMap[udanmaku.mode] ?? CommentMode.rtl
+  const normalizedMode = normalizeCommentMode(mode)
+  const color = udanmaku.color
+
+  const senderID = udanmaku.senderID.replace('@danmaku-anywhere', '')
+
+  const p =
+    senderID && senderID !== 'anonymous@dan-uni/dan-any'
+      ? `${time.toFixed(2)},${normalizedMode},${color},${senderID}`
+      : `${time.toFixed(2)},${normalizedMode},${color}`
+
+  return {
+    p,
+    m: udanmaku.content,
+  }
+}
+
+export function toCommentEntities(udanmakus: UDanmaku[]): CommentEntity[] {
+  return udanmakus.map(toCommentEntity)
+}
+
+export function toUDanmaku(
+  ce: CommentEntity,
+  udb: InitedUniDB,
+  platform?: string
+): UDanmaku | null {
+  const parsed = parseCommentEntityP(ce.p)
+
+  if (!parsed) {
+    return null
+  }
+
+  const { time, mode, color, uid } = parsed
+
+  const map_d = {
+    ...defaultUniDM,
+    pool: 'Def' as const,
+    SOID: 'comment-entity@danmaku-anywhere',
+    progress: Math.round(time * 1000),
+    mode: modeMap[mode] ?? 'Normal',
+    color: hexToRgb888(color),
+    senderID: uid ? `${uid}@danmaku-anywhere` : defaultUniDM.senderID,
+    content: ce.m,
+    ctime: new Date(),
+    platform: platform ?? null,
+  }
+
+  return { ...map_d, DMID: udb.DMIDGenerator(map_d) }
+}

--- a/packages/danmaku-converter/src/canonical/comment/index.ts
+++ b/packages/danmaku-converter/src/canonical/comment/index.ts
@@ -1,2 +1,3 @@
+export * from './danAnyAdapter.js'
 export * from './types.js'
 export * from './utils.js'

--- a/packages/danmaku-converter/src/canonical/episode/index.ts
+++ b/packages/danmaku-converter/src/canonical/episode/index.ts
@@ -1,33 +1,33 @@
 import type { DanmakuSourceType } from '../provider/provider.js'
+import type { WithSeasonV1 } from './v4/schema.js'
 import type {
-  CustomEpisodeInsertV4,
-  CustomEpisodeLiteV4,
-  CustomEpisodeV4,
-  EpisodeInsertV4,
-  EpisodeLiteV4,
-  EpisodeMetaV4,
-  EpisodeV4,
-  WithSeasonV1,
-} from './v4/schema.js'
+  CustomEpisodeInsertV5,
+  CustomEpisodeLiteV5,
+  CustomEpisodeV5,
+  EpisodeInsertV5,
+  EpisodeLiteV5,
+  EpisodeMetaV5,
+  EpisodeV5,
+} from './v5/schema.js'
 
 export * from './migration/migration.js'
 export * from './v3/schema.js'
 export * from './v4/schema.js'
 export * from './v5/index.js'
 
-export const EPISODE_SCHEMA_VERSION = 4 as const
+export const EPISODE_SCHEMA_VERSION = 5 as const
 
-export type Episode = EpisodeV4
-export type EpisodeInsert = EpisodeInsertV4
-export type EpisodeLite = EpisodeLiteV4
-export type EpisodeMeta = EpisodeMetaV4
+export type Episode = EpisodeV5
+export type EpisodeInsert = EpisodeInsertV5
+export type EpisodeLite = EpisodeLiteV5
+export type EpisodeMeta = EpisodeMetaV5
 
 export type WithSeason<T extends { provider: DanmakuSourceType }> =
   WithSeasonV1<T>
 
-export type CustomEpisode = CustomEpisodeV4
-export type CustomEpisodeInsert = CustomEpisodeInsertV4
-export type CustomEpisodeLite = CustomEpisodeLiteV4
+export type CustomEpisode = CustomEpisodeV5
+export type CustomEpisodeInsert = CustomEpisodeInsertV5
+export type CustomEpisodeLite = CustomEpisodeLiteV5
 
 export type GenericEpisode = WithSeason<Episode> | CustomEpisode
 export type GenericEpisodeLite = WithSeason<EpisodeLite> | CustomEpisodeLite

--- a/packages/danmaku-converter/src/canonical/episode/index.ts
+++ b/packages/danmaku-converter/src/canonical/episode/index.ts
@@ -13,6 +13,7 @@ import type {
 export * from './migration/migration.js'
 export * from './v3/schema.js'
 export * from './v4/schema.js'
+export * from './v5/index.js'
 
 export const EPISODE_SCHEMA_VERSION = 4 as const
 

--- a/packages/danmaku-converter/src/canonical/episode/migration/migration.ts
+++ b/packages/danmaku-converter/src/canonical/episode/migration/migration.ts
@@ -53,10 +53,12 @@ function v1ToV3(v1Data: z.infer<typeof zEpisodeImportV1>): DanmakuInsertV3 {
         provider: DanmakuSourceType.MacCMS,
         seasonTitle: v1Data.meta.animeTitle, // Rename animeTitle to seasonTitle
         episodeTitle:
-          v1Data.meta.episodeTitle ?? v1Data.meta.episodeNumber!.toString(),
+          v1Data.meta.episodeTitle ??
+          v1Data.meta.episodeNumber?.toString() ??
+          '',
       },
       episodeTitle:
-        v1Data.meta.episodeTitle ?? v1Data.meta.episodeNumber!.toString(),
+        v1Data.meta.episodeTitle ?? v1Data.meta.episodeNumber?.toString() ?? '',
       seasonTitle: v1Data.meta.animeTitle,
     }
   }

--- a/packages/danmaku-converter/src/canonical/episode/v4/schema.ts
+++ b/packages/danmaku-converter/src/canonical/episode/v4/schema.ts
@@ -12,6 +12,8 @@ export const zCustomEpisodeInsertV4 = z.object({
   title: z.string().refine(stripHtml),
   comments: z.array(zCommentEntity),
   commentCount: z.number(),
+  // Optional: foreign key to chunks table for UDanmaku storage
+  chunkId: z.number().optional(),
   schemaVersion: z.literal(4),
 })
 
@@ -47,6 +49,9 @@ export const zEpisodeInsertV4 = z.object({
   seasonId: z.number(),
   comments: z.array(zCommentEntity),
   commentCount: z.number(),
+  // Optional: foreign key to chunks table for UDanmaku storage
+  // When present, prefer loading from chunks over comments array
+  chunkId: z.number().optional(),
   schemaVersion: z.literal(4),
   // The last time we checked for updates
   lastChecked: z.number(),

--- a/packages/danmaku-converter/src/canonical/episode/v5/index.ts
+++ b/packages/danmaku-converter/src/canonical/episode/v5/index.ts
@@ -1,0 +1,1 @@
+export * from './schema.js'

--- a/packages/danmaku-converter/src/canonical/episode/v5/schema.ts
+++ b/packages/danmaku-converter/src/canonical/episode/v5/schema.ts
@@ -28,6 +28,7 @@ const zBaseEpisodeV5 = z.object({
   commentCount: z.number(),
   schemaVersion: z.literal(5),
   lastChecked: z.number(),
+  params: z.record(z.string(), z.unknown()).optional(),
 })
 
 export const zDanDanPlayProviderIds = z.object({

--- a/packages/danmaku-converter/src/canonical/episode/v5/schema.ts
+++ b/packages/danmaku-converter/src/canonical/episode/v5/schema.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod'
+import { stripHtml } from '../../../utils/index.js'
+import { DanmakuSourceType, type DbEntity } from '../../provider/provider.js'
+
+export const zCustomEpisodeInsertV5 = z.object({
+  provider: z.literal(DanmakuSourceType.MacCMS),
+  title: z.string().refine(stripHtml),
+  commentsChunkId: z.number(),
+  commentCount: z.number(),
+  schemaVersion: z.literal(5),
+})
+
+export type CustomEpisodeInsertV5 = z.infer<typeof zCustomEpisodeInsertV5>
+
+export type CustomEpisodeV5 = DbEntity<CustomEpisodeInsertV5>
+
+export type CustomEpisodeLiteV5 = CustomEpisodeV5
+
+const zBaseEpisodeV5 = z.object({
+  title: z.string().refine(stripHtml),
+  episodeNumber: z.union([z.number(), z.string()]).optional(),
+  imageUrl: z.url().optional(),
+  externalLink: z.url().optional(),
+  alternativeTitle: z.array(z.string()).optional(),
+  indexedId: z.string(),
+  seasonId: z.number(),
+  commentsChunkId: z.number(),
+  commentCount: z.number(),
+  schemaVersion: z.literal(5),
+  lastChecked: z.number(),
+})
+
+export const zDanDanPlayProviderIds = z.object({
+  episodeId: z.number(),
+})
+
+export const zDanDanPlayParams = z.object({
+  episodeId: z.number().optional(),
+  animeId: z.number().optional(),
+  withRelated: z.boolean().optional(),
+  chConvert: z.boolean().optional(),
+})
+
+export const zBilibiliProviderIds = z.object({
+  cid: z.number(),
+  epid: z.number().optional(),
+  aid: z.number().optional(),
+  bvid: z.string().optional(),
+})
+
+export const zTencentProviderIds = z.object({
+  vid: z.string(),
+})
+
+export const zDanDanPlayEpisodeV5 = zBaseEpisodeV5.extend({
+  provider: z.literal(DanmakuSourceType.DanDanPlay),
+  providerIds: zDanDanPlayProviderIds,
+  params: zDanDanPlayParams.optional(),
+})
+
+export const zBilibiliEpisodeV5 = zBaseEpisodeV5.extend({
+  provider: z.literal(DanmakuSourceType.Bilibili),
+  providerIds: zBilibiliProviderIds,
+})
+
+export const zTencentEpisodeV5 = zBaseEpisodeV5.extend({
+  provider: z.literal(DanmakuSourceType.Tencent),
+  providerIds: zTencentProviderIds,
+})
+
+export const zEpisodeInsertV5 = z.discriminatedUnion('provider', [
+  zDanDanPlayEpisodeV5,
+  zBilibiliEpisodeV5,
+  zTencentEpisodeV5,
+])
+
+export type DanDanPlayEpisodeInsertV5 = z.infer<typeof zDanDanPlayEpisodeV5>
+export type BilibiliEpisodeInsertV5 = z.infer<typeof zBilibiliEpisodeV5>
+export type TencentEpisodeInsertV5 = z.infer<typeof zTencentEpisodeV5>
+
+export type EpisodeInsertV5 = z.infer<typeof zEpisodeInsertV5>
+
+export type DanDanPlayEpisodeV5 = DbEntity<DanDanPlayEpisodeInsertV5>
+export type BilibiliEpisodeV5 = DbEntity<BilibiliEpisodeInsertV5>
+export type TencentEpisodeV5 = DbEntity<TencentEpisodeInsertV5>
+
+export type EpisodeV5 =
+  | DanDanPlayEpisodeV5
+  | BilibiliEpisodeV5
+  | TencentEpisodeV5
+
+export type EpisodeLiteV5 = EpisodeV5
+
+export type EpisodeMetaV5 = Omit<
+  EpisodeInsertV5,
+  'commentsChunkId' | 'commentCount'
+>
+
+export type EpisodeImportV5 = Omit<EpisodeInsertV5, 'seasonId'>

--- a/packages/danmaku-provider/package.json
+++ b/packages/danmaku-provider/package.json
@@ -66,7 +66,7 @@
     "openapi-ts": "openapi-ts"
   },
   "dependencies": {
-    "@dan-uni/dan-any": "^2.2.7",
+    "@dan-uni/dan-any": "^2.3.0",
     "@danmaku-anywhere/danmaku-converter": "workspace:*",
     "@danmaku-anywhere/result": "workspace:*",
     "protobufjs": "^7.5.4",

--- a/packages/danmaku-provider/package.json
+++ b/packages/danmaku-provider/package.json
@@ -66,6 +66,7 @@
     "openapi-ts": "openapi-ts"
   },
   "dependencies": {
+    "@dan-uni/dan-any": "^2.2.7",
     "@danmaku-anywhere/danmaku-converter": "workspace:*",
     "@danmaku-anywhere/result": "workspace:*",
     "protobufjs": "^7.5.4",

--- a/packages/danmaku-provider/src/providers/bilibili/api.test.ts
+++ b/packages/danmaku-provider/src/providers/bilibili/api.test.ts
@@ -5,7 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { HttpException } from '../../exceptions/HttpException'
 import { ResponseParseException } from '../../exceptions/ResponseParseException'
-import { mockFetch, mockFetchResponse } from '../utils/testUtils'
+import {
+  createTestUniChunk,
+  mockFetch,
+  mockFetchResponse,
+} from '../utils/testUtils'
 
 import {
   getBangumiInfo,
@@ -143,26 +147,26 @@ describe('Bilibili', () => {
   })
 
   describe('get danmaku xml', () => {
-    it('should parse and return danmaku xml', async () => {
+    it('should parse and return danmaku in UniChunk', async () => {
       mockFetchResponse(mockDanmakuXml)
 
-      const result = await getDanmakuXml(1)
+      const uchunk = await createTestUniChunk()
+      const result = await getDanmakuXml(uchunk, 1)
 
       expect(result.success).toBe(true)
       if (result.success) {
-        const data = result.data
-        expect(data).toHaveLength(17)
-        expect(data).toContainEqual({
-          m: '分多少----、',
-          p: '3771.649,1,16777215',
-        })
+        const danmakus = await result.data.$danmakus
+        expect(danmakus).toHaveLength(17)
+        expect(danmakus[0]).toHaveProperty('content')
+        expect(danmakus[0]).toHaveProperty('progress')
       }
     })
 
     it('should return error if response is not xml', async () => {
       mockFetch(new Response('not xml'))
 
-      const result = await getDanmakuXml(1)
+      const uchunk = await createTestUniChunk()
+      const result = await getDanmakuXml(uchunk, 1)
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error).toBeInstanceOf(ResponseParseException)
@@ -178,18 +182,21 @@ describe('Bilibili', () => {
 
       mockFetchResponse(mockProtoResponse)
 
-      const generator = getDanmakuProtoSegment(1)
+      const uchunk = await createTestUniChunk()
+      const generator = getDanmakuProtoSegment(uchunk, 1)
 
       const firstResult = await generator.next()
       expect(firstResult.value.success).toBe(true)
       if (firstResult.value.success) {
-        expect(firstResult.value.data).toHaveLength(937)
+        const count1 = await firstResult.value.data.$count
+        expect(count1).toBe(937)
       }
 
       const secondResult = await generator.next()
       expect(secondResult.value.success).toBe(true)
       if (secondResult.value.success) {
-        expect(secondResult.value.data).toHaveLength(937)
+        const count2 = await secondResult.value.data.$count
+        expect(count2).toBe(937 * 2)
       }
 
       mockFetchResponse(mockProtoResponse, 304)
@@ -218,17 +225,20 @@ describe('Bilibili', () => {
         } as any
       })
 
-      const result = await getDanmakuProto(1)
+      const uchunk = await createTestUniChunk()
+      const result = await getDanmakuProto(uchunk, 1)
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data).toHaveLength(937 * 3)
+        const count = await result.data.$count
+        expect(count).toBe(937 * 3)
       }
     })
 
     it('should return error when data is invalid', async () => {
       mockFetchResponse(new TextEncoder().encode('invalid').buffer)
 
-      const result = await getDanmakuProto(1)
+      const uchunk = await createTestUniChunk()
+      const result = await getDanmakuProto(uchunk, 1)
       expect(result.success).toBe(false)
     })
   })

--- a/packages/danmaku-provider/src/providers/bilibili/api.ts
+++ b/packages/danmaku-provider/src/providers/bilibili/api.ts
@@ -1,13 +1,11 @@
-import {
-  type CommentEntity,
-  zGenericXml,
-} from '@danmaku-anywhere/danmaku-converter'
+import { BiliGrpcAdapter, BiliXmlAdapter } from '@dan-uni/dan-any/adapters'
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import { err, ok, type Result } from '@danmaku-anywhere/result'
+import { z } from 'zod'
 import type { DanmakuProviderError } from '../../exceptions/BaseError.js'
 import { HttpException } from '../../exceptions/HttpException.js'
 import { InputError } from '../../exceptions/InputError.js'
 import { ResponseParseException } from '../../exceptions/ResponseParseException.js'
-import { bilibili as bilibiliProto } from '../../protobuf/protobuf.js'
 import { createThrottle } from '../utils/createThrottle.js'
 import { fetchData } from '../utils/fetchData.js'
 import type {
@@ -19,7 +17,6 @@ import type {
 } from './schema.js'
 import {
   zBilibiliBangumiInfoResponse,
-  zBilibiliCommentProto,
   zBilibiliSearchResponse,
   zBilibiliUserInfo,
 } from './schema.js'
@@ -118,8 +115,9 @@ export const getBangumiInfo = async ({
 }
 
 export const getDanmakuXml = async (
+  uchunk: UniChunk,
   cid: number
-): Promise<Result<CommentEntity[], DanmakuProviderError>> => {
+): Promise<Result<UniChunk, DanmakuProviderError>> => {
   await throttle()
 
   const url = `${BILIBILI_API_URL_ROOT}/x/v1/dm/list.so?oid=${cid}`
@@ -127,7 +125,9 @@ export const getDanmakuXml = async (
   const response = await fetchData({
     url,
     responseType: 'text',
-    responseSchema: zGenericXml,
+    responseSchema: z
+      .string()
+      .transform(async (xml) => await uchunk.import(BiliXmlAdapter(xml))),
   })
 
   if (!response.success) return response
@@ -136,15 +136,16 @@ export const getDanmakuXml = async (
 }
 
 export async function* getDanmakuProtoSegment(
+  uchunk: UniChunk,
   oid: number,
   pid?: number
-): AsyncGenerator<Result<CommentEntity[], DanmakuProviderError>> {
-  const MAX_SEGMENT = 100 // arbitrary number
+): AsyncGenerator<Result<UniChunk, DanmakuProviderError>> {
+  const MAX_SEGMENT = 100
 
   let segmentIndex = 1
 
   const params = new URLSearchParams({
-    type: '1', // 1 for video, 2 for comics
+    type: '1',
     oid: oid.toString(),
     segment_index: segmentIndex.toString(),
   })
@@ -182,30 +183,13 @@ export async function* getDanmakuProtoSegment(
 
       const buffer = await response.arrayBuffer()
 
-      let parsed: bilibiliProto.community.service.dm.v1.IDmSegMobileReply
-
       try {
-        parsed = bilibiliProto.community.service.dm.v1.DmSegMobileReply.decode(
-          new Uint8Array(buffer)
-        )
+        await uchunk.import(BiliGrpcAdapter(buffer))
+        yield ok(uchunk)
       } catch (e) {
         yield err(
           new ResponseParseException({
             message: 'Failed to decode protobuf',
-            cause: e,
-            url,
-            responseBody: 'protobuf',
-          })
-        )
-        return
-      }
-
-      try {
-        const comments = await zBilibiliCommentProto.parseAsync(parsed)
-        yield ok(comments.elems)
-      } catch (e) {
-        yield err(
-          new ResponseParseException({
             cause: e,
             url,
             responseBody: 'protobuf',
@@ -233,35 +217,18 @@ export async function* getDanmakuProtoSegment(
   }
 }
 
-// Evenly pick a sample from an array up to a limit
-const sample = <T>(arr: T[], limit: number): T[] => {
-  if (arr.length <= limit) return arr
-
-  const sample: T[] = []
-  const step = Math.ceil(arr.length / limit)
-
-  for (let i = 0; i < arr.length; i += step) {
-    sample.push(arr[i])
-  }
-
-  return sample
-}
-
-// oid = cid, pid = avids
 export const getDanmakuProto = async (
+  uchunk: UniChunk,
   oid: number,
-  pid?: number,
-  { limitPerMinute = 1000 }: { limitPerMinute?: number } = {}
-): Promise<Result<CommentEntity[], DanmakuProviderError>> => {
-  const segments = getDanmakuProtoSegment(oid, pid)
-  const comments: CommentEntity[][] = []
+  pid?: number
+): Promise<Result<UniChunk, DanmakuProviderError>> => {
+  const segments = getDanmakuProtoSegment(uchunk, oid, pid)
 
   for await (const result of segments) {
     if (!result.success) {
       return result
     }
-    comments.push(sample(result.data, limitPerMinute * 6)) // each segment is 6 minutes
   }
 
-  return ok(comments.flat())
+  return ok(uchunk)
 }

--- a/packages/danmaku-provider/src/providers/ddp/api.test.ts
+++ b/packages/danmaku-provider/src/providers/ddp/api.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ResponseParseException } from '../../exceptions/ResponseParseException'
-import { mockFetchResponse } from '../utils/testUtils'
+import { createTestUniChunk, mockFetchResponse } from '../utils/testUtils'
 import {
   commentGetComment,
   getBangumiAnime,
@@ -107,13 +107,12 @@ describe('DanDanPlay API', () => {
 
   describe('commentGetComment', () => {
     it('should return error on unexpected data', async () => {
-      mockFetchResponse({})
+      mockFetchResponse()
 
-      const result = await commentGetComment(1)
+      const uchunk = await createTestUniChunk()
+      const result = await commentGetComment(uchunk, 1)
       expect(result.success).toBe(false)
       if (!result.success) {
-        // Since commentGetComment doesn't throw DDP exception (it just returns comments),
-        // but if parsing fails, it returns ResponseParseException.
         expect(result.error).toBeInstanceOf(ResponseParseException)
       }
     })

--- a/packages/danmaku-provider/src/providers/ddp/api.ts
+++ b/packages/danmaku-provider/src/providers/ddp/api.ts
@@ -1,3 +1,5 @@
+import { DdplayAdapter } from '@dan-uni/dan-any/adapters'
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
   commentOptionsToString,
   parseCommentEntityP,
@@ -167,22 +169,30 @@ export const searchSearchEpisodes = async (
 }
 
 export const commentGetComment = async (
+  uchunk: UniChunk,
   episodeId: number,
   query: GetCommentQuery = {},
   context?: DanDanPlayQueryContext
-): Promise<Result<CommentData[], DanmakuProviderError>> => {
+): Promise<Result<UniChunk, DanmakuProviderError>> => {
   const result = await fetchDanDanPlay(
     {
       path: `/v2/comment/${episodeId.toString()}`,
       query,
-      responseSchema: zCommentResponseV2,
+      responseSchema: zCommentResponseV2.transform(async (data) => {
+        const normalizedData = {
+          count: data.count,
+          comments: data.comments.map((c) => ({ ...c, cid: c.cid ?? 0 })),
+        }
+        await uchunk.import(DdplayAdapter(normalizedData))
+        return uchunk
+      }),
       requestSchema: { query: zGetCommentQuery },
     },
     context
   )
 
   if (!result.success) return result
-  return ok(result.data.comments)
+  return result
 }
 
 export const commentSendComment = async (
@@ -233,21 +243,22 @@ export const commentGetExtComment = async (
 }
 
 export const commentGetCommentManualWithRelated = async (
+  uchunk: UniChunk,
   episodeId: number,
   params: GetCommentQuery = {},
   context?: DanDanPlayQueryContext
-): Promise<Result<CommentData[], DanmakuProviderError>> => {
+): Promise<Result<UniChunk, DanmakuProviderError>> => {
   const commentsResult = await commentGetComment(
+    uchunk,
     episodeId,
     {
       ...params,
-      withRelated: false, // disable this flag to fetch related comments manually
+      withRelated: false,
     },
     context
   )
 
   if (!commentsResult.success) return commentsResult
-  const comments = commentsResult.data
 
   if (params.withRelated) {
     try {
@@ -264,8 +275,7 @@ export const commentGetCommentManualWithRelated = async (
           )
 
           if (additionalCommentsResult.success) {
-            additionalCommentsResult.data.forEach((comment) => {
-              // if the shift is not 0, we need to adjust the time of the comments
+            for (const comment of additionalCommentsResult.data) {
               if (entry.shift !== 0) {
                 const options = parseCommentEntityP(comment.p)
                 if (options) {
@@ -273,9 +283,20 @@ export const commentGetCommentManualWithRelated = async (
                   comment.p = commentOptionsToString(options)
                 }
               }
+            }
 
-              comments.push(comment)
-            })
+            const tempChunk = await uchunk.$db.makeChunk()
+            await tempChunk.import(
+              DdplayAdapter({
+                comments: additionalCommentsResult.data.map((c) => ({
+                  ...c,
+                  cid: c.cid ?? 0,
+                })),
+                count: additionalCommentsResult.data.length,
+              })
+            )
+            const danmakus = await tempChunk.$danmakus
+            await uchunk.upsertDanmakus(danmakus)
           }
         }
       }
@@ -284,7 +305,7 @@ export const commentGetCommentManualWithRelated = async (
     }
   }
 
-  return ok(comments)
+  return ok(uchunk)
 }
 
 export const relatedGetRelated = async (

--- a/packages/danmaku-provider/src/providers/macCms/api.ts
+++ b/packages/danmaku-provider/src/providers/macCms/api.ts
@@ -1,5 +1,5 @@
 import { ok, type Result } from '@danmaku-anywhere/result'
-import type { ZodType, z } from 'zod'
+import type { ZodType } from 'zod'
 import type { DanmakuProviderError } from '../../exceptions/BaseError.js'
 import { fetchData } from '../utils/fetchData.js'
 import { zDanmuIcuDanmaku } from './danmuIcu.js'
@@ -40,7 +40,7 @@ export const fetchDanmuIcuComments = async (
   baseUrl: string,
   videoUrl: string,
   stripColor: boolean
-): Promise<Result<z.infer<typeof zDanmuIcuDanmaku>, DanmakuProviderError>> => {
+): Promise<Result<Array<{ p: string; m: string }>, DanmakuProviderError>> => {
   const url = withQuery(baseUrl, '/', {
     ac: 'dm',
     url: videoUrl,
@@ -51,7 +51,7 @@ export const fetchDanmuIcuComments = async (
     return commentsResult
   }
 
-  const comments = commentsResult.data
+  const comments = commentsResult.data.danmuku
 
   if (stripColor) {
     // set color to white if stripColor is true

--- a/packages/danmaku-provider/src/providers/macCms/danmuIcu.test.ts
+++ b/packages/danmaku-provider/src/providers/macCms/danmuIcu.test.ts
@@ -5,8 +5,22 @@ import data from './danmuIcu.json' with { type: 'json' }
 describe('Parse danmuIcu', () => {
   test('should parse correctly', () => {
     const result = zDanmuIcuDanmaku.parse(data)
-    expect(result).toHaveLength(3600)
-    expect(result[0].m).toBe('我需要一个吐槽役的角色出场')
-    expect(result[0].p).toBe('1158.293,1,8811256')
+
+    // Verify structure
+    expect(result).toHaveProperty('code')
+    expect(result).toHaveProperty('name')
+    expect(result).toHaveProperty('danum')
+    expect(result).toHaveProperty('danmuku')
+
+    // Verify parsed danmuku array
+    expect(Array.isArray(result.danmuku)).toBe(true)
+    expect(result.danmuku.length).toBeGreaterThan(0)
+
+    // Verify first comment is correctly transformed
+    const firstComment = result.danmuku.find(
+      (c) => c.m === '我需要一个吐槽役的角色出场'
+    )
+    expect(firstComment).toBeDefined()
+    expect(firstComment?.p).toBe('1158.293,1,8811256')
   })
 })

--- a/packages/danmaku-provider/src/providers/macCms/danmuIcu.ts
+++ b/packages/danmaku-provider/src/providers/macCms/danmuIcu.ts
@@ -1,7 +1,6 @@
 import { VodAdapter } from '@dan-uni/dan-any/adapters'
 import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
-  type CommentEntity,
   CommentMode,
   hexToRgb888,
   zHex,
@@ -10,43 +9,39 @@ import {
 import { ok, type Result } from '@danmaku-anywhere/result'
 import { z } from 'zod'
 
-export const zDanmuIcuDanmaku = z
-  .object({
-    code: z.number(),
-    name: z.string(),
-    danum: z.number(),
-    danmuku: z.array(
-      z
-        .tuple([
-          zTime,
-          z.string().transform((mode) => {
-            switch (mode) {
-              case 'top':
-                return CommentMode.top
-              case 'bottom':
-                return CommentMode.bottom
-              default:
-                return CommentMode.rtl
-            }
-          }),
-          zHex,
-          z.string().default(''),
-          z.string(),
-        ])
-        .rest(z.any())
-        .transform((data) => {
-          const [time, mode, color, , text] = data
-
-          return {
-            p: `${time},${mode},${hexToRgb888(color)}`,
-            m: text,
+export const zDanmuIcuDanmaku = z.object({
+  code: z.number(),
+  name: z.string(),
+  danum: z.number(),
+  danmuku: z.array(
+    z
+      .tuple([
+        zTime,
+        z.string().transform((mode) => {
+          switch (mode) {
+            case 'top':
+              return CommentMode.top
+            case 'bottom':
+              return CommentMode.bottom
+            default:
+              return CommentMode.rtl
           }
-        })
-    ),
-  })
-  .transform((data): CommentEntity[] => {
-    return data.danmuku.slice(-data.danum)
-  })
+        }),
+        zHex,
+        z.string().default(''),
+        z.string(),
+      ])
+      .rest(z.any())
+      .transform((data) => {
+        const [time, mode, color, , text] = data
+
+        return {
+          p: `${time},${mode},${hexToRgb888(color)}`,
+          m: text,
+        }
+      })
+  ),
+})
 
 export async function getDanmakuFromDanmuIcu(
   uchunk: UniChunk,

--- a/packages/danmaku-provider/src/providers/macCms/danmuIcu.ts
+++ b/packages/danmaku-provider/src/providers/macCms/danmuIcu.ts
@@ -1,3 +1,5 @@
+import { VodAdapter } from '@dan-uni/dan-any/adapters'
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import {
   type CommentEntity,
   CommentMode,
@@ -5,6 +7,7 @@ import {
   zHex,
   zTime,
 } from '@danmaku-anywhere/danmaku-converter'
+import { ok, type Result } from '@danmaku-anywhere/result'
 import { z } from 'zod'
 
 export const zDanmuIcuDanmaku = z
@@ -15,7 +18,7 @@ export const zDanmuIcuDanmaku = z
     danmuku: z.array(
       z
         .tuple([
-          zTime, // time
+          zTime,
           z.string().transform((mode) => {
             switch (mode) {
               case 'top':
@@ -25,10 +28,10 @@ export const zDanmuIcuDanmaku = z
               default:
                 return CommentMode.rtl
             }
-          }), // mode
-          zHex, // color
-          z.string().prefault(''), // ?
-          z.string(), // text
+          }),
+          zHex,
+          z.string().default(''),
+          z.string(),
         ])
         .rest(z.any())
         .transform((data) => {
@@ -42,6 +45,30 @@ export const zDanmuIcuDanmaku = z
     ),
   })
   .transform((data): CommentEntity[] => {
-    // the danmaku list often has extra items in the beginning, use slice to remove them
     return data.danmuku.slice(-data.danum)
   })
+
+export async function getDanmakuFromDanmuIcu(
+  uchunk: UniChunk,
+  videoId: string,
+  domain?: string
+): Promise<Result<UniChunk, Error>> {
+  try {
+    const url = `https://danmu.icu/api/v1/danmaku/${videoId}`
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      return { success: false, error: new Error(`HTTP ${response.status}`) }
+    }
+
+    const json = await response.json()
+    await uchunk.import(VodAdapter(json, videoId, domain))
+
+    return ok(uchunk)
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e : new Error(String(e)),
+    }
+  }
+}

--- a/packages/danmaku-provider/src/providers/tencent/api.test.ts
+++ b/packages/danmaku-provider/src/providers/tencent/api.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ResponseParseException } from '../../exceptions/ResponseParseException'
-import { mockFetchResponse } from '../utils/testUtils'
+import { createTestUniChunk, mockFetchResponse } from '../utils/testUtils'
 
 import * as tencentApi from './api'
 import { TencentApiException } from './exceptions'
@@ -148,22 +148,23 @@ describe('Tencent', () => {
         } as any
       })
 
+      const uchunk = await createTestUniChunk()
       const generator = tencentApi.getDanmakuGenerator(
+        uchunk,
         'm00253deqqo',
         segmentData
       )
 
+      let resultCount = 0
       for await (const commentsResult of generator) {
         expect(commentsResult.success).toBe(true)
         if (commentsResult.success) {
-          expect(commentsResult.data).toHaveLength(
-            mockData.mockBarrage600000Response.barrage_list.length
-          )
+          resultCount++
         }
       }
 
+      expect(resultCount).toBe(totalSegments)
       expect(fetch).toHaveBeenCalledTimes(totalSegments)
-      // should call all segments
       expect(fetch).toHaveBeenNthCalledWith(
         1,
         'https://dm.video.qq.com/barrage/segment/m00253deqqo/t/v1/0/30000',
@@ -183,7 +184,9 @@ describe('Tencent', () => {
 
       mockFetchResponse(new TextEncoder().encode('invalid').buffer)
 
+      const uchunk = await createTestUniChunk()
       const generator = tencentApi.getDanmakuGenerator(
+        uchunk,
         'm00253deqqo',
         segmentData
       )

--- a/packages/danmaku-provider/src/providers/tencent/api.ts
+++ b/packages/danmaku-provider/src/providers/tencent/api.ts
@@ -1,5 +1,7 @@
-import type { CommentEntity } from '@danmaku-anywhere/danmaku-converter'
+import { TencentAdapter } from '@dan-uni/dan-any/adapters'
+import type { UniChunk } from '@dan-uni/dan-any/core'
 import { ok, type Result } from '@danmaku-anywhere/result'
+import { z } from 'zod'
 import type { DanmakuProviderError } from '../../exceptions/BaseError.js'
 import { createThrottle } from '../utils/createThrottle.js'
 import { fetchData } from '../utils/fetchData.js'
@@ -13,7 +15,6 @@ import type {
   TencentVideoSeason,
 } from './schema.js'
 import {
-  zTencentComment,
   zTencentCommentSegment,
   zTencentEpisodeListResponse,
   zTencentPageDetailResponse,
@@ -239,9 +240,10 @@ export const getDanmakuSegments = async (
 }
 
 export async function* getDanmakuGenerator(
+  uchunk: UniChunk,
   vid: string,
   segmentData: TencentCommentSegmentData
-): AsyncGenerator<Result<CommentEntity[], DanmakuProviderError>> {
+): AsyncGenerator<Result<UniChunk, DanmakuProviderError>> {
   const segments = Object.values(segmentData.segment_index)
 
   if (segmentData.segment_span === 0) return
@@ -253,32 +255,35 @@ export async function* getDanmakuGenerator(
 
     const result = await fetchData({
       url,
-      responseSchema: zTencentComment,
+      responseSchema: z
+        .object({ barrage_list: z.array(z.any()) })
+        .transform(async (d) => {
+          await uchunk.import(TencentAdapter(d, vid))
+          return uchunk
+        }),
     })
 
     if (!result.success) {
       yield result
     } else {
-      yield ok(result.data.barrage_list)
+      yield result
     }
   }
 }
 
 export const getDanmaku = async (
+  uchunk: UniChunk,
   vid: string
-): Promise<Result<CommentEntity[], DanmakuProviderError>> => {
+): Promise<Result<UniChunk, DanmakuProviderError>> => {
   const segmentDataResult = await getDanmakuSegments(vid)
 
   if (!segmentDataResult.success) return segmentDataResult
 
-  const generator = getDanmakuGenerator(vid, segmentDataResult.data)
-
-  const comments: CommentEntity[] = []
+  const generator = getDanmakuGenerator(uchunk, vid, segmentDataResult.data)
 
   for await (const segmentResult of generator) {
     if (!segmentResult.success) return segmentResult
-    comments.push(...segmentResult.data)
   }
 
-  return ok(comments)
+  return ok(uchunk)
 }

--- a/packages/danmaku-provider/src/providers/utils/testUtils.ts
+++ b/packages/danmaku-provider/src/providers/utils/testUtils.ts
@@ -1,3 +1,4 @@
+import { UniDB } from '@dan-uni/dan-any/core/main/pure'
 import { vi } from 'vitest'
 
 const asText = (data: unknown) => {
@@ -44,4 +45,10 @@ export const createFetchOverride = () => {
       })
     )
   }
+}
+
+export async function createTestUniChunk() {
+  const udb = new UniDB()
+  const initedUdb = udb.init()
+  return initedUdb.makeChunk({})
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,13 +188,13 @@ importers:
         version: 10.53.1
       better-auth:
         specifier: ^1.4.18
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)
+        version: 0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
       hono:
         specifier: ^4.10.6
         version: 4.12.21
@@ -346,7 +346,7 @@ importers:
         version: 0.5.0
       better-auth:
         specifier: ^1.4.18
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0)))
       clarity-js:
         specifier: ^0.8.41
         version: 0.8.64
@@ -468,6 +468,9 @@ importers:
 
   packages/danmaku-converter:
     dependencies:
+      '@dan-uni/dan-any':
+        specifier: ^2.2.7
+        version: 2.2.7(@opentelemetry/api@1.9.1)
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -494,6 +497,9 @@ importers:
 
   packages/danmaku-provider:
     dependencies:
+      '@dan-uni/dan-any':
+        specifier: ^2.2.7
+        version: 2.2.7(@opentelemetry/api@1.9.1)
       '@danmaku-anywhere/danmaku-converter':
         specifier: workspace:*
         version: link:../danmaku-converter
@@ -716,6 +722,7 @@ packages:
   '@angular/animations@21.2.14':
     resolution: {integrity: sha512-9WLnsJE0xqtd1rVtHMvsAUxFy3OdPks4bdmUIqyw23X/je7ytUALAGWNadffcZBwRpa1A6TUnLr9X4+Draz3kw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    deprecated: '@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.'
     peerDependencies:
       '@angular/core': 21.2.14
 
@@ -1284,6 +1291,9 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@dan-uni/dan-any@2.2.7':
+    resolution: {integrity: sha512-jIrix9oY9ulI8L3sgklZVQAT9qrm8PzWYYgTMAgReUQiMC2ENcnoVKN5V1du7Amkap0fvYmEK+V3AaV0qpxrcQ==}
+
   '@devicefarmer/adbkit-logcat@2.1.3':
     resolution: {integrity: sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==}
     engines: {node: '>= 4'}
@@ -1321,6 +1331,14 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@electric-sql/pglite-tools@0.4.3':
+    resolution: {integrity: sha512-KFpstSxcTxq+kzY0TCToEC7yHuAXYMcGNeTCSEnivugTVrW+UqvjOhuFxauXctZEFSGPW0Biik6lf0ery21U1Q==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.5.3
+
+  '@electric-sql/pglite@0.5.3':
+    resolution: {integrity: sha512-iTTYbA5Uesrl+N7zss0J5LopT7KE4j9aymYo+EZZh+rZbARQCUQOs+n2pay64JRUpc3fCkpfrniTNJnvYzOE+g==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -3223,6 +3241,9 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -4736,6 +4757,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4862,6 +4886,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -5542,6 +5569,122 @@ packages:
       sqlite3:
         optional: true
 
+  drizzle-orm@1.0.0-rc.4-5d5b77c:
+    resolution: {integrity: sha512-Oq9W4B11PracWY9cuCLTFT+JA5kXqR6rBmWcM8oh0xwLgCviVl9wh6ZuWX7Zpv1Jir/8W+M37syvjSYtj1f5iA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@effect/sql-pg': '>=4.0.0-beta.58 || >=4.0.0'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@sinclair/typebox': '>=0.34.8'
+      '@sqlitecloud/drivers': '>=1.0.653'
+      '@tidbcloud/serverless': '*'
+      '@tursodatabase/database': '>=0.2.1'
+      '@tursodatabase/database-common': '>=0.2.1'
+      '@tursodatabase/database-wasm': '>=0.2.1'
+      '@types/better-sqlite3': '*'
+      '@types/mssql': ^9.1.4
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      arktype: '>=2.0.0'
+      better-sqlite3: '>=9.3.0'
+      bun-types: '*'
+      effect: '>=4.0.0-beta.58 || >=4.0.0'
+      expo-sqlite: '>=14.0.0'
+      mssql: ^11.0.1
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+      typebox: '>=1.0.0'
+      valibot: '>=1.0.0-beta.7'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@effect/sql-pg':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      '@sqlitecloud/drivers':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@tursodatabase/database':
+        optional: true
+      '@tursodatabase/database-common':
+        optional: true
+      '@tursodatabase/database-wasm':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/mssql':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      arktype:
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      effect:
+        optional: true
+      expo-sqlite:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      typebox:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -5822,8 +5965,15 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@4.5.6:
     resolution: {integrity: sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==}
+    hasBin: true
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
     hasBin: true
 
   fastq@1.20.1:
@@ -6311,6 +6461,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+
   is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
 
@@ -6391,6 +6544,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -7173,6 +7329,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.6.0:
+    resolution: {integrity: sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -7884,6 +8044,9 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
 
@@ -8470,6 +8633,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
@@ -9110,12 +9277,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))':
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
 
   '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
@@ -9308,6 +9475,54 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dan-uni/dan-any@2.2.7(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+      '@electric-sql/pglite': 0.5.3
+      '@electric-sql/pglite-tools': 0.4.3(@electric-sql/pglite@0.5.3)
+      '@noble/hashes': 2.2.0
+      drizzle-orm: 1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(zod@4.4.3)
+      fast-xml-builder: 1.2.0
+      fast-xml-parser: 5.9.3
+      json-bigint: 1.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@effect/sql-pg'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@sinclair/typebox'
+      - '@sqlitecloud/drivers'
+      - '@tidbcloud/serverless'
+      - '@tursodatabase/database'
+      - '@tursodatabase/database-common'
+      - '@tursodatabase/database-wasm'
+      - '@types/better-sqlite3'
+      - '@types/mssql'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - arktype
+      - better-sqlite3
+      - bun-types
+      - effect
+      - expo-sqlite
+      - mssql
+      - mysql2
+      - pg
+      - postgres
+      - sql.js
+      - sqlite3
+      - typebox
+      - valibot
+
   '@devicefarmer/adbkit-logcat@2.1.3': {}
 
   '@devicefarmer/adbkit-monkey@1.2.1': {}
@@ -9350,6 +9565,12 @@ snapshots:
       tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@electric-sql/pglite-tools@0.4.3(@electric-sql/pglite@0.5.3)':
+    dependencies:
+      '@electric-sql/pglite': 0.5.3
+
+  '@electric-sql/pglite@0.5.3': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -10770,6 +10991,8 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
+  '@nodable/entities@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -12026,6 +12249,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  anynum@1.0.1: {}
+
   argparse@2.0.1: {}
 
   array-differ@4.0.0: {}
@@ -12077,10 +12302,10 @@ snapshots:
       postcss-media-query-parser: 0.2.3
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))
       '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -12098,7 +12323,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
@@ -12106,10 +12331,10 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.0(react@19.2.6))(react@19.2.6)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17))
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))
       '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -12127,7 +12352,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
       react: 19.2.6
       react-dom: 19.2.0(react@19.2.6)
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.22.4)(yaml@2.9.0))
@@ -12147,6 +12372,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bignumber.js@9.3.1: {}
 
   blake3-wasm@2.1.5: {}
 
@@ -12774,10 +13001,17 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.3
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17):
     optionalDependencies:
+      '@electric-sql/pglite': 0.5.3
       '@opentelemetry/api': 1.9.1
       kysely: 0.28.17
+
+  drizzle-orm@1.0.0-rc.4-5d5b77c(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.1)(zod@4.4.3):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.5.3
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -13198,9 +13432,23 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.6.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@4.5.6:
     dependencies:
       strnum: 1.1.2
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.0
+      strnum: 2.4.1
+      xml-naming: 0.1.0
 
   fastq@1.20.1:
     dependencies:
@@ -13693,6 +13941,8 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  is-unsafe@1.0.1: {}
+
   is-utf8@0.2.1: {}
 
   is-wsl@2.2.0:
@@ -13791,6 +14041,10 @@ snapshots:
       - supports-color
 
   jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -14838,6 +15092,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.6.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -15614,6 +15870,10 @@ snapshots:
 
   strnum@1.1.2: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   stubborn-fs@2.0.0:
     dependencies:
       stubborn-utils: 1.0.2
@@ -16146,6 +16406,8 @@ snapshots:
       sax: 1.6.0
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xml2js@0.6.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.1
         version: 2.0.47(zod@4.4.3)
+      '@dan-uni/dan-any':
+        specifier: ^2.2.7
+        version: 2.2.7(@opentelemetry/api@1.9.1)
       '@danmaku-anywhere/danmaku-converter':
         specifier: workspace:*
         version: link:../danmaku-converter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,8 +252,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.47(zod@4.4.3)
       '@dan-uni/dan-any':
-        specifier: ^2.2.7
-        version: 2.2.7(@opentelemetry/api@1.9.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@opentelemetry/api@1.9.1)
       '@danmaku-anywhere/danmaku-converter':
         specifier: workspace:*
         version: link:../danmaku-converter
@@ -472,8 +472,8 @@ importers:
   packages/danmaku-converter:
     dependencies:
       '@dan-uni/dan-any':
-        specifier: ^2.2.7
-        version: 2.2.7(@opentelemetry/api@1.9.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@opentelemetry/api@1.9.1)
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -501,8 +501,8 @@ importers:
   packages/danmaku-provider:
     dependencies:
       '@dan-uni/dan-any':
-        specifier: ^2.2.7
-        version: 2.2.7(@opentelemetry/api@1.9.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@opentelemetry/api@1.9.1)
       '@danmaku-anywhere/danmaku-converter':
         specifier: workspace:*
         version: link:../danmaku-converter
@@ -1152,6 +1152,9 @@ packages:
   '@bufbuild/protobuf@2.12.0':
     resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
 
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
@@ -1294,8 +1297,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@dan-uni/dan-any@2.2.7':
-    resolution: {integrity: sha512-jIrix9oY9ulI8L3sgklZVQAT9qrm8PzWYYgTMAgReUQiMC2ENcnoVKN5V1du7Amkap0fvYmEK+V3AaV0qpxrcQ==}
+  '@dan-uni/dan-any@2.3.0':
+    resolution: {integrity: sha512-o6qQBZKSKja6uEe5sizyBqmxcyZgev7aw+VgLZBW/rJH29fFCxx8KHfxts+A5S/Cl/Bk9l0Q4G1IHkSC/jT+IQ==}
 
   '@devicefarmer/adbkit-logcat@2.1.3':
     resolution: {integrity: sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==}
@@ -9362,6 +9365,8 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.0': {}
 
+  '@bufbuild/protobuf@2.12.1': {}
+
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
@@ -9478,9 +9483,9 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@dan-uni/dan-any@2.2.7(@opentelemetry/api@1.9.1)':
+  '@dan-uni/dan-any@2.3.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@bufbuild/protobuf': 2.12.0
+      '@bufbuild/protobuf': 2.12.1
       '@electric-sql/pglite': 0.5.3
       '@electric-sql/pglite-tools': 0.4.3(@electric-sql/pglite@0.5.3)
       '@noble/hashes': 2.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,4 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - '@mr-quin/dango'
   - '@mr-quin/dango-manifests'
+  - '@dan-uni/dan-any'

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "dan-any": {
+      "source": "ani-uni/dan-any",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/dan-any/SKILL.md",
+      "computedHash": "6317e028c1e45f6218dc08ab71d8c3d0fbb32e1a833e9b4297452234aa202869"
+    }
+  }
+}


### PR DESCRIPTION
1. 更新了dexie数据库的episode部分，将弹幕数组从episode独立出来
2. 弹幕现在通过dan-any的格式进行存储(在之后的弹幕导入中，其可以减少弹幕类型转换带来的原始信息损失)
3. v4格式的弹幕为Ddplay格式弹幕的兼容型，现已支持自动迁移
4. 现在支持导入所有dan-any支持的弹幕格式导入

已测试：
1. 导入弹幕功能
2. 弹幕查看功能
3. 弹幕导出功能
4. 弹幕渲染功能

后续规划：
1. 弹幕引擎相关：参考 https://github.com/zhw2590582/ArtPlayer/pull/1043 的功能描述
2. 优化弹幕导出功能
3. 另打算建立一个弹幕共享平台，希望可以接入，让每一个用户尝试获取新的弹幕后可以共享(这个主要是面向例如当前bili上有一些传资源有弹幕，但视频本身可能一段时间后下架，导致弹幕资源丢失的场景)

---

这边只测试了离线功能能够正常使用，联网搜索不知道为什么 `no manifest registered with id: {xxx}`
希望能帮忙确认一下是不是这个pr的问题