### PR TITLE
(app) preload host libwayland in the release-manager AppImage [DA-657]

### DIFF
--- a/app/release-manager/AGENTS.md
+++ b/app/release-manager/AGENTS.md
@@ -44,6 +44,13 @@ unauthenticated requests suffice.
   `NO_STRIP=1` for `tauri build`. linuxdeploy bundles an older `strip` that
   cannot parse that section and fails otherwise. The CI runner (ubuntu-22.04)
   does not need this.
+- Host webkit vs bundled: the AppImage bundles the ubuntu-22.04 webkit and
+  libwayland. On a much newer host the bundled libwayland can't negotiate EGL
+  with the host compositor/Mesa, so the window fails to start. `main.rs`
+  preloads the host libwayland and re-execs once (only when launched from the
+  AppImage) to work around it. The bundled webkit still renders in software on
+  newer GPUs, so it can feel sluggish; the real fix is to use the host webkit
+  (ship rpm/deb, or a non-bundling AppImage), not done in v1.
 
 ## How to run
 

--- a/app/release-manager/src-tauri/src/main.rs
+++ b/app/release-manager/src-tauri/src/main.rs
@@ -1,5 +1,64 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    prefer_host_wayland();
+
     release_manager_lib::run()
+}
+
+// The AppImage bundles an older libwayland than the host it runs on, and that
+// stale client can't negotiate EGL with a newer compositor/Mesa, so the window
+// fails to start (blank screen, EGL_BAD_PARAMETER). When launched from the
+// AppImage, preload the host's libwayland and re-exec once so the host libs win.
+// LD_PRELOAD only takes effect at process start, hence the re-exec.
+#[cfg(target_os = "linux")]
+fn prefer_host_wayland() {
+    use std::os::unix::process::CommandExt;
+
+    // Only inside the AppImage, and only once (guard against an exec loop).
+    if std::env::var_os("APPDIR").is_none() || std::env::var_os("RM_HOST_WAYLAND").is_some() {
+        return;
+    }
+
+    let libs = [
+        "libwayland-client.so.0",
+        "libwayland-egl.so.1",
+        "libwayland-cursor.so.0",
+        "libwayland-server.so.0",
+    ];
+    let dirs = ["/usr/lib64", "/usr/lib/x86_64-linux-gnu", "/usr/lib"];
+
+    let mut preload: Vec<String> = Vec::new();
+    for lib in libs {
+        for dir in dirs {
+            let path = format!("{dir}/{lib}");
+            if std::path::Path::new(&path).exists() {
+                preload.push(path);
+                break;
+            }
+        }
+    }
+    if preload.is_empty() {
+        return;
+    }
+
+    if let Some(existing) = std::env::var_os("LD_PRELOAD") {
+        if !existing.is_empty() {
+            preload.insert(0, existing.to_string_lossy().into_owned());
+        }
+    }
+
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+
+    std::env::set_var("LD_PRELOAD", preload.join(" "));
+    std::env::set_var("RM_HOST_WAYLAND", "1");
+
+    // exec replaces this process; it returns only on failure, in which case we
+    // fall through and let the app try to start as before.
+    let _ = std::process::Command::new(exe)
+        .args(std::env::args_os().skip(1))
+        .exec();
 }


### PR DESCRIPTION
## Summary
- Fixes the release-manager AppImage coming up as a **blank white window** on newer Linux hosts (reproduced on Fedora 44, Wayland, Intel Arc / Mesa 26).
- Root cause: the AppImage bundles ubuntu-22.04's `libwayland-*`. On a much newer host the stale `libwayland-client`/`libwayland-egl` can't negotiate EGL with the host compositor/Mesa, so the WebKit web process aborts at `Could not create default EGL display: EGL_BAD_PARAMETER`. No `WEBKIT_*` flag helps because the failure is below WebKit, in Wayland/EGL init.
- Fix: when launched from the AppImage, `main.rs` preloads the host's `libwayland` and re-execs once (LD_PRELOAD only applies at process start). Guarded to run only inside the AppImage (`APPDIR` set) and only once (`RM_HOST_WAYLAND`). Falls through to normal startup if no host libs are found.

## Scope / not fixed here
- This makes the AppImage **launch on its own** (no manual `LD_PRELOAD`). It does **not** fix performance: the bundled ubuntu webkit still renders in software on new GPUs, so it can feel sluggish. The real fix is to use the **host** webkit (ship rpm/deb, or a non-bundling AppImage); deferred past v1 and noted in `AGENTS.md`.
- Code-only change: no CI or signing changes, so the updater signature flow is untouched.

## Test plan
- `cargo check -p release-manager` clean.
- Confirmed manually that `LD_PRELOAD=/usr/lib64/libwayland-client.so.0 <appimage>` renders (this PR automates that).
- [ ] After merge, re-cut `release-manager-v0.1.0` and confirm the AppImage launches with no manual env vars on Fedora/Wayland.