### PR TITLE
(proxy) parse trusted origins as a list [DA-671]

### DIFF
--- a/backend/proxy/src/auth/config.test.ts
+++ b/backend/proxy/src/auth/config.test.ts
@@ -1,0 +1,54 @@
+import { env } from 'cloudflare:test'
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { describe, expect, it } from 'vitest'
+import { parseTrustedOrigins } from '@/auth/trustedOrigins'
+import { getOrCreateDb } from '@/db'
+
+const BASE_URL = 'https://api.test.example'
+const RAW_TRUSTED_ORIGINS = 'https://a.example,https://b.example'
+
+function createTestAuth(trustedOrigins: string[]) {
+  return betterAuth({
+    baseURL: BASE_URL,
+    basePath: '/auth',
+    secret: 'test-secret',
+    database: drizzleAdapter(getOrCreateDb(env.DB), { provider: 'sqlite' }),
+    trustedOrigins,
+    advanced: {
+      disableOriginCheck: false,
+    },
+  })
+}
+
+function signOutRequest(origin: string) {
+  return new Request(`${BASE_URL}/auth/sign-out`, {
+    method: 'POST',
+    headers: {
+      Origin: origin,
+      Cookie: 'better-auth.session_token=whatever',
+    },
+  })
+}
+
+describe('trustedOrigins wired into betterAuth', () => {
+  it('rejects a cookie-bearing request from a listed origin when the list is passed unparsed', async () => {
+    const auth = createTestAuth([RAW_TRUSTED_ORIGINS])
+
+    const response = await auth.handler(signOutRequest('https://b.example'))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.message).toBe('Invalid origin')
+  })
+
+  it('accepts a cookie-bearing request from a listed origin when the list is parsed', async () => {
+    const auth = createTestAuth(parseTrustedOrigins(RAW_TRUSTED_ORIGINS))
+
+    const response = await auth.handler(signOutRequest('https://b.example'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+})

--- a/backend/proxy/src/auth/config.ts
+++ b/backend/proxy/src/auth/config.ts
@@ -2,6 +2,7 @@ import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { admin, bearer, jwt, openAPI } from 'better-auth/plugins'
 import { ac, adminRole, moderatorRole, userRole } from '@/auth/permissions'
+import { parseTrustedOrigins } from '@/auth/trustedOrigins'
 import { getOrCreateDb } from '@/db'
 import { getOrCreateEmailService } from '@/email'
 
@@ -47,7 +48,7 @@ async function createAuth(env: Env) {
     baseURL,
     basePath: '/auth',
     secret,
-    trustedOrigins: [env.BETTER_AUTH_TRUSTED_ORIGINS],
+    trustedOrigins: parseTrustedOrigins(env.BETTER_AUTH_TRUSTED_ORIGINS),
     emailAndPassword: {
       enabled: true,
       minPasswordLength: 6,

--- a/backend/proxy/src/auth/trustedOrigins.test.ts
+++ b/backend/proxy/src/auth/trustedOrigins.test.ts
@@ -21,12 +21,6 @@ describe('parseTrustedOrigins', () => {
     ).toEqual(['https://a.example', 'https://b.example'])
   })
 
-  it('returns a single-entry array for a value with no commas', () => {
-    expect(parseTrustedOrigins('https://a.example')).toEqual([
-      'https://a.example',
-    ])
-  })
-
   it('returns an empty array for an empty value', () => {
     expect(parseTrustedOrigins('')).toEqual([])
   })

--- a/backend/proxy/src/auth/trustedOrigins.test.ts
+++ b/backend/proxy/src/auth/trustedOrigins.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { parseTrustedOrigins } from '@/auth/trustedOrigins'
+
+describe('parseTrustedOrigins', () => {
+  it('splits a comma-separated value into one entry per origin', () => {
+    expect(parseTrustedOrigins('https://a.example,https://b.example')).toEqual([
+      'https://a.example',
+      'https://b.example',
+    ])
+  })
+
+  it('trims whitespace around entries', () => {
+    expect(
+      parseTrustedOrigins(' https://a.example , https://b.example ')
+    ).toEqual(['https://a.example', 'https://b.example'])
+  })
+
+  it('drops empty segments', () => {
+    expect(
+      parseTrustedOrigins('https://a.example,,https://b.example,')
+    ).toEqual(['https://a.example', 'https://b.example'])
+  })
+
+  it('returns a single-entry array for a value with no commas', () => {
+    expect(parseTrustedOrigins('https://a.example')).toEqual([
+      'https://a.example',
+    ])
+  })
+
+  it('returns an empty array for an empty value', () => {
+    expect(parseTrustedOrigins('')).toEqual([])
+  })
+})

--- a/backend/proxy/src/auth/trustedOrigins.ts
+++ b/backend/proxy/src/auth/trustedOrigins.ts
@@ -1,0 +1,6 @@
+export function parseTrustedOrigins(value: string): string[] {
+  return value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0)
+}


### PR DESCRIPTION
## Summary

- `BETTER_AUTH_TRUSTED_ORIGINS` is a comma-separated env var, but `trustedOrigins: [env.BETTER_AUTH_TRUSTED_ORIGINS]` wrapped it as a single array element, so the literal joined string could never match a real `Origin` header. Only the `baseURL` origin (which better-auth trusts implicitly) was ever actually trusted.
- Added `parseTrustedOrigins` in `backend/proxy/src/auth/trustedOrigins.ts`: splits on commas, trims each entry, drops empty segments.
- `config.ts` now passes `parseTrustedOrigins(env.BETTER_AUTH_TRUSTED_ORIGINS)` to better-auth instead of the single-element array.

## Behavior change (please read)

This is not parse-only in effect: the corrected parse newly trusts origins in staging and production that are not functionally trusted today.

- Production `BETTER_AUTH_TRUSTED_ORIGINS` is `https://danmaku.weeblify.app,https://api.danmaku.weeblify.app`, and `baseURL` is `https://api.danmaku.weeblify.app`. Today only `api.danmaku.weeblify.app` is trusted (as the implicit baseURL origin). After this change, `https://danmaku.weeblify.app` becomes trusted too.
- Staging trusts `https://danmaku-staging.weeblify.app` and `https://danmaku.weeblify.app` in addition to its baseURL, for the same reason.
- Dev is unaffected: `advanced.disableOriginCheck` is already `true` there, so the origin check is skipped regardless.

These are exactly the origins already listed in the env var, i.e. the ones the config was always intended to trust, so this is the fix doing its job rather than an unrelated widening. Flagging it here per the acceptance criteria since it is a real change in which origins better-auth will accept for cookie-based requests.

## CORS credentials follow-up

Checked whether `hono/cors` needs `credentials: true` for cookie-based auth from the web app. It currently does not set it (`backend/proxy/src/index.ts`), and the only existing better-auth client (`packages/danmaku-anywhere/src/common/auth/createAuthClient.ts`) is bearer-token only, so this has not mattered yet. Once a cookie-based client (the web app) is added, it will need `credentials: true` on the CORS middleware plus `credentials: 'include'` on its fetch calls, or the browser will refuse to expose the response. Not changed in this PR as instructed; leaving as a follow-up.

## Test plan

- Verified: lint clean on changed files (pre-existing `noVar` errors in `public/pages/reset-password.html` are unrelated to this change) · tests `backend/proxy (affected) -> 15 files / 72 passed` · e2e skipped (backend change, no spec applies)
- `backend/proxy/src/auth/trustedOrigins.test.ts`: unit coverage of the parse helper itself: multi-origin split, whitespace trimming, empty-segment dropping, empty input.
- `backend/proxy/src/auth/config.test.ts`: integration coverage that exercises better-auth's actual origin-check path, not just the string helper. Builds a real `betterAuth` instance through `drizzleAdapter`/D1 and sends a cookie-bearing `POST /auth/sign-out` from `https://b.example`: with `trustedOrigins: [rawValue]` (the old bug) it gets rejected with a 403 `Invalid origin`; with `trustedOrigins: parseTrustedOrigins(rawValue)` it's accepted. Confirmed by mutation: reverting `parseTrustedOrigins` to `(v) => [v]` turns the "accepts" case back into a 403 failure.