### PR TITLE
(chore) upgrade @hookform/resolvers so type-check survives either zod hoist [DA-666]

### DIFF
--- a/packages/danmaku-anywhere/package.json
+++ b/packages/danmaku-anywhere/package.json
@@ -58,7 +58,7 @@
     "@fontsource-variable/noto-sans-sc": "^5.2.10",
     "@fontsource-variable/noto-sans-tc": "^5.2.10",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
-    "@hookform/resolvers": "^5.2.2",
+    "@hookform/resolvers": "^5.4.3",
     "@mediapipe/tasks-vision": "0.10.18",
     "@mr-quin/dango": "^0.8.1",
     "@mr-quin/dango-manifests": "^0.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,8 +355,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@hookform/resolvers':
-        specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.76.0(react@19.2.0))
+        specifier: ^5.4.3
+        version: 5.4.3(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.76.0(react@19.2.0))(zod@4.4.3)
       '@mediapipe/tasks-vision':
         specifier: 0.10.18
         version: 0.10.18
@@ -2330,10 +2330,83 @@ packages:
       hono: '>=4.10.0'
       zod: ^3.25.0 || ^4.0.0
 
-  '@hookform/resolvers@5.2.2':
-    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+  '@hookform/resolvers@5.4.3':
+    resolution: {integrity: sha512-jtS1DEvkT1ql8ImIDQL+UmkhEnDmt3Bp7Yt4q5XQpc0JiQ8b8+I7yT/KQze4gw9Ocmi9xa9ef6zxifizPgdp3A==}
     peerDependencies:
+      '@sinclair/typebox': '>=0.25.24'
+      '@standard-schema/spec': ^1.0.0
+      '@typeschema/main': '>=0.13.7'
+      '@vinejs/vine': ^2.0.0 || ^3.0.0
+      ajv: ^8.12.0
+      ajv-errors: ^3.0.0
+      ajv-formats: ^2.1.1
+      arktype: ^2.0.0
+      ata-validator: ^0.7.0
+      class-transformer: '>=0.4.0'
+      class-validator: '>=0.12.0'
+      computed-types: ^1.0.0
+      effect: ^3.10.3
+      fluentvalidation-ts: ^3.0.0
+      fp-ts: ^2.7.0
+      io-ts: ^2.0.0
+      joi: ^17.0.0
+      nope-validator: '>=0.12.0'
       react-hook-form: ^7.55.0
+      superstruct: '>=0.12.0'
+      typanion: ^3.3.2
+      valibot: ^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc
+      vest: '>=3.0.0'
+      yup: ^1.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      '@standard-schema/spec':
+        optional: true
+      '@typeschema/main':
+        optional: true
+      '@vinejs/vine':
+        optional: true
+      ajv:
+        optional: true
+      ajv-errors:
+        optional: true
+      ajv-formats:
+        optional: true
+      arktype:
+        optional: true
+      ata-validator:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+      computed-types:
+        optional: true
+      effect:
+        optional: true
+      fluentvalidation-ts:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      nope-validator:
+        optional: true
+      superstruct:
+        optional: true
+      typanion:
+        optional: true
+      valibot:
+        optional: true
+      vest:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -10083,10 +10156,14 @@ snapshots:
       hono: 4.12.21
       zod: 4.4.3
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.76.0(react@19.2.0))':
+  '@hookform/resolvers@5.4.3(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.76.0(react@19.2.0))(zod@4.4.3)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.76.0(react@19.2.0)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      zod: 4.4.3
 
   '@humanfs/core@0.19.2':
     dependencies:


### PR DESCRIPTION
## Summary
- Bump `@hookform/resolvers` from `^5.2.2` to `^5.4.3` in the extension package, so `zodResolver` type-checks regardless of which zod v4 minor pnpm hoists.

## Context

Two zod v4 minors coexist in the tree. `4.4.3` is what the extension and its runtime dependencies (`ai-sdk`, `better-auth`, `@hono/zod-openapi`) use. `4.3.6` arrives through the web app's Angular CLI toolchain, via `@modelcontextprotocol/sdk`.

zod bakes its own version into its declarations: `zod/v4/core/versions.d.ts` ships `minor: 3` in 4.3.6 and `minor: 4` in 4.4.3. `@hookform/resolvers@5.2.2` defaults its generic to the fully branded `z4.$ZodType<Output, Input>`, so a schema built by one copy fails the overload against the other with `Type '4' is not assignable to type '3'`.

Which copy `@hookform/resolvers` resolves its types from is not stable across installs from the same lockfile. Measured, all with an unmodified lockfile:

| Checkout | resolvers | `zod/v4/core` resolves to | `tsc --noEmit` |
| --- | --- | --- | --- |
| long-lived local checkout | 5.2.2 | 4.3.6 and 4.4.3 | 4 errors |
| long-lived local checkout | 5.4.3 | 4.4.3 only | clean |
| freshly bootstrapped worktree | 5.2.2 | 4.4.3 only | clean |

So this is not a broken master. CI installs fresh, lands on the good hoist, and PR Quality is green on master and on branches cut from it. What it is: a contributor whose checkout happens to hoist 4.3.6 gets four `TS2769` errors in `SignInForm.tsx:26`, `SignUpForm.tsx:34`, `AiProviderForm.tsx:96` and `IntegrationEditor.tsx:54` that CI will not reproduce, and `pnpm lint` runs `tsc` first so lint fails with it. That is an unpleasant thing to debug, and it is luck that CI has been on the right side of it.

## Why 5.4.3

Upstream fixed exactly this in resolvers PR 852, "zodResolver() type overload fails with Zod v4.3.x due to branded version mismatch", which replaces the branded generic default with a minimal structural interface that carries no version brand. That shipped in `5.4.2`, so `5.4.3` is the smallest bump that actually contains the fix rather than merely happening to work.

Not going further to `5.5.x` is a deliberate choice to keep the bump minimal, not a claim that `5.4.3` is more mature. Both lines are recent: `5.4.1` through `5.4.3` and `5.5.0` were all published on 2026-07-25. An earlier revision of this PR described `5.4.3` as a May release. That was wrong, `5.4.0` is from May and the patch releases are not.

Reviewed the release notes across `5.2.2` to `5.4.3`: nothing breaking. `5.4.1` made several validator libraries optional peer dependencies, which is what the large `peerDependenciesMeta` block in the lockfile diff comes from. Type-only, no runtime effect. `zodResolver` is used in exactly the four files listed above and nowhere else in the repo.

## Test plan
- Verified: lint pass (exit 0) · type-check pass (exit 0) · tests `pnpm test` -> 957 passed across 7 packages (integration-policy 10, danmaku-converter 57, danmaku-engine 46, danmaku-provider 36, proxy 66, web-scraper 7, danmaku-anywhere 735) · e2e skipped, no runtime behavior changes and no spec touched
- [ ] Reviewer sanity check: `pnpm exec tsc --noEmit` in `packages/danmaku-anywhere` is clean on this branch

## Notes
- No source files changed. The diff is `package.json` plus the lockfile.
- The caret was checked against how CI actually installs. `pr-quality.yml` runs a bare `pnpm install`, and pnpm leaves a lockfile-pinned version alone when it already satisfies the range, so `^5.4.3` does not float to `5.5.7` on CI.
- Deliberately not addressed here: deduplicating zod itself. A root `pnpm.overrides` entry collapsing 4.3.6 into 4.4.3 would remove the ambiguity at its source rather than making one consumer tolerant of it, but it forces the Angular CLI toolchain onto a zod minor it was not resolved against. That is a larger call and belongs in its own change.