### PR TITLE
(extension) verify message origin on the app postMessage bridge [DA-667]

### DIFF
--- a/packages/danmaku-anywhere/manifest.ts
+++ b/packages/danmaku-anywhere/manifest.ts
@@ -1,6 +1,6 @@
 import { defineManifest } from '@crxjs/vite-plugin'
 import { getBuildContext } from './scripts/getBuildContext'
-import { APP_URLS } from './src/common/appUrls'
+import { getAppUrls } from './src/common/appUrls'
 
 const { isDev, browser, appVersion } = getBuildContext()
 
@@ -43,7 +43,7 @@ export const manifest = defineManifest({
   },
   content_scripts: [
     {
-      matches: APP_URLS,
+      matches: getAppUrls(isDev),
       js: ['src/content/app/index.ts'],
       run_at: 'document_start',
     },

--- a/packages/danmaku-anywhere/manifest.ts
+++ b/packages/danmaku-anywhere/manifest.ts
@@ -1,5 +1,6 @@
 import { defineManifest } from '@crxjs/vite-plugin'
 import { getBuildContext } from './scripts/getBuildContext'
+import { APP_URLS } from './src/common/appUrls'
 
 const { isDev, browser, appVersion } = getBuildContext()
 
@@ -24,12 +25,6 @@ if (isChrome) {
 if (isDev) {
   permissions.push('declarativeNetRequestFeedback')
 }
-
-const APP_URLS = [
-  'https://danmaku.weeblify.app/*', // prod
-  'https://*.quinfish.workers.dev/*', // staging
-  'http://localhost:4200/*', // local dev
-]
 
 export const manifest = defineManifest({
   manifest_version: 3,

--- a/packages/danmaku-anywhere/src/common/appUrls.ts
+++ b/packages/danmaku-anywhere/src/common/appUrls.ts
@@ -1,0 +1,7 @@
+// Consumed by manifest.ts at build time, so this module must stay free of
+// browser and import.meta.env dependencies.
+export const APP_URLS = [
+  'https://danmaku.weeblify.app/*', // prod
+  'https://*.quinfish.workers.dev/*', // staging
+  'http://localhost:4200/*', // local dev
+]

--- a/packages/danmaku-anywhere/src/common/appUrls.ts
+++ b/packages/danmaku-anywhere/src/common/appUrls.ts
@@ -1,7 +1,17 @@
-// Consumed by manifest.ts at build time, so this module must stay free of
-// browser and import.meta.env dependencies.
-export const APP_URLS = [
+// Consumed by manifest.ts in the Node build context, so this module must stay
+// free of browser and import.meta.env dependencies.
+const APP_URLS = [
   'https://danmaku.weeblify.app/*', // prod
   'https://*.quinfish.workers.dev/*', // staging
+]
+
+const DEV_APP_URLS = [
   'http://localhost:4200/*', // local dev
 ]
+
+export function getAppUrls(isDev: boolean): string[] {
+  if (isDev) {
+    return [...APP_URLS, ...DEV_APP_URLS]
+  }
+  return APP_URLS
+}

--- a/packages/danmaku-anywhere/src/content/app/appOrigin.ts
+++ b/packages/danmaku-anywhere/src/content/app/appOrigin.ts
@@ -1,8 +1,13 @@
-import { APP_URLS } from '@/common/appUrls'
+import { getAppUrls } from '@/common/appUrls'
 import { matchUrl } from '@/common/utils/matchUrl'
+import { tryCatchSync } from '@/common/utils/tryCatch'
 
 export function isAllowedAppOrigin(origin: string): boolean {
-  return APP_URLS.some((pattern) => {
-    return matchUrl(origin, pattern)
+  const [url, err] = tryCatchSync(() => new URL(origin))
+  if (err) {
+    return false
+  }
+  return getAppUrls(import.meta.env.DEV).some((pattern) => {
+    return matchUrl(url.origin, pattern)
   })
 }

--- a/packages/danmaku-anywhere/src/content/app/appOrigin.ts
+++ b/packages/danmaku-anywhere/src/content/app/appOrigin.ts
@@ -1,0 +1,8 @@
+import { APP_URLS } from '@/common/appUrls'
+import { matchUrl } from '@/common/utils/matchUrl'
+
+export function isAllowedAppOrigin(origin: string): boolean {
+  return APP_URLS.some((pattern) => {
+    return matchUrl(origin, pattern)
+  })
+}

--- a/packages/danmaku-anywhere/src/content/app/index.test.ts
+++ b/packages/danmaku-anywhere/src/content/app/index.test.ts
@@ -1,11 +1,25 @@
-import { DA_EXT_SOURCE_APP } from '@danmaku-anywhere/web-scraper'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KazumiPolicy } from '@danmaku-anywhere/danmaku-provider/kazumi'
+import {
+  createExtRequest,
+  DA_EXT_SOURCE_APP,
+  type ExtRequest,
+} from '@danmaku-anywhere/web-scraper'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 /**
  * The app bridge content script runs on every app URL, so a page that holds a
  * handle to an app window could otherwise post commands straight into it.
  * These tests drive the real window listener and assert it only acts on
- * messages this window posted to itself from an allowed app origin.
+ * messages this window posted to itself from an allowed app origin, with the
+ * localhost origin trusted in dev builds only.
  */
 
 const kazumiSearchContent = vi.fn(async () => ({ data: [] }))
@@ -28,17 +42,18 @@ vi.mock('@/common/rpcClient/background/client', () => {
   return { chromeRpcClient: { kazumiSearchContent } }
 })
 
-function createRequest() {
-  return {
-    source: DA_EXT_SOURCE_APP,
-    type: 'request',
-    action: 'kazumiSearch',
+const policy = { name: 'test-policy' } as unknown as KazumiPolicy
+
+function createRequest(): ExtRequest {
+  return createExtRequest({
     id: 'kazumiSearch-1',
-    data: { keyword: 'test', policy: {} },
-  }
+    action: 'kazumiSearch',
+    data: { keyword: 'test', policy },
+    source: DA_EXT_SOURCE_APP,
+  })
 }
 
-function post(origin: string, source: MessageEventSource | null) {
+function post(origin: string, source: MessageEventSource): Promise<void> {
   window.dispatchEvent(
     new MessageEvent('message', {
       data: createRequest(),
@@ -49,18 +64,26 @@ function post(origin: string, source: MessageEventSource | null) {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
-let otherWindow: MessageEventSource
+let otherWindow: Window
 
 beforeAll(async () => {
   const frame = document.createElement('iframe')
   document.body.appendChild(frame)
-  otherWindow = frame.contentWindow as MessageEventSource
+  if (!frame.contentWindow) {
+    throw new Error('iframe has no contentWindow')
+  }
+  otherWindow = frame.contentWindow
 
   await import('./index')
 })
 
 beforeEach(() => {
+  vi.stubEnv('DEV', true)
   kazumiSearchContent.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
 })
 
 describe('app bridge message listener', () => {
@@ -70,14 +93,30 @@ describe('app bridge message listener', () => {
     expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
   })
 
-  it('handles a request from the local dev app origin', async () => {
+  it('handles a request from a staging subdomain', async () => {
+    await post('https://danmaku-anywhere.quinfish.workers.dev', window)
+
+    expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles a request from the local dev app origin in a dev build', async () => {
     await post('http://localhost:4200', window)
 
     expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
   })
 
-  it('handles a request from a staging subdomain', async () => {
-    await post('https://danmaku-anywhere.quinfish.workers.dev', window)
+  it('ignores a request from the local dev app origin in a production build', async () => {
+    vi.stubEnv('DEV', false)
+
+    await post('http://localhost:4200', window)
+
+    expect(kazumiSearchContent).not.toHaveBeenCalled()
+  })
+
+  it('still handles the production app origin in a production build', async () => {
+    vi.stubEnv('DEV', false)
+
+    await post('https://danmaku.weeblify.app', window)
 
     expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
   })

--- a/packages/danmaku-anywhere/src/content/app/index.test.ts
+++ b/packages/danmaku-anywhere/src/content/app/index.test.ts
@@ -1,0 +1,105 @@
+import { DA_EXT_SOURCE_APP } from '@danmaku-anywhere/web-scraper'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The app bridge content script runs on every app URL, so a page that holds a
+ * handle to an app window could otherwise post commands straight into it.
+ * These tests drive the real window listener and assert it only acts on
+ * messages this window posted to itself from an allowed app origin.
+ */
+
+const kazumiSearchContent = vi.fn(async () => ({ data: [] }))
+
+vi.mock('@/common/ioc/uiIoc', () => {
+  return {
+    uiContainer: {
+      get: () => {
+        return { get: async () => ({ id: 'test-id' }) }
+      },
+    },
+  }
+})
+
+vi.mock('@/common/options/extensionOptions/service', () => {
+  return { ExtensionOptionsService: class {} }
+})
+
+vi.mock('@/common/rpcClient/background/client', () => {
+  return { chromeRpcClient: { kazumiSearchContent } }
+})
+
+function createRequest() {
+  return {
+    source: DA_EXT_SOURCE_APP,
+    type: 'request',
+    action: 'kazumiSearch',
+    id: 'kazumiSearch-1',
+    data: { keyword: 'test', policy: {} },
+  }
+}
+
+function post(origin: string, source: MessageEventSource | null) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: createRequest(),
+      origin,
+      source,
+    })
+  )
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+let otherWindow: MessageEventSource
+
+beforeAll(async () => {
+  const frame = document.createElement('iframe')
+  document.body.appendChild(frame)
+  otherWindow = frame.contentWindow as MessageEventSource
+
+  await import('./index')
+})
+
+beforeEach(() => {
+  kazumiSearchContent.mockClear()
+})
+
+describe('app bridge message listener', () => {
+  it('handles a request the app posted to its own window', async () => {
+    await post('https://danmaku.weeblify.app', window)
+
+    expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles a request from the local dev app origin', async () => {
+    await post('http://localhost:4200', window)
+
+    expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles a request from a staging subdomain', async () => {
+    await post('https://danmaku-anywhere.quinfish.workers.dev', window)
+
+    expect(kazumiSearchContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a request from another window on an allowed origin', async () => {
+    await post('https://danmaku.weeblify.app', otherWindow)
+
+    expect(kazumiSearchContent).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'https://evil.com',
+    'https://danmaku.weeblify.app.evil.com',
+    'https://evil.danmaku.weeblify.app',
+    'https://evil-quinfish.workers.dev',
+    'https://quinfish.workers.dev.evil.com',
+    'http://danmaku.weeblify.app',
+    'http://localhost:4201',
+    'null',
+  ])('ignores a request claiming to be the app from %s', async (origin) => {
+    await post(origin, window)
+
+    expect(kazumiSearchContent).not.toHaveBeenCalled()
+  })
+})

--- a/packages/danmaku-anywhere/src/content/app/index.ts
+++ b/packages/danmaku-anywhere/src/content/app/index.ts
@@ -14,6 +14,7 @@ import { portNames } from '@/common/ports/portNames'
 import type { RPCClientResponse } from '@/common/rpc/client'
 import { chromeRpcClient } from '@/common/rpcClient/background/client'
 import { tryCatch } from '@/common/utils/tryCatch'
+import { isAllowedAppOrigin } from '@/content/app/appOrigin'
 import { isCustomDanmakuGetPayload } from '@/content/app/danmakuGetRouting'
 
 const extensionOptionsService = uiContainer.get(ExtensionOptionsService)
@@ -60,6 +61,14 @@ const createRpcWrapper =
 window.addEventListener(
   'message',
   async (event: MessageEvent<ExtMessage>): Promise<void> => {
+    // Only trust messages the app posted to its own window. Without this a
+    // third party holding a handle to an app window could drive the bridge.
+    if (event.source !== window) {
+      return
+    }
+    if (!isAllowedAppOrigin(event.origin)) {
+      return
+    }
     if (event.data?.source !== DA_EXT_SOURCE_APP) return
     if (event.data?.type === 'response') return
 


### PR DESCRIPTION
## Summary

- Gate the app bridge `message` listener on `event.source === window` and on `event.origin` matching an allowed app origin, before any payload is trusted. Previously any page holding a handle to an app window could post a command into the switch, including `setRequestHeaders`, which installs a session DNR rule with a caller-controlled `urlFilter` and a forced `Access-Control-Allow-Origin: *`.
- Move the app URL list out of `manifest.ts` into `src/common/appUrls.ts` so the manifest `content_scripts.matches` and the runtime origin check read the same list.
- Trust `http://localhost:4200` in dev builds only. `getAppUrls(isDev)` is the single gate: `manifest.ts` passes the build-context flag, `appOrigin.ts` passes `import.meta.env.DEV`. A shipped extension therefore neither injects the bridge on localhost nor accepts it as an origin, so a locally running dev server that renders untrusted content cannot drive the bridge on a real user's machine.
- Add `src/content/app/appOrigin.ts`, which normalizes through `new URL(...).origin` and then matches with the existing `matchUrl` (URLPattern), not string comparison.
- Add `src/content/app/index.test.ts`, which drives the real registered window listener rather than the predicate in isolation.

## Test plan

- Verified: lint pass (tsc 0 errors, biome 16 pre-existing warnings, 0 new, no fixes applied) · tests `pnpm exec vitest run` in packages/danmaku-anywhere -> 78 files / 749 tests passed, of which the new `src/content/app/index.test.ts` is 14 · e2e skipped, no e2e spec touched and no e2e coverage exists for the app bridge
- Mutation checked the new tests against the source, not just against themselves:
  - delete the `isAllowedAppOrigin` check from `index.ts` -> 9 of 14 fail
  - delete the `event.source !== window` check from `index.ts` -> 1 of 14 fails
  - make `getAppUrls` return the dev list unconditionally -> 1 of 14 fails
- Reject cases go through the listener with a correct `source: 'app'` payload, so they only pass because the guard runs: `https://evil.com`, `https://danmaku.weeblify.app.evil.com`, `https://evil.danmaku.weeblify.app`, `https://evil-quinfish.workers.dev`, `https://quinfish.workers.dev.evil.com`, `http://danmaku.weeblify.app`, `http://localhost:4201`, `null`, plus an allowed origin posted from an iframe window, plus `http://localhost:4200` with `DEV` stubbed false.
- Accept cases cover prod, a staging subdomain, and local dev in a dev build, plus prod still accepted with `DEV` stubbed false (so the production-build test is not passing by breaking everything).
- Build agreement checked on real output. Production `vite build`: `content_scripts[0].matches` is `["https://danmaku.weeblify.app/*", "https://*.quinfish.workers.dev/*"]` and `grep -r localhost:4200 build/` finds nothing, so the pattern is dead-code eliminated from the bundle too. `NODE_ENV=development vite build`: the manifest and the emitted content script both carry `http://localhost:4200/*`.

## Notes

- The origin check reuses `matchUrl` (URLPattern) so a wildcard host pattern never degrades into a substring test. One intentional difference from Chrome match-pattern semantics: `https://*.quinfish.workers.dev/*` matches the bare host `quinfish.workers.dev` for content script injection but not for this origin check, since URLPattern requires the leading label. Staging always runs on a subdomain, so the effect is that the bridge is slightly stricter than injection, never looser.
- The app posts with `window.postMessage(payload, window.location.origin)` to its own window, so `event.source === window` and `event.origin` is the app origin. Existing flows (kazumiSearch, kazumiGetChapters, extractMedia, episodeGetAll, danmakuGet, setRequestHeaders) are unchanged.
- Dev-workflow consequence of the localhost gate: driving a local `app/web` dev server now needs a dev-mode extension (`pnpm dev`, or `pnpm dev:browser` without `--build`). A production build run locally will no longer talk to `localhost:4200`. This matches how `externally_connectable` already gates `http://localhost:4321` on `isDev`.

### Known adjacent gap, not closed by this PR

There is a second, wider route to the same background RPC surface, raised separately. `manifest.ts` `externally_connectable.matches` is `*://danmaku.weeblify.app/*`, whose scheme wildcard includes plaintext http, and `RpcManager.ts` binds the full background RPC server (including `setHeaders`) to `chrome.runtime.onMessageExternal`. That list is also duplicated in `src/common/constants.ts`, the same drift this PR removed for the app URLs. Do not read this PR as having sealed the whole surface.

Also still out of scope as agreed: tightening the DNR rule built in `packages/web-scraper/src/messaging/messaging.ts` (initiator/tab restriction, expiry, payload schema validation). That path still has no runtime validation, it is just no longer reachable from a foreign page.
