### PR TITLE
(proxy) shorten manifest cache TTL to 15 minutes [DA-665]

### DIFF
--- a/backend/proxy/src/routes/api/manifest/router.test.ts
+++ b/backend/proxy/src/routes/api/manifest/router.test.ts
@@ -35,6 +35,7 @@ describe('Manifest API', () => {
 
     expect(response.status).toBe(200)
     expect(fetchSpy).toHaveBeenCalledWith(`${dangoBaseUrl}/catalog.json`)
+    expect(response.headers.get('Cache-Control')).toBe('max-age=900')
 
     const content: any = await response.json()
     expect(content.packageVersion).toBe('0.2.0')
@@ -61,6 +62,7 @@ describe('Manifest API', () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       `${dangoBaseUrl}/src/manifests/builtin-bilibili.json`
     )
+    expect(response.headers.get('Cache-Control')).toBe('max-age=900')
 
     const content: any = await response.json()
     expect(content.id).toBe('builtin:bilibili')

--- a/backend/proxy/src/routes/api/manifest/router.ts
+++ b/backend/proxy/src/routes/api/manifest/router.ts
@@ -10,7 +10,7 @@ const dangoBaseUrl =
 
 const filePattern = /^src\/manifests\/[\w.-]+\.json$/
 
-const oneHour = 60 * 60
+const cacheMaxAge = 15 * 60
 
 manifestRouter.get(
   '/',
@@ -41,7 +41,7 @@ manifestRouter.get(
     },
   }),
   useCache({
-    maxAge: oneHour,
+    maxAge: cacheMaxAge,
   }),
   async (c) => {
     return await fetch(`${dangoBaseUrl}/catalog.json`)
@@ -70,7 +70,7 @@ manifestRouter.get(
     },
   }),
   useCache({
-    maxAge: oneHour,
+    maxAge: cacheMaxAge,
   }),
   async (c) => {
     const { file } = c.req.valid('query')


### PR DESCRIPTION
## Summary
- Drop the cache TTL on both dango manifest routes from 1 hour to 15 minutes.
- Tests pin the emitted `Cache-Control` so the TTL cannot drift silently.

## Why

A manifest fix published upstream kept being served stale long after it landed, which leaves the extension showing a pending update that reapplying does not clear. A shorter TTL bounds that window. The underlying index/file skew is structural and tracked separately.

## Test plan
- Verified: lint pass for the touched files · tests `pnpm --filter proxy test` -> 66 passed (13 files) · e2e skipped
- [ ] `pnpm --filter proxy test`

## Notes
- Needs an accompanying CDN configuration change to take effect, and proxy deploys are manual. Details in the task.
- e2e skipped: no extension-facing behavior change, and the e2e catalog specs serve their own fixtures rather than hitting the proxy.