### PR TITLE
(proxy) validate the kazumi rules file path [DA-670]

### DIFF
--- a/backend/proxy/src/routes/api/kazumi/rules.test.ts
+++ b/backend/proxy/src/routes/api/kazumi/rules.test.ts
@@ -56,27 +56,25 @@ describe('Kazumi Rules API', () => {
     expect(content.success).toBe(false)
   })
 
-  it('rejects path traversal and encoded bypass attempts (GET /file)', async () => {
+  it.each([
+    '../../../etc/passwd',
+    '..%2f..%2f..%2fetc%2fpasswd',
+    '..%252f..%252fetc%252fpasswd',
+    'a.json%00../../etc/passwd',
+    '..%5c..%5cx.json',
+    '/etc/passwd',
+    'https://evil.com/malicious.json',
+  ])('rejects %s as the file parameter (GET /file)', async (file) => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockRejectedValue(new Error('fetch should not be called'))
 
-    const maliciousFiles = [
-      '../../../etc/passwd',
-      '..%2f..%2f..%2fetc%2fpasswd',
-      '/etc/passwd',
-      'https://evil.com/malicious.json',
-    ]
+    const request = new Request(
+      createTestUrl(`/kazumi/rules/file?file=${file}`)
+    )
+    const response = await makeUnitTestRequest(request)
 
-    for (const file of maliciousFiles) {
-      const request = new Request(
-        createTestUrl(`/kazumi/rules/file?file=${file}`)
-      )
-      const response = await makeUnitTestRequest(request)
-
-      expect(response.status).toBe(400)
-    }
-
+    expect(response.status).toBe(400)
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 })

--- a/backend/proxy/src/routes/api/kazumi/rules.test.ts
+++ b/backend/proxy/src/routes/api/kazumi/rules.test.ts
@@ -55,4 +55,28 @@ describe('Kazumi Rules API', () => {
     const content: any = await response.json()
     expect(content.success).toBe(false)
   })
+
+  it('rejects path traversal and encoded bypass attempts (GET /file)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('fetch should not be called'))
+
+    const maliciousFiles = [
+      '../../../etc/passwd',
+      '..%2f..%2f..%2fetc%2fpasswd',
+      '/etc/passwd',
+      'https://evil.com/malicious.json',
+    ]
+
+    for (const file of maliciousFiles) {
+      const request = new Request(
+        createTestUrl(`/kazumi/rules/file?file=${file}`)
+      )
+      const response = await makeUnitTestRequest(request)
+
+      expect(response.status).toBe(400)
+    }
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
 })

--- a/backend/proxy/src/routes/api/kazumi/rules.ts
+++ b/backend/proxy/src/routes/api/kazumi/rules.ts
@@ -4,6 +4,8 @@ import { factory } from '@/factory'
 
 export const rulesRouter = factory.createApp()
 
+const filePattern = /^[\w.-]+\.json$/
+
 rulesRouter.get(
   '/',
   describeRoute({
@@ -41,7 +43,7 @@ rulesRouter.get(
   validator(
     'query',
     z.object({
-      file: z.string().min(1),
+      file: z.string().regex(filePattern),
     })
   ),
   describeRoute({


### PR DESCRIPTION
## Summary

- `GET /kazumi/rules/file` validated its `file` query param with only `z.string().min(1)`, then interpolated it unescaped into an upstream `raw.githubusercontent.com` URL, so a value like `../../../etc/passwd` traversed outside the intended `KazumiRules` directory.
- Anchored the schema to `z.string().regex(/^[\w.-]+\.json$/)`, mirroring the existing pattern used by the dango manifest file route (`backend/proxy/src/routes/api/manifest/router.ts`). The disallowed `/` blocks traversal, encoded slashes, leading slashes, and absolute URLs alike, since the validated value can never contain a path separator.
- Confirmed against the live upstream directory listing that every one of the 82 real `.json` rule files still matches the new pattern, so legitimate rule fetching is unaffected.

## Test plan

- Verified: lint clean on changed files (pre-existing unrelated warnings/errors in `public/pages/reset-password.html` and `drizzle.config.ts` predate this change) · tests `pnpm --filter proxy test -> 13 files / 67 tests passed` · e2e skipped (backend change, no spec applies)
- Added a rejection test covering a naive `../` traversal, a `%2f`-encoded slash bypass, a leading slash, and an absolute URL, all asserted to return 400 with `fetch` never called. Verified this test fails (500, not 400) when the regex is reverted to `min(1)`, confirming it actually protects the fix.

## Notes

`tsgo --noEmit` currently fails to run against `backend/proxy` on master too (a pre-existing `tsconfig.json` incompatibility with the installed `tsgo` version, unrelated to this change), so type-check for this package could not be run through the normal script. The root `pnpm type-check` (which does not cover this package, since it lacks a `type-check` script) passes cleanly.