### PR TITLE
(proxy) head-sample CF Observability in production [DA-663]

### DIFF
--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -157,6 +157,10 @@
       "ratelimits": []
     },
     "production": {
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 0.005
+      },
       "vars": {
         "ENVIRONMENT": "production",
         "ALLOWED_ORIGIN": "https://danmaku.weeblify.app",


### PR DESCRIPTION
Reduces production Workers Logs volume via head-based sampling. Closes DA-663.

## Problem
`head_sampling_rate` sits at its default of 1, so every request is logged: one invocation event plus the Hono access-logger lines. That is more log volume than production needs.

## What it does
- Adds an `observability` block to `env.production` with `head_sampling_rate: 0.005`.
- Scoped to production only. `observability` is an *inheritable* wrangler key, so dev and staging keep the default rate, where volume is low and full logs matter for debugging.

Head sampling drops the whole request, invocation log included. `wrangler tail` is unaffected, so live debugging is unchanged.

## Verify
`wrangler.json` is plain JSON with no source changes. Parsed the config and asserted `env.production.observability` is `{enabled: true, head_sampling_rate: 0.005}` while `env.staging.observability` stays undefined, i.e. inheriting the top-level rate.