### PR TITLE
(app) build a Windows NSIS installer in release CI [DA-657]

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -8,11 +8,14 @@ name: Release Manager App
 # Flow:
 #   1. Push a release-manager-v<version> tag (or run manually) -> the build job compiles,
 #      signs, and creates a DRAFT GitHub release with the AppImage, its signature, and a
-#      latest.json updater manifest. Nothing is published automatically.
+#      latest.json updater manifest. A second job adds a Windows NSIS installer to the
+#      same draft (installer only, no self-update, so no updater artifacts or signing).
+#      Nothing is published automatically.
 #   2. A human reviews and PUBLISHES that draft release.
 #   3. Publishing fires the promote job, which copies latest.json onto the floating
 #      release-manager-latest release. That is the stable URL the in-app updater polls,
-#      so updates only go live after the versioned AppImage is public.
+#      so updates only go live after the versioned AppImage is public. The Windows
+#      installer has no self-update; Windows users re-download to update.
 
 on:
   push:
@@ -76,6 +79,47 @@ jobs:
           generateReleaseNotes: true
           uploadUpdaterJson: true
           args: '--bundles appimage'
+
+  build-windows:
+    if: github.event_name != 'release'
+    # Runs after the Linux job so the draft release already exists and this job
+    # only uploads its installer to it, avoiding a concurrent create-release race.
+    needs: build
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/release-manager/src-tauri -> target
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and draft Windows installer
+        uses: tauri-apps/tauri-action@v0.6.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: app/release-manager
+          tagName: ${{ github.event_name == 'push' && 'release-manager-v__VERSION__' || '' }}
+          releaseName: ${{ github.event_name == 'push' && 'Release Manager v__VERSION__' || '' }}
+          releaseDraft: true
+          prerelease: false
+          # Installer only: no updater artifacts (disabled via the config override),
+          # so this job needs no signing key. Windows has no in-app self-update.
+          args: '--bundles nsis --config src-tauri/tauri.windows.conf.json'
 
   promote-latest:
     # When a human publishes a release-manager-v* draft, copy its updater manifest onto

--- a/app/release-manager/AGENTS.md
+++ b/app/release-manager/AGENTS.md
@@ -5,7 +5,11 @@
 A standalone, self-updating desktop app (Tauri 2) that downloads extension
 release/preview builds from the `Mr-Quin/danmaku-anywhere` GitHub releases and
 manages which cached build is the "active" unpacked folder loaded into
-`chrome://extensions`. Linux only for v1, shipped as a self-contained AppImage.
+`chrome://extensions`. Primary target is Linux, shipped as a self-updating
+AppImage. Windows also ships as an NSIS installer (installer only: no in-app
+self-update, so its build produces no updater artifacts and needs no signing
+key). The core is cross-platform; the unix-only bits (config file mode, the
+libwayland trampoline) are `cfg`-gated.
 
 It is versioned and released independently of the extension, with its own
 self-update lifecycle. It consumes the extension's `v*`/`preview-*`/`nightly-*`

--- a/app/release-manager/src-tauri/tauri.windows.conf.json
+++ b/app/release-manager/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `windows-latest` job to the release-manager workflow that builds a **Windows NSIS installer** and uploads it to the **same draft release** as the Linux AppImage.
- **Installer only** (per decision): a small config override (`src-tauri/tauri.windows.conf.json`) sets `bundle.createUpdaterArtifacts: false`, so the Windows job produces no updater artifacts, **needs no signing key**, and Windows ships **without in-app self-update** (users re-download to update).
- The Windows job `needs: build` so the Linux job creates the draft first, avoiding a concurrent create-release race.
- No app code changes: the core already compiles on Windows (unix-only bits, `config.json` mode `0600` and the libwayland trampoline, are `cfg`-gated). Windows uses **WebView2**, so the Linux bundled-webkit/EGL problems do not apply.

## Why installer-only
Windows self-update would require merging Windows into the shared `latest.json` (both platforms in one release's manifest). Skipped for now to keep CI simple; can be added later.

## Known limitation
The in-app updater UI still exists on the Windows build. Auto-check on mount swallows errors, but the manual "Check for updates" button will error there (the feed's `latest.json` has no `windows-x86_64` entry). Hiding the updater UI on Windows is a small follow-up if wanted.

## Test plan
- Workflow YAML + override JSON validated locally.
- [ ] On the next `release-manager-v*` tag, confirm the draft gets both the Linux `.AppImage` and the Windows `.exe` (NSIS) installer.
- [ ] Reviewer with Windows: run the installer, confirm the app launches (WebView2) and the Stable/Installed/Browse UI works. Not verifiable in this Linux environment.