### PR TITLE
(chore) bump @mr-quin/dango + dango-manifests to 0.8.0 [DA-662]

### DIFF
--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -60,7 +60,7 @@
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@mediapipe/tasks-vision": "0.10.18",
-    "@mr-quin/dango": "^0.7.0",
+    "@mr-quin/dango": "^0.8.0",
     "@mui/icons-material": "^9.0.1",
     "@mui/lab": "9.0.0-beta.3",
     "@mui/material": "^9.0.1",
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "2.2.1",
-    "@mr-quin/dango-manifests": "^0.7.0",
+    "@mr-quin/dango-manifests": "^0.8.0",
     "@playwright/test": "^1.59.1",
     "@types/chrome": "^0.0.326",
     "@types/d3": "^7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,8 +361,8 @@ importers:
         specifier: 0.10.18
         version: 0.10.18
       '@mr-quin/dango':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       '@mui/icons-material':
         specifier: ^9.0.1
         version: 9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.15)(react@19.2.0)
@@ -476,8 +476,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@mr-quin/dango-manifests':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.60.0
@@ -2890,11 +2890,11 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@mr-quin/dango-manifests@0.7.0':
-    resolution: {integrity: sha512-EOP8UmhE8fHdrEQlM8GmpMY3IgrnB2mAQyUVoew1WNZhWDXUHLIAZfrq4K2xtqwFLf/xyE6MiNmV5a9yNLXnBw==}
+  '@mr-quin/dango-manifests@0.8.0':
+    resolution: {integrity: sha512-xuY0Rn+/zhn1snH6C/x3tVerJAH2L7Jd0BY9LxaHEewjLgurn9M9Pdd/nTIGZ7jv5gRkmSCA7kApp3b7fAx5dg==}
 
-  '@mr-quin/dango@0.7.0':
-    resolution: {integrity: sha512-X8TOnPtAJvSvjFFbJtIBl6mESqDm+K5pz10P6Gn2iAaVynocNoo8/+0ShgkbZYrT1oI74gDBeCbynbc+dEa8mg==}
+  '@mr-quin/dango@0.8.0':
+    resolution: {integrity: sha512-NvzJ7F+fwJv2M1ffPy1M67LNe7kdiHysXxYZiLMedlna2rSPPzbNZwFxr6PdXvEg0PHS8t6Hyj+IKkhxwBZTmA==}
     engines: {node: '>=20'}
 
   '@mr-quin/danmu@0.20.0-rc.4':
@@ -10563,9 +10563,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mr-quin/dango-manifests@0.7.0': {}
+  '@mr-quin/dango-manifests@0.8.0': {}
 
-  '@mr-quin/dango@0.7.0':
+  '@mr-quin/dango@0.8.0':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
       fast-xml-parser: 4.5.6


### PR DESCRIPTION
Bumps `@mr-quin/dango` and `@mr-quin/dango-manifests` from `^0.7.0` to `^0.8.0` (both published to npm).

## What this ships
- **Engine (bundled):** dango 0.8.0 adds `Base64DecodeError` so codec/crypto helpers raise a typed engine error on invalid base64 instead of a raw `atob` DOMException. Additive, no behavior change for valid input. This is the only load-bearing change here.
- **Seed manifests (bundled):** kept in lockstep at 0.8.0.

## What this does NOT need
The live provider manifest fixes (hanjutv warm-up, mango aphone endpoint, migu POST, youku token guard) already reach users via the **proxy manifest catalog**, which serves from the dango repo `main` (`raw.githubusercontent.com/Mr-Quin/dango/main/packages/dango-manifests`). They do not depend on this extension bump.

## Risk
Low. Lockfile diff is dango-only; no transitive changes. Verified the bump introduces zero new type errors vs baseline master.

## Note
`pnpm type-check` is already red on `master` (pre-existing `SignUpForm.tsx` Zod v4 / `@hookform/resolvers` v5 mismatch, unrelated to this change).