### PR TITLE
(extension) bundle dango manifest catalog as offline fallback [DA-661]

### DIFF
--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -91,3 +91,15 @@ export function mockCatalog(
     },
   }
 }
+
+// Simulates a fully unreachable proxy: both the index and file endpoints
+// fail. Used to exercise the offline bundled-catalog fallback in
+// ManifestRegistry, which only kicks in once the index request fails.
+export function offlineCatalog(): NetworkMock {
+  return {
+    pattern: /\/manifest(\/file)?(\?|$)/,
+    respond: async (route: Route) => {
+      await route.fulfill({ status: 500, body: 'unavailable' })
+    },
+  }
+}

--- a/packages/danmaku-anywhere/e2e/setup/fixtures.ts
+++ b/packages/danmaku-anywhere/e2e/setup/fixtures.ts
@@ -9,6 +9,7 @@ import {
   attachNetworkWatcher,
   type NetworkWatcher,
 } from './network-watcher'
+import type { NetworkMock } from './profile'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // e2e/setup/fixtures.ts → ../../build
@@ -34,14 +35,21 @@ export const test = base.extend<{
   consoleErrors: () => string[]
   expectedConsoleErrors: ExpectedConsoleErrorPattern[]
   allowedNetworkOrigins: AllowedNetworkPattern[]
+  catalogMock: NetworkMock
   _assertNoUnexpectedConsoleErrors: void
   _assertNoUnmockedNetwork: void
 }>({
   // See e2e/AGENTS.md → Baselines for the opt-out / opt-in contract.
   expectedConsoleErrors: [[], { option: true }],
   allowedNetworkOrigins: [[], { option: true }],
+  // The pre-boot catalog mock. Defaults to a working catalog so every spec
+  // boots with the three built-ins seeded; override via test.use() to
+  // exercise boot against an unreachable catalog (the mock must be in place
+  // before the SW's first fetch, so this can't be swapped from inside a test
+  // body — see e2e/specs/providers/offline-fallback.spec.ts).
+  catalogMock: [mockCatalog(), { option: true }],
 
-  context: async ({ allowedNetworkOrigins }, use) => {
+  context: async ({ allowedNetworkOrigins, catalogMock }, use) => {
     const context = await chromium.launchPersistentContext('', {
       channel: 'chromium',
       args: [
@@ -56,8 +64,7 @@ export const test = base.extend<{
     )
     // Registered after the watcher so it wins (newest handler first), and
     // before the SW boots so the registry's catalog seed is mocked.
-    const catalog = mockCatalog()
-    await context.route(catalog.pattern, catalog.respond)
+    await context.route(catalogMock.pattern, catalogMock.respond)
     watchersByContext.set(context, {
       console: consoleWatcher,
       network: networkWatcher,

--- a/packages/danmaku-anywhere/e2e/specs/providers/offline-fallback.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/offline-fallback.spec.ts
@@ -1,0 +1,59 @@
+import { offlineCatalog } from '../../network/catalog'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+
+/**
+ * First-boot offline fallback: the manifest catalog proxy is unreachable
+ * (index and file endpoints both fail) on a fresh profile with an empty
+ * manifest store. ManifestRegistry seeds its bundled dango manifests instead
+ * of leaving the registry empty, so the built-in sources still appear in the
+ * Providers page catalog with no successful network round trip, and the
+ * catalog is reported as never having been checked.
+ */
+
+test.use({
+  catalogMock: offlineCatalog(),
+  // Boot's syncCatalog() and the Providers page's pending-updates query each
+  // hit the unreachable index and log their own failure; same pair allowed in
+  // e2e/specs/sources/update-recovery.spec.ts.
+  expectedConsoleErrors: [
+    'Failed to fetch manifest catalog',
+    'Error in RPC handler',
+  ],
+})
+
+test('built-in sources load from the bundled catalog when the proxy is unreachable on first boot', async ({
+  page,
+  extensionId,
+  da,
+}) => {
+  // The offline index retries once with a 1s delay before falling back to
+  // the bundle, so the manifest store fills in well after the popup would
+  // otherwise mount and query an empty registry once with no later refetch.
+  // Wait for the store directly (the RPC's ground truth) before opening the
+  // popup so the page's first query already sees the seeded catalog.
+  await expect
+    .poll(
+      async () => {
+        const stored = (await da.storage.get('local', 'manifests')) as Record<
+          string,
+          unknown
+        >
+        return Object.keys(stored ?? {}).length
+      },
+      { timeout: 10_000 }
+    )
+    .toBeGreaterThan(0)
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+
+  await expect(popup.providers.checkedNeverLabel()).toBeVisible()
+
+  for (const name of [
+    /DanDanPlay|弹弹play/,
+    /Bilibili|B站/,
+    /Tencent Video|腾讯视频/,
+  ]) {
+    await expect(popup.providers.importButton(name)).toBeVisible()
+  }
+})

--- a/packages/danmaku-anywhere/e2e/specs/providers/offline-fallback.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/offline-fallback.spec.ts
@@ -1,4 +1,8 @@
-import { offlineCatalog } from '../../network/catalog'
+import {
+  manifestVersion,
+  mockCatalog,
+  offlineCatalog,
+} from '../../network/catalog'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
 
@@ -8,8 +12,13 @@ import { expect, test } from '../../setup/fixtures'
  * manifest store. ManifestRegistry seeds its bundled dango manifests instead
  * of leaving the registry empty, so the built-in sources still appear in the
  * Providers page catalog with no successful network round trip, and the
- * catalog is reported as never having been checked.
+ * catalog is reported as never having been checked. Once the proxy recovers,
+ * the next reachable sync auto-replaces a bundle-seeded manifest with the
+ * catalog copy with no manual apply, since the tag on it (not surfaced as a
+ * pending update) exists only to mark it as not user-chosen.
  */
+
+const BUMPED = '9.9.9'
 
 test.use({
   catalogMock: offlineCatalog(),
@@ -56,4 +65,62 @@ test('built-in sources load from the bundled catalog when the proxy is unreachab
   ]) {
     await expect(popup.providers.importButton(name)).toBeVisible()
   }
+})
+
+test('a bundle-seeded source auto-upgrades to the catalog copy on the next reachable sync, no manual apply', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  const iqiyiName = /iQIYI|爱奇艺/
+  const bundledVersion = manifestVersion('iqiyi')
+
+  await expect
+    .poll(
+      async () => {
+        const stored = (await da.storage.get('local', 'manifests')) as Record<
+          string,
+          { kind: string }
+        >
+        return stored?.iqiyi?.kind
+      },
+      { timeout: 10_000 }
+    )
+    .toBe('bundled')
+
+  // The first reachable sync after an offline boot also runs the deferred
+  // default-provider seed (unseeded because the offline boot never reached
+  // it), auto-importing dandanplay/bilibili/tencent as provider configs and
+  // triggering their login probes. Orthogonal to the bundle auto-upgrade
+  // under test here, so mark seeding done up front to keep this test scoped
+  // to the manifest catalog.
+  await da.providerConfig.markSeeded()
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+  await expect(popup.providers.catalogRow(iqiyiName)).toContainText(
+    `v${bundledVersion}`
+  )
+
+  // The proxy recovers: shadow the offline mock with a working one that
+  // advertises a newer iQIYI, same as a normal catalog update.
+  const recovered = mockCatalog(
+    ['dandanplay', 'bilibili', 'tencent', 'iqiyi'],
+    { iqiyi: BUMPED }
+  )
+  await context.route(recovered.pattern, recovered.respond)
+
+  await popup.providers.refreshCatalog()
+
+  await expect(popup.providers.catalogRow(iqiyiName)).toContainText(
+    `v${BUMPED}`
+  )
+  await expect(popup.providers.checkedNeverLabel()).toBeHidden()
+
+  const stored = (await da.storage.get('local', 'manifests')) as Record<
+    string,
+    { kind: string; manifest: { version: string } }
+  >
+  expect(stored.iqiyi.kind).toBe('preinstalled')
+  expect(stored.iqiyi.manifest.version).toBe(BUMPED)
 })

--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -61,6 +61,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mediapipe/tasks-vision": "0.10.18",
     "@mr-quin/dango": "^0.8.0",
+    "@mr-quin/dango-manifests": "^0.8.0",
     "@mui/icons-material": "^9.0.1",
     "@mui/lab": "9.0.0-beta.3",
     "@mui/material": "^9.0.1",
@@ -100,7 +101,6 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "2.2.1",
-    "@mr-quin/dango-manifests": "^0.8.0",
     "@playwright/test": "^1.59.1",
     "@types/chrome": "^0.0.326",
     "@types/d3": "^7.4.3",

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ILogger } from '@/common/Logger'
+import { bundledCatalogIndex } from './bundledCatalog'
 import { ManifestRegistry } from './ManifestRegistry'
 import type {
   IManifestStore,
@@ -14,7 +15,8 @@ import type {
  * user imports), detect-vs-apply (getPendingUpdates diffs versions without
  * fetching files or applying; applyUpdates replaces only the named preinstalled
  * ids, never a user import or an unseeded id), skipping a bad/failed file,
- * index failures (one retry after a delay, then give up), that neither
+ * index failures (one retry after a delay, then give up), the offline bundle
+ * fallback seeding built-ins only when the index is unreachable, that neither
  * update() nor getPendingUpdates stamps
  * lastCheckedAt (only recordChecked does), and
  * register / unregister / hydrate-skip-invalid.
@@ -194,6 +196,63 @@ describe('ManifestRegistry', () => {
     }
   })
 
+  it('update seeds the bundled catalog when the index is unreachable and the store is empty', async () => {
+    const fetchMock = stubFetch(() => ({ status: 503, body: 'unavailable' }))
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    const result = await settleIndexRetry(() => registry.update())
+
+    expect(result).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const bundledIds = bundledCatalogIndex()
+      .map((entry) => entry.id)
+      .sort()
+    expect(bundledIds).toEqual(
+      expect.arrayContaining(['dandanplay', 'bilibili', 'tencent'])
+    )
+    expect(registry.list().sort()).toEqual(bundledIds)
+    for (const id of bundledIds) {
+      expect(registry.getRunner(id)).toBeDefined()
+    }
+    const stored = await store.getAll()
+    for (const id of bundledIds) {
+      expect(stored[id]?.kind).toBe('preinstalled')
+    }
+  })
+
+  it('update does not seed the bundle when the index is reachable', async () => {
+    stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const store = new InMemoryStore()
+    const setMany = vi.spyOn(store, 'setMany')
+    const registry = new ManifestRegistry(silentLogger, store)
+    const result = await registry.update()
+
+    expect(result).toBe(true)
+    expect(registry.list()).toEqual(['one'])
+    expect(setMany).toHaveBeenCalledTimes(1)
+    expect(Object.keys(setMany.mock.calls[0][0])).toEqual(['one'])
+  })
+
+  it('update bundle fallback does not overwrite a manifest already in the store', async () => {
+    stubFetch(() => ({ status: 503, body: 'unavailable' }))
+    const store = new InMemoryStore({
+      dandanplay: {
+        manifest: makeManifest('dandanplay', 1, '0.0.1-custom'),
+        kind: 'user',
+      },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    await settleIndexRetry(() => registry.update())
+
+    const stored = await store.get('dandanplay')
+    expect(stored?.kind).toBe('user')
+    expect(stored?.manifest).toMatchObject({ version: '0.0.1-custom' })
+  })
+
   it('listManifests returns id/name/version/kind for each registered manifest', async () => {
     stubCatalogFetch([], {})
     const store = new InMemoryStore({
@@ -295,15 +354,18 @@ describe('ManifestRegistry', () => {
     )
   })
 
-  it('update retries once and leaves the store empty when the index fetch keeps failing', async () => {
+  it('update retries once, then falls back to the bundle when the index fetch keeps failing', async () => {
     const fetchMock = stubFetch(() => ({ status: 503, body: 'unavailable' }))
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
     await expect(settleIndexRetry(() => registry.update())).resolves.toBe(false)
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(await store.getAll()).toEqual({})
-    expect(registry.list()).toEqual([])
+    expect(Object.keys(await store.getAll()).sort()).toEqual(
+      bundledCatalogIndex()
+        .map((entry) => entry.id)
+        .sort()
+    )
   })
 
   it('update succeeds when the index fetch recovers on the retry', async () => {
@@ -326,7 +388,7 @@ describe('ManifestRegistry', () => {
     expect(registry.list()).toEqual(['one'])
   })
 
-  it('update leaves the store empty when the index body is malformed', async () => {
+  it('update falls back to the bundle when the index body is malformed', async () => {
     stubFetch((url) =>
       url.includes('/manifest/file')
         ? { status: 200, body: makeManifest('x') }
@@ -336,8 +398,11 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     await expect(settleIndexRetry(() => registry.update())).resolves.toBe(false)
 
-    expect(await store.getAll()).toEqual({})
-    expect(registry.list()).toEqual([])
+    expect(Object.keys(await store.getAll()).sort()).toEqual(
+      bundledCatalogIndex()
+        .map((entry) => entry.id)
+        .sort()
+    )
   })
 
   it('update skips a catalog file that fails schema validation', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -217,8 +217,80 @@ describe('ManifestRegistry', () => {
     }
     const stored = await store.getAll()
     for (const id of bundledIds) {
-      expect(stored[id]?.kind).toBe('preinstalled')
+      expect(stored[id]?.kind).toBe('bundled')
     }
+  })
+
+  it('update auto-upgrades a bundle-seeded entry once the index becomes reachable', async () => {
+    const store = new InMemoryStore({
+      dandanplay: {
+        manifest: makeManifest('dandanplay', 1, '0.5.0'),
+        kind: 'bundled',
+      },
+    })
+    stubCatalogFetch([catalogEntry('dandanplay', '0.6.0')], {
+      [manifestPath('dandanplay')]: makeManifest('dandanplay', 1, '0.6.0'),
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    const result = await registry.update()
+
+    expect(result).toBe(true)
+    const stored = await store.get('dandanplay')
+    expect(stored?.kind).toBe('preinstalled')
+    expect(stored?.manifest).toMatchObject({ version: '0.6.0' })
+  })
+
+  it('update leaves a bundle-seeded entry the catalog no longer lists alone', async () => {
+    const store = new InMemoryStore({
+      'user:one': {
+        manifest: makeManifest('user:one', 1, '0.5.0'),
+        kind: 'bundled',
+      },
+    })
+    stubCatalogFetch([catalogEntry('other')], {
+      [manifestPath('other')]: makeManifest('other'),
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    await registry.update()
+
+    const stored = await store.get('user:one')
+    expect(stored?.kind).toBe('bundled')
+    expect(stored?.manifest).toMatchObject({ version: '0.5.0' })
+  })
+
+  it('getPendingUpdates does not list a bundle-seeded entry even when the catalog has moved on', async () => {
+    const store = new InMemoryStore({
+      dandanplay: {
+        manifest: makeManifest('dandanplay', 1, '0.5.0'),
+        kind: 'bundled',
+      },
+    })
+    stubCatalogFetch([catalogEntry('dandanplay', '0.6.0')], {})
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    expect(await registry.getPendingUpdates()).toEqual([])
+  })
+
+  it('applyUpdates replaces a bundle-seeded entry named directly', async () => {
+    const store = new InMemoryStore({
+      dandanplay: {
+        manifest: makeManifest('dandanplay', 1, '0.5.0'),
+        kind: 'bundled',
+      },
+    })
+    stubCatalogFetch([catalogEntry('dandanplay', '0.6.0')], {
+      [manifestPath('dandanplay')]: makeManifest('dandanplay', 1, '0.6.0'),
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+    await registry.applyUpdates(['dandanplay'])
+
+    const stored = await store.get('dandanplay')
+    expect(stored?.kind).toBe('preinstalled')
+    expect(stored?.manifest).toMatchObject({ version: '0.6.0' })
   })
 
   it('update does not seed the bundle when the index is reachable', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -160,14 +160,17 @@ export class ManifestRegistry {
     }
   }
 
-  // Add-only: seeds only manifests absent from the store; a changed preinstalled
-  // manifest surfaces via getPendingUpdates instead of being replaced here.
-  // Returns false when the catalog index could not be fetched.
+  // Add-only for everything except a bundle-seeded entry: a changed
+  // preinstalled manifest surfaces via getPendingUpdates instead of being
+  // replaced here, but a 'bundled' entry auto-upgrades to the catalog copy
+  // the moment the index is reachable again, with no manual apply. Returns
+  // false when the catalog index could not be fetched.
   //
   // Remote is primary because it's fresh; the bundled catalog is a same-shape
   // fallback used only when remote is unreachable, so providers still exist
-  // offline. The bundle can be stale, but once online getPendingUpdates
-  // surfaces remote-newer-than-bundle so the user can update.
+  // offline. The bundle can be stale, so the first successful sync replaces
+  // any still-listed bundled entry outright rather than waiting for a manual
+  // update, since the user never chose to install the bundled version.
   async update(): Promise<boolean> {
     await this.ready
     const entries = await this.loadIndex()
@@ -177,7 +180,10 @@ export class ManifestRegistry {
     }
     const stored = await this.store.getAll()
     const missing = entries.filter((entry) => !stored[entry.id])
-    await this.fetchAndStore(missing)
+    const bundledStale = entries.filter(
+      (entry) => stored[entry.id]?.kind === 'bundled'
+    )
+    await this.fetchAndStore([...missing, ...bundledStale])
     return true
   }
 
@@ -195,7 +201,14 @@ export class ManifestRegistry {
     const updates: ManifestUpdate[] = []
     for (const entry of entries) {
       const existing = stored[entry.id]
-      if (!existing || existing.kind === 'user') {
+      // 'user' is never replaced by the catalog. 'bundled' auto-upgrades in
+      // update() as soon as the index is reachable, so it must not also
+      // surface here as a manual "update available".
+      if (
+        !existing ||
+        existing.kind === 'user' ||
+        existing.kind === 'bundled'
+      ) {
         continue
       }
       const fromVersion = storedVersion(existing.manifest)
@@ -210,11 +223,12 @@ export class ManifestRegistry {
     return updates
   }
 
-  // Replace only the named manifests that are already stored as preinstalled.
-  // User imports and ids not already seeded are left untouched, so an apply
-  // can never clobber a user manifest or install a brand-new source. Throws on
-  // failure (unreachable catalog or a file that did not apply) so a user-driven
-  // update surfaces the error instead of silently no-op'ing.
+  // Replace only the named manifests that are already stored as preinstalled
+  // or bundled. User imports and ids not already seeded are left untouched,
+  // so an apply can never clobber a user manifest or install a brand-new
+  // source. Throws on failure (unreachable catalog or a file that did not
+  // apply) so a user-driven update surfaces the error instead of silently
+  // no-op'ing.
   async applyUpdates(manifestIds: string[]): Promise<void> {
     await this.ready
     const entries = await this.loadIndex()
@@ -225,7 +239,10 @@ export class ManifestRegistry {
     const stored = await this.store.getAll()
     const targets = entries.filter((entry) => {
       const existing = stored[entry.id]
-      return wanted.has(entry.id) && existing?.kind === 'preinstalled'
+      return (
+        wanted.has(entry.id) &&
+        (existing?.kind === 'preinstalled' || existing?.kind === 'bundled')
+      )
     })
     const applied = await this.fetchAndStore(targets)
     if (applied.length < targets.length) {
@@ -317,7 +334,10 @@ export class ManifestRegistry {
 
   // Add-only, same contract as fetchAndStore: only ids absent from the store
   // are seeded. Each bundled manifest is re-validated with zManifest so a
-  // corrupt bundle entry is skipped rather than crashing startup.
+  // corrupt bundle entry is skipped rather than crashing startup. Tagged
+  // 'bundled' rather than 'preinstalled' so update() knows to replace it
+  // outright on the next reachable sync instead of treating it as a normal
+  // installed source pinned until a manual apply.
   private async seedFromBundle(): Promise<void> {
     const stored = await this.store.getAll()
     const missing = bundledCatalogIndex().filter((entry) => !stored[entry.id])
@@ -337,7 +357,7 @@ export class ManifestRegistry {
         )
         continue
       }
-      updates[parsed.data.id] = { manifest: raw, kind: 'preinstalled' }
+      updates[parsed.data.id] = { manifest: raw, kind: 'bundled' }
       toRegister.push(parsed.data)
     }
     if (toRegister.length === 0) {
@@ -347,7 +367,7 @@ export class ManifestRegistry {
     for (const manifest of toRegister) {
       this.runners.set(manifest.id, {
         runner: this.buildRunner(manifest),
-        kind: 'preinstalled',
+        kind: 'bundled',
       })
     }
   }

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -13,6 +13,7 @@ import type {
   ProviderManifestInfo,
 } from '@/common/rpcClient/background/types'
 import { invariant, sleep } from '@/common/utils/utils'
+import { bundledCatalogIndex, bundledManifestRaw } from './bundledCatalog'
 import { extensionFetchLike } from './extensionFetchLike'
 import {
   type IManifestStore,
@@ -162,10 +163,16 @@ export class ManifestRegistry {
   // Add-only: seeds only manifests absent from the store; a changed preinstalled
   // manifest surfaces via getPendingUpdates instead of being replaced here.
   // Returns false when the catalog index could not be fetched.
+  //
+  // Remote is primary because it's fresh; the bundled catalog is a same-shape
+  // fallback used only when remote is unreachable, so providers still exist
+  // offline. The bundle can be stale, but once online getPendingUpdates
+  // surfaces remote-newer-than-bundle so the user can update.
   async update(): Promise<boolean> {
     await this.ready
     const entries = await this.loadIndex()
     if (!entries) {
+      await this.seedFromBundle()
       return false
     }
     const stored = await this.store.getAll()
@@ -306,6 +313,43 @@ export class ManifestRegistry {
       })
     }
     return fetched.map(({ parsed }) => parsed.id)
+  }
+
+  // Add-only, same contract as fetchAndStore: only ids absent from the store
+  // are seeded. Each bundled manifest is re-validated with zManifest so a
+  // corrupt bundle entry is skipped rather than crashing startup.
+  private async seedFromBundle(): Promise<void> {
+    const stored = await this.store.getAll()
+    const missing = bundledCatalogIndex().filter((entry) => !stored[entry.id])
+    if (missing.length === 0) {
+      return
+    }
+    const updates: Record<string, ManifestEntry> = {}
+    const toRegister: Manifest[] = []
+    for (const entry of missing) {
+      const raw = bundledManifestRaw(entry.id)
+      const parsed = zManifest.safeParse(raw)
+      if (!parsed.success) {
+        this.log.error(
+          'Skipping invalid bundled manifest:',
+          entry.id,
+          parsed.error.issues
+        )
+        continue
+      }
+      updates[parsed.data.id] = { manifest: raw, kind: 'preinstalled' }
+      toRegister.push(parsed.data)
+    }
+    if (toRegister.length === 0) {
+      return
+    }
+    await this.store.setMany(updates)
+    for (const manifest of toRegister) {
+      this.runners.set(manifest.id, {
+        runner: this.buildRunner(manifest),
+        kind: 'preinstalled',
+      })
+    }
   }
 
   private async loadIndex(): Promise<CatalogEntry[] | null> {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestStore.ts
@@ -2,7 +2,13 @@ import { Mutex } from 'async-mutex'
 import { injectable } from 'inversify'
 import { ExtStorageService } from '@/common/storage/ExtStorageService'
 
-export type ManifestKind = 'preinstalled' | 'user'
+// 'bundled' behaves like 'preinstalled' everywhere except getPendingUpdates
+// (auto-upgrades on the next reachable sync instead of surfacing as a manual
+// update) and applyUpdates (also eligible, so a direct call still replaces
+// it). It marks a manifest seeded from the build-time bundle rather than
+// fetched from the catalog; fetchAndStore always writes 'preinstalled', so
+// the tag clears the moment the catalog copy replaces the entry.
+export type ManifestKind = 'preinstalled' | 'user' | 'bundled'
 
 export interface ManifestEntry {
   manifest: unknown

--- a/packages/danmaku-anywhere/src/background/services/providers/bundledCatalog.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/bundledCatalog.ts
@@ -1,0 +1,53 @@
+import { SUPPORTED_API_VERSIONS, zManifest } from '@mr-quin/dango'
+
+export interface BundledCatalogEntry {
+  id: string
+  apiVersion: number
+  version: string
+  file: string
+}
+
+interface BundledEntry extends BundledCatalogEntry {
+  raw: unknown
+}
+
+// Vite eager glob: the manifest JSON files are inlined at build time, so the
+// registry has an offline-usable catalog with no network round trip. The
+// pnpm symlink for @mr-quin/dango-manifests resolves through this glob same
+// as a real directory.
+const rawModules = import.meta.glob(
+  '/node_modules/@mr-quin/dango-manifests/src/manifests/*.json',
+  { eager: true, import: 'default' }
+) as Record<string, unknown>
+
+function manifestFile(id: string): string {
+  return `src/manifests/${id}.json`
+}
+
+const bundledById = new Map<string, BundledEntry>()
+
+for (const raw of Object.values(rawModules)) {
+  const parsed = zManifest.safeParse(raw)
+  if (!parsed.success) {
+    continue
+  }
+  const manifest = parsed.data
+  if (!SUPPORTED_API_VERSIONS.has(manifest.apiVersion)) {
+    continue
+  }
+  bundledById.set(manifest.id, {
+    id: manifest.id,
+    apiVersion: manifest.apiVersion,
+    version: manifest.version,
+    file: manifestFile(manifest.id),
+    raw,
+  })
+}
+
+export function bundledCatalogIndex(): BundledCatalogEntry[] {
+  return [...bundledById.values()].map(({ raw: _raw, ...entry }) => entry)
+}
+
+export function bundledManifestRaw(id: string): unknown {
+  return bundledById.get(id)?.raw
+}

--- a/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
+++ b/packages/danmaku-anywhere/src/common/rpcClient/background/types.ts
@@ -121,7 +121,7 @@ export interface ProviderManifestInfo {
   name: string
   version: string
   configSchema?: ConfigSchema
-  kind: 'preinstalled' | 'user'
+  kind: 'preinstalled' | 'user' | 'bundled'
   // The manifest's declared instance-identity config fields; drives
   // namespaceKey derivation wherever configs are matched to seasons.
   identityFields: readonly string[]
@@ -166,7 +166,7 @@ export interface ManifestTestEpisodeRow {
 
 export interface ManifestSource {
   manifest: unknown
-  kind: 'preinstalled' | 'user'
+  kind: 'preinstalled' | 'user' | 'bundled'
 }
 
 export interface ManifestTestSearchInput {

--- a/packages/danmaku-anywhere/src/popup/pages/providers/components/ManifestKindChip.tsx
+++ b/packages/danmaku-anywhere/src/popup/pages/providers/components/ManifestKindChip.tsx
@@ -2,7 +2,7 @@ import { Chip } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 interface ManifestKindChipProps {
-  kind?: 'preinstalled' | 'user'
+  kind?: 'preinstalled' | 'user' | 'bundled'
 }
 
 export const ManifestKindChip = ({ kind }: ManifestKindChipProps) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@mr-quin/dango':
         specifier: ^0.8.0
         version: 0.8.0
+      '@mr-quin/dango-manifests':
+        specifier: ^0.8.0
+        version: 0.8.0
       '@mui/icons-material':
         specifier: ^9.0.1
         version: 9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react@19.2.0))(@types/react@19.2.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.15)(react@19.2.0)
@@ -475,9 +478,6 @@ importers:
       '@crxjs/vite-plugin':
         specifier: 2.2.1
         version: 2.2.1
-      '@mr-quin/dango-manifests':
-        specifier: ^0.8.0
-        version: 0.8.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.60.0


### PR DESCRIPTION
Bundles the dango manifest catalog into the build as an **offline fallback** for manifest loading. Closes DA-661.

## Problem
A fresh install with the catalog proxy unreachable gets zero sources: `onInstalled → syncCatalog` fails, the manifest store stays empty, `seedDefaultProviders` refuses to seed, and recovery waits for the 12h alarm or a manual refresh.

## What it does
- **Bundle** all `@mr-quin/dango-manifests` JSONs into the build via a Vite eager glob (`bundledCatalog.ts`); the index is derived from each manifest's own fields (same shape the network catalog produces). Adds ~104KB uncompressed to the background bundle.
- **Fallback:** `ManifestRegistry.update()` seeds missing manifests from the bundle **only when the network index is unreachable**, tagged with a new `kind: 'bundled'`. Remote stays primary; a reachable catalog always wins (fresh).
- **Auto-upgrade:** the first successful sync replaces any still-listed `'bundled'` entry with the remote copy (clearing the tag) — no manual "Update". `getPendingUpdates` skips bundled entries so they never surface as a manual update.

## Tests
- Unit (`ManifestRegistry.test.ts`): offline seeds bundled + tagged; reachable index doesn't touch the bundle; auto-upgrade replaces + clears the tag; bundled entries excluded from pending updates.
- e2e (`providers/offline-fallback.spec.ts`): first-boot offline → built-ins load from bundle (`checked never`); then proxy recovers with a bumped manifest → refresh auto-upgrades to `preinstalled` + new version, asserted against storage ground truth, no manual click.

## Verify
`build:packages` + extension build OK (manifests confirmed inlined). Full Vitest 735/735. e2e providers/sources/baseline/lifecycle 45/45. biome clean. `tsc` adds no new errors (the 4 pre-existing Zod v4 / react-hook-form resolver errors on master are unrelated).