### PR TITLE
(extension) seed default providers when the catalog is unreachable [DA-668]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ProvidersPage.ts
@@ -67,6 +67,12 @@ export class ProvidersPage {
     return this.page.getByText(/^(Update failed|更新失败)$/)
   }
 
+  installedHeading(count: number): Locator {
+    return this.page.getByText(
+      new RegExp(`^(Installed|已安装) \\(${count}\\)$`)
+    )
+  }
+
   checkedNeverLabel(): Locator {
     return this.page.getByText(/not checked yet|尚未检查/)
   }

--- a/packages/danmaku-anywhere/e2e/specs/providers/offline-fallback.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/providers/offline-fallback.spec.ts
@@ -1,24 +1,32 @@
+import type { BrowserContext } from '@playwright/test'
 import {
   manifestVersion,
   mockCatalog,
   offlineCatalog,
 } from '../../network/catalog'
+import { mockLoginProbes } from '../../network/loginProbes'
 import { Popup } from '../../pom/Popup'
 import { expect, test } from '../../setup/fixtures'
 
 /**
  * First-boot offline fallback: the manifest catalog proxy is unreachable
  * (index and file endpoints both fail) on a fresh profile with an empty
- * manifest store. ManifestRegistry seeds its bundled dango manifests instead
- * of leaving the registry empty, so the built-in sources still appear in the
- * Providers page catalog with no successful network round trip, and the
- * catalog is reported as never having been checked. Once the proxy recovers,
- * the next reachable sync auto-replaces a bundle-seeded manifest with the
- * catalog copy with no manual apply, since the tag on it (not surfaced as a
- * pending update) exists only to mark it as not user-chosen.
+ * manifest store. ManifestRegistry seeds its bundled dango manifests and the
+ * boot sync still seeds the default provider configs from them, so the
+ * built-in sources land installed and usable with no successful network round
+ * trip, and the catalog is reported as never having been checked. Once the
+ * proxy recovers, the next reachable sync auto-replaces a bundle-seeded
+ * manifest with the catalog copy with no manual apply, and does not re-seed
+ * the configs on top of the offline ones.
  */
 
 const BUMPED = '9.9.9'
+
+const BUILT_IN_NAMES = [
+  /DanDanPlay|弹弹play/,
+  /Bilibili|B站/,
+  /Tencent Video|腾讯视频/,
+]
 
 test.use({
   catalogMock: offlineCatalog(),
@@ -31,40 +39,49 @@ test.use({
   ],
 })
 
-test('built-in sources load from the bundled catalog when the proxy is unreachable on first boot', async ({
+// applyProfile is off limits here: it clears storage, which would wipe the
+// bundle-seeded manifests and configs this spec is about. Route the probes the
+// seeded sources fire on render directly instead.
+async function routeLoginProbes(context: BrowserContext): Promise<void> {
+  for (const mock of mockLoginProbes()) {
+    await context.route(mock.pattern, mock.respond)
+  }
+}
+
+test('built-in sources are installed from the bundled catalog when the proxy is unreachable on first boot', async ({
+  context,
   page,
   extensionId,
   da,
 }) => {
-  // The offline index retries once with a 1s delay before falling back to
-  // the bundle, so the manifest store fills in well after the popup would
-  // otherwise mount and query an empty registry once with no later refetch.
-  // Wait for the store directly (the RPC's ground truth) before opening the
-  // popup so the page's first query already sees the seeded catalog.
+  await routeLoginProbes(context)
+
+  // The offline index retries once with a 1s delay before falling back to the
+  // bundle, so the seed lands well after the popup would otherwise mount and
+  // query an empty list once with no later refetch. Wait for the configs (the
+  // seed's ground truth) before opening the popup.
   await expect
     .poll(
       async () => {
-        const stored = (await da.storage.get('local', 'manifests')) as Record<
-          string,
-          unknown
-        >
-        return Object.keys(stored ?? {}).length
+        const configs = await da.providerConfig.list()
+        return configs.map((config) => config.manifestId).sort()
       },
       { timeout: 10_000 }
     )
-    .toBeGreaterThan(0)
+    .toEqual(['bilibili', 'dandanplay', 'tencent'])
 
   const popup = await Popup.open(page, extensionId, '/providers')
 
   await expect(popup.providers.checkedNeverLabel()).toBeVisible()
+  await expect(popup.providers.installedHeading(3)).toBeVisible()
 
-  for (const name of [
-    /DanDanPlay|弹弹play/,
-    /Bilibili|B站/,
-    /Tencent Video|腾讯视频/,
-  ]) {
-    await expect(popup.providers.importButton(name)).toBeVisible()
+  for (const name of BUILT_IN_NAMES) {
+    await expect(popup.providers.row(name).first()).toBeVisible()
+    await expect(popup.providers.importButton(name)).toBeHidden()
   }
+
+  const configs = await da.providerConfig.list()
+  expect(configs.every((config) => config.enabled)).toBe(true)
 })
 
 test('a bundle-seeded source auto-upgrades to the catalog copy on the next reachable sync, no manual apply', async ({
@@ -73,6 +90,8 @@ test('a bundle-seeded source auto-upgrades to the catalog copy on the next reach
   extensionId,
   da,
 }) => {
+  await routeLoginProbes(context)
+
   const iqiyiName = /iQIYI|爱奇艺/
   const bundledVersion = manifestVersion('iqiyi')
 
@@ -88,14 +107,6 @@ test('a bundle-seeded source auto-upgrades to the catalog copy on the next reach
       { timeout: 10_000 }
     )
     .toBe('bundled')
-
-  // The first reachable sync after an offline boot also runs the deferred
-  // default-provider seed (unseeded because the offline boot never reached
-  // it), auto-importing dandanplay/bilibili/tencent as provider configs and
-  // triggering their login probes. Orthogonal to the bundle auto-upgrade
-  // under test here, so mark seeding done up front to keep this test scoped
-  // to the manifest catalog.
-  await da.providerConfig.markSeeded()
 
   const popup = await Popup.open(page, extensionId, '/providers')
   await expect(popup.providers.catalogRow(iqiyiName)).toContainText(
@@ -116,6 +127,7 @@ test('a bundle-seeded source auto-upgrades to the catalog copy on the next reach
     `v${BUMPED}`
   )
   await expect(popup.providers.checkedNeverLabel()).toBeHidden()
+  await expect(popup.providers.installedHeading(3)).toBeVisible()
 
   const stored = (await da.storage.get('local', 'manifests')) as Record<
     string,

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -203,7 +203,7 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     const result = await settleIndexRetry(() => registry.update())
 
-    expect(result).toBe(false)
+    expect(result).toBe('unreachable')
     expect(fetchMock).toHaveBeenCalledTimes(2)
 
     const bundledIds = bundledCatalogIndex()
@@ -228,7 +228,7 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     const result = await registry.update()
 
-    expect(result).toBe(false)
+    expect(result).toBe('empty')
     expect(Object.keys(await store.getAll()).sort()).toEqual(
       bundledCatalogIndex()
         .map((entry) => entry.id)
@@ -248,7 +248,7 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     const result = await registry.update()
 
-    expect(result).toBe(false)
+    expect(result).toBe('empty')
     expect(fileFetches(fetchMock)).toEqual([])
     const bundledIds = bundledCatalogIndex()
       .map((entry) => entry.id)
@@ -271,7 +271,7 @@ describe('ManifestRegistry', () => {
     await registry.ready
     const result = await registry.update()
 
-    expect(result).toBe(true)
+    expect(result).toBe('synced')
     const stored = await store.get('dandanplay')
     expect(stored?.kind).toBe('preinstalled')
     expect(stored?.manifest).toMatchObject({ version: '0.6.0' })
@@ -338,7 +338,7 @@ describe('ManifestRegistry', () => {
     const registry = new ManifestRegistry(silentLogger, store)
     const result = await registry.update()
 
-    expect(result).toBe(true)
+    expect(result).toBe('synced')
     expect(registry.list()).toEqual(['one'])
     expect(setMany).toHaveBeenCalledTimes(1)
     expect(Object.keys(setMany.mock.calls[0][0])).toEqual(['one'])
@@ -466,7 +466,9 @@ describe('ManifestRegistry', () => {
     const fetchMock = stubFetch(() => ({ status: 503, body: 'unavailable' }))
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(false)
+    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(
+      'unreachable'
+    )
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(Object.keys(await store.getAll()).sort()).toEqual(
@@ -490,7 +492,9 @@ describe('ManifestRegistry', () => {
     })
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(true)
+    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(
+      'synced'
+    )
 
     expect(indexCalls).toBe(2)
     expect(registry.list()).toEqual(['one'])
@@ -504,7 +508,9 @@ describe('ManifestRegistry', () => {
     )
     const store = new InMemoryStore()
     const registry = new ManifestRegistry(silentLogger, store)
-    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(false)
+    await expect(settleIndexRetry(() => registry.update())).resolves.toBe(
+      'unreachable'
+    )
 
     expect(Object.keys(await store.getAll()).sort()).toEqual(
       bundledCatalogIndex()

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -16,9 +16,10 @@ import type {
  * fetching files or applying; applyUpdates replaces only the named preinstalled
  * ids, never a user import or an unseeded id), skipping a bad/failed file,
  * index failures (one retry after a delay, then give up), the offline bundle
- * fallback seeding built-ins only when the index is unreachable, that neither
- * update() nor getPendingUpdates stamps
- * lastCheckedAt (only recordChecked does), and
+ * fallback seeding built-ins whenever the index yields no usable manifests
+ * (unreachable, empty, or all entries dropped by the apiVersion filter) and
+ * never when it yields some, that neither update() nor getPendingUpdates
+ * stamps lastCheckedAt (only recordChecked does), and
  * register / unregister / hydrate-skip-invalid.
  */
 
@@ -219,6 +220,41 @@ describe('ManifestRegistry', () => {
     for (const id of bundledIds) {
       expect(stored[id]?.kind).toBe('bundled')
     }
+  })
+
+  it('update seeds the bundled catalog when the index lists no manifests', async () => {
+    stubCatalogFetch([], {})
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    const result = await registry.update()
+
+    expect(result).toBe(false)
+    expect(Object.keys(await store.getAll()).sort()).toEqual(
+      bundledCatalogIndex()
+        .map((entry) => entry.id)
+        .sort()
+    )
+  })
+
+  it('update seeds the bundled catalog when every index entry fails the apiVersion check', async () => {
+    const fetchMock = stubCatalogFetch(
+      [
+        catalogEntry('future', '1.0.0', 999),
+        catalogEntry('later', '2.0.0', 998),
+      ],
+      {}
+    )
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+    const result = await registry.update()
+
+    expect(result).toBe(false)
+    expect(fileFetches(fetchMock)).toEqual([])
+    const bundledIds = bundledCatalogIndex()
+      .map((entry) => entry.id)
+      .sort()
+    expect(Object.keys(await store.getAll()).sort()).toEqual(bundledIds)
+    expect(registry.list().sort()).toEqual(bundledIds)
   })
 
   it('update auto-upgrades a bundle-seeded entry once the index becomes reachable', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -40,6 +40,13 @@ type CatalogManifest = { raw: unknown; parsed: Manifest }
 export const CATALOG_UNREACHABLE_MESSAGE =
   'Failed to fetch the manifest catalog'
 
+// A catalog that answered but offers nothing this build can run is not a
+// network failure, so it must not be reported as one.
+export const CATALOG_EMPTY_MESSAGE =
+  'The manifest catalog has no sources this version can use'
+
+export type CatalogSyncResult = 'synced' | 'unreachable' | 'empty'
+
 function storedVersion(manifest: unknown): unknown {
   if (
     manifest !== null &&
@@ -163,23 +170,26 @@ export class ManifestRegistry {
   // Add-only for everything except a bundle-seeded entry: a changed
   // preinstalled manifest surfaces via getPendingUpdates instead of being
   // replaced here, but a 'bundled' entry auto-upgrades to the catalog copy
-  // the moment the index is reachable again, with no manual apply. Returns
-  // false when the catalog index yielded no usable manifests.
+  // the moment the index is reachable again, with no manual apply.
   //
   // Remote is primary because it's fresh; the bundled catalog is a same-shape
   // fallback used only when remote is unusable, so providers still exist
   // offline. The bundle can be stale, so the first successful sync replaces
   // any still-listed bundled entry outright rather than waiting for a manual
   // update, since the user never chose to install the bundled version.
-  async update(): Promise<boolean> {
+  async update(): Promise<CatalogSyncResult> {
     await this.ready
     const entries = await this.loadIndex()
+    if (!entries) {
+      await this.seedFromBundle()
+      return 'unreachable'
+    }
     // An index that parses but lists nothing usable (empty, or every entry
     // dropped by the api-version filter) leaves the user with no sources just
-    // as an unreachable one does, so both fall back to the bundle.
-    if (!entries || entries.length === 0) {
+    // as an unreachable one does, so it falls back to the bundle too.
+    if (entries.length === 0) {
       await this.seedFromBundle()
-      return false
+      return 'empty'
     }
     const stored = await this.store.getAll()
     const missing = entries.filter((entry) => !stored[entry.id])
@@ -187,7 +197,7 @@ export class ManifestRegistry {
       (entry) => stored[entry.id]?.kind === 'bundled'
     )
     await this.fetchAndStore([...missing, ...bundledStale])
-    return true
+    return 'synced'
   }
 
   // Index-only: diff stored versions against the catalog without fetching files

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -164,17 +164,20 @@ export class ManifestRegistry {
   // preinstalled manifest surfaces via getPendingUpdates instead of being
   // replaced here, but a 'bundled' entry auto-upgrades to the catalog copy
   // the moment the index is reachable again, with no manual apply. Returns
-  // false when the catalog index could not be fetched.
+  // false when the catalog index yielded no usable manifests.
   //
   // Remote is primary because it's fresh; the bundled catalog is a same-shape
-  // fallback used only when remote is unreachable, so providers still exist
+  // fallback used only when remote is unusable, so providers still exist
   // offline. The bundle can be stale, so the first successful sync replaces
   // any still-listed bundled entry outright rather than waiting for a manual
   // update, since the user never chose to install the bundled version.
   async update(): Promise<boolean> {
     await this.ready
     const entries = await this.loadIndex()
-    if (!entries) {
+    // An index that parses but lists nothing usable (empty, or every entry
+    // dropped by the api-version filter) leaves the user with no sources just
+    // as an unreachable one does, so both fall back to the bundle.
+    if (!entries || entries.length === 0) {
       await this.seedFromBundle()
       return false
     }

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -403,7 +403,7 @@ describe('ProviderService.refreshCatalog', () => {
     const getPendingUpdates = vi.fn(async () => opts.pending)
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => true),
+      update: vi.fn(async () => 'synced'),
       getPendingUpdates,
       applyUpdates,
       recordChecked,
@@ -489,7 +489,7 @@ describe('ProviderService.refreshCatalog', () => {
     const getPendingUpdates = vi.fn(async () => [])
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => false),
+      update: vi.fn(async () => 'unreachable'),
       getPendingUpdates,
       applyUpdates: vi.fn(async () => {}),
       recordChecked,
@@ -515,6 +515,34 @@ describe('ProviderService.refreshCatalog', () => {
 
     expect(getPendingUpdates).not.toHaveBeenCalled()
     expect(recordChecked).not.toHaveBeenCalled()
+  })
+
+  it('throws a fetch-free error when the catalog answers with nothing usable', async () => {
+    const registry = {
+      ready: Promise.resolve(true),
+      update: vi.fn(async () => 'empty'),
+      getPendingUpdates: vi.fn(async () => []),
+      applyUpdates: vi.fn(async () => {}),
+      recordChecked: vi.fn(async () => {}),
+      listManifests: vi.fn(() => []),
+      getLastCheckedAt: vi.fn(async () => 0),
+    } as unknown as ManifestRegistry
+    const service = new ProviderService(
+      {} as unknown as DanmakuService,
+      {} as unknown as SeasonService,
+      {
+        hasSeeded: vi.fn(async () => true),
+      } as unknown as ProviderConfigService,
+      vi.fn(),
+      registry,
+      {} as unknown as BookmarkService,
+      silentLogger,
+      silentExtensionOptions
+    )
+
+    await expect(service.refreshCatalog()).rejects.toThrow(
+      /no sources this version can use/
+    )
   })
 })
 
@@ -562,7 +590,8 @@ describe('ProviderService.seedDefaultProviders', () => {
     seeded?: boolean
     manifests?: { id: string; name: string }[]
     lang?: string
-    synced?: boolean
+    catalog?: 'synced' | 'unreachable' | 'empty'
+    existingConfigs?: ProviderConfig[]
   }) {
     let seeded = opts.seeded ?? false
     const set = vi.fn(async (_configs: ProviderConfig[]) => {})
@@ -574,14 +603,14 @@ describe('ProviderService.seedDefaultProviders', () => {
       options: { set, onChange: vi.fn() },
       markSeeded,
       hasSeeded,
-      getAll: vi.fn(async () => []),
+      getAll: vi.fn(async () => opts.existingConfigs ?? []),
     } as unknown as ProviderConfigService
 
     const listManifests = vi.fn(() => opts.manifests ?? DEFAULT_MANIFESTS)
     const recordChecked = vi.fn(async () => {})
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => opts.synced ?? true),
+      update: vi.fn(async () => opts.catalog ?? 'synced'),
       getPendingUpdates: vi.fn(async () => []),
       recordChecked,
       listManifests,
@@ -686,7 +715,9 @@ describe('ProviderService.seedDefaultProviders', () => {
   })
 
   it('locks the flag without seeding when an existing install updates', async () => {
-    const { service, set, markSeeded, hasSeeded } = buildForSeed({})
+    const { service, set, markSeeded, hasSeeded } = buildForSeed({
+      existingConfigs: [makeConfig('mine')],
+    })
 
     service.setup()
     const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
@@ -716,10 +747,10 @@ describe('ProviderService.seedDefaultProviders', () => {
 
   it('seeds from the bundled manifests when the catalog is unreachable', async () => {
     const { service, set, markSeeded, recordChecked } = buildForSeed({
-      synced: false,
+      catalog: 'unreachable',
     })
 
-    await expect(service.syncCatalog()).resolves.toBe(false)
+    await expect(service.syncCatalog()).resolves.toBe('unreachable')
 
     expect(set).toHaveBeenCalledTimes(1)
     expect(set.mock.calls[0][0].map((c) => c.manifestId)).toEqual([
@@ -734,7 +765,7 @@ describe('ProviderService.seedDefaultProviders', () => {
   it('does not seed on an unreachable catalog once the flag is locked', async () => {
     const { service, set, markSeeded } = buildForSeed({
       seeded: true,
-      synced: false,
+      catalog: 'unreachable',
     })
 
     await service.syncCatalog()
@@ -750,6 +781,44 @@ describe('ProviderService.seedDefaultProviders', () => {
 
     expect(set).toHaveBeenCalledTimes(1)
     expect(markSeeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('locks the flag instead of writing over configs that already exist', async () => {
+    const { service, set, markSeeded } = buildForSeed({
+      existingConfigs: [makeConfig('mine')],
+    })
+
+    await service.seedDefaultProviders()
+
+    expect(set).not.toHaveBeenCalled()
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('seeds an install whose first run never reached the seed when it updates', async () => {
+    const { service, set, markSeeded } = buildForSeed({})
+
+    service.setup()
+    const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
+    const listener = calls.at(-1)?.[0] as (details: {
+      reason: string
+    }) => Promise<void>
+    await listener({ reason: 'update' })
+
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-seed an update install whose configs the user deleted', async () => {
+    const { service, set } = buildForSeed({ seeded: true })
+
+    service.setup()
+    const calls = vi.mocked(chrome.runtime.onInstalled.addListener).mock.calls
+    const listener = calls.at(-1)?.[0] as (details: {
+      reason: string
+    }) => Promise<void>
+    await listener({ reason: 'update' })
+
+    expect(set).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -499,7 +499,9 @@ describe('ProviderService.refreshCatalog', () => {
     const service = new ProviderService(
       {} as unknown as DanmakuService,
       {} as unknown as SeasonService,
-      {} as unknown as ProviderConfigService,
+      {
+        hasSeeded: vi.fn(async () => true),
+      } as unknown as ProviderConfigService,
       vi.fn(),
       registry,
       {} as unknown as BookmarkService,
@@ -560,6 +562,7 @@ describe('ProviderService.seedDefaultProviders', () => {
     seeded?: boolean
     manifests?: { id: string; name: string }[]
     lang?: string
+    synced?: boolean
   }) {
     let seeded = opts.seeded ?? false
     const set = vi.fn(async (_configs: ProviderConfig[]) => {})
@@ -575,11 +578,12 @@ describe('ProviderService.seedDefaultProviders', () => {
     } as unknown as ProviderConfigService
 
     const listManifests = vi.fn(() => opts.manifests ?? DEFAULT_MANIFESTS)
+    const recordChecked = vi.fn(async () => {})
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => true),
+      update: vi.fn(async () => opts.synced ?? true),
       getPendingUpdates: vi.fn(async () => []),
-      recordChecked: vi.fn(async () => {}),
+      recordChecked,
       listManifests,
     } as unknown as ManifestRegistry
 
@@ -598,7 +602,7 @@ describe('ProviderService.seedDefaultProviders', () => {
       extensionOptions
     )
 
-    return { service, set, markSeeded, hasSeeded, listManifests }
+    return { service, set, markSeeded, hasSeeded, listManifests, recordChecked }
   }
 
   it('seeds the preloaded set with manifest-derived names on a fresh install', async () => {
@@ -705,6 +709,44 @@ describe('ProviderService.seedDefaultProviders', () => {
       reason: string
     }) => Promise<void>
     await listener({ reason: 'install' })
+
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('seeds from the bundled manifests when the catalog is unreachable', async () => {
+    const { service, set, markSeeded, recordChecked } = buildForSeed({
+      synced: false,
+    })
+
+    await expect(service.syncCatalog()).resolves.toBe(false)
+
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(set.mock.calls[0][0].map((c) => c.manifestId)).toEqual([
+      'dandanplay',
+      'bilibili',
+      'tencent',
+    ])
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+    expect(recordChecked).not.toHaveBeenCalled()
+  })
+
+  it('does not seed on an unreachable catalog once the flag is locked', async () => {
+    const { service, set, markSeeded } = buildForSeed({
+      seeded: true,
+      synced: false,
+    })
+
+    await service.syncCatalog()
+
+    expect(set).not.toHaveBeenCalled()
+    expect(markSeeded).not.toHaveBeenCalled()
+  })
+
+  it('seeds once when two syncs run at the same time', async () => {
+    const { service, set, markSeeded } = buildForSeed({})
+
+    await Promise.all([service.syncCatalog(), service.syncCatalog()])
 
     expect(set).toHaveBeenCalledTimes(1)
     expect(markSeeded).toHaveBeenCalledTimes(1)

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -39,7 +39,9 @@ import { invariant, isServiceWorker } from '@/common/utils/utils'
 import type { OmitSeasonId } from './IDanmakuProvider'
 import { MANIFEST_RUN_OPTIONS } from './ManifestProviderService'
 import {
+  CATALOG_EMPTY_MESSAGE,
   CATALOG_UNREACHABLE_MESSAGE,
+  type CatalogSyncResult,
   ManifestRegistry,
 } from './ManifestRegistry'
 import {
@@ -396,19 +398,37 @@ export class ProviderService {
 
   private async onInstalled(reason: string): Promise<void> {
     if (reason === 'update') {
-      // Lock the flag for an existing install so its configs are never
-      // re-seeded, even if the user has deleted them all.
-      await this.providerConfigService.markSeeded()
+      await this.lockSeedForExistingInstall()
     }
     await this.syncCatalog()
   }
 
-  // Throws on an unreachable catalog so a user-driven refresh surfaces the
-  // failure instead of silently returning the stale list.
+  // Lock the flag for an existing install so its configs are never re-seeded,
+  // even if the user has deleted them all. An unset flag with no configs is a
+  // different user: their first-run seed never happened, so leave them
+  // unlocked for the sync that follows to heal.
+  private async lockSeedForExistingInstall(): Promise<void> {
+    if (await this.providerConfigService.hasSeeded()) {
+      return
+    }
+    const configs = await this.providerConfigService.getAll()
+    if (configs.length === 0) {
+      return
+    }
+    await this.providerConfigService.markSeeded()
+  }
+
+  // Throws on a catalog that produced no usable list so a user-driven refresh
+  // surfaces the failure instead of silently returning the stale list, and
+  // says which failure it was: a catalog that answered but offers nothing this
+  // build can run is not a network problem.
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
-    const synced = await this.syncCatalog()
-    if (!synced) {
+    const result = await this.syncCatalog()
+    if (result === 'unreachable') {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
+    }
+    if (result === 'empty') {
+      throw new Error(CATALOG_EMPTY_MESSAGE)
     }
     return this.listManifests(locale)
   }
@@ -416,11 +436,11 @@ export class ProviderService {
   // Bring the catalog current: updates for uninstalled sources (no config or
   // user data to disturb) are applied here, while installed-source updates stay
   // manual via the Updates list. Records the check only on a real sync, so
-  // "checked Nm ago" never advances on a bare detection. Returns whether the
-  // catalog index yielded a usable manifest list.
-  async syncCatalog(): Promise<boolean> {
-    const fetched = await this.manifestRegistry.update()
-    if (fetched) {
+  // "checked Nm ago" never advances on a bare detection. Returns how the
+  // catalog index resolved.
+  async syncCatalog(): Promise<CatalogSyncResult> {
+    const result = await this.manifestRegistry.update()
+    if (result === 'synced') {
       // update() just reached the index, so a failure here means it died
       // mid-sync; skip the best-effort auto-apply rather than fail the sync.
       const pending = await this.manifestRegistry
@@ -446,10 +466,10 @@ export class ProviderService {
       await this.manifestRegistry.recordChecked()
     }
     // update() leaves the registry populated either way, from the catalog or
-    // from the bundle, so an unreachable catalog still seeds working sources
+    // from the bundle, so an unusable catalog still seeds working sources
     // instead of leaving a first-run user with an empty list.
     await this.seedDefaultProviders()
-    return fetched
+    return result
   }
 
   // syncCatalog can run concurrently (install, alarm, popup refresh) and the
@@ -467,6 +487,15 @@ export class ProviderService {
   // is present so a transient partial fetch never seeds a subset and then locks.
   private async runSeedDefaultProviders(): Promise<void> {
     if (await this.providerConfigService.hasSeeded()) {
+      return
+    }
+    // The flag and the configs share chrome.storage.sync, so on a signed-in
+    // profile the flag can still read as unset while the user's real configs
+    // are arriving. Any config at all means this is not a blank slate, and
+    // seeding over it would push the defaults out to every other device.
+    const existing = await this.providerConfigService.getAll()
+    if (existing.length > 0) {
+      await this.providerConfigService.markSeeded()
       return
     }
     await this.manifestRegistry.ready

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -61,6 +61,7 @@ function enrichEpisode(
 @injectable('Singleton')
 export class ProviderService {
   private readonly logger: ILogger
+  private seeding: Promise<void> | null = null
 
   constructor(
     @inject(DanmakuService)
@@ -416,43 +417,55 @@ export class ProviderService {
   // user data to disturb) are applied here, while installed-source updates stay
   // manual via the Updates list. Records the check only on a real sync, so
   // "checked Nm ago" never advances on a bare detection. Returns whether the
-  // catalog index was reachable.
+  // catalog index yielded a usable manifest list.
   async syncCatalog(): Promise<boolean> {
     const fetched = await this.manifestRegistry.update()
-    if (!fetched) {
-      return false
-    }
-    // update() just reached the index, so a failure here means it died
-    // mid-sync; skip the best-effort auto-apply rather than fail the sync.
-    const pending = await this.manifestRegistry
-      .getPendingUpdates()
-      .catch((e) => {
-        this.logger.warn('Failed to detect pending updates mid-sync:', e)
-        return []
-      })
-    const configs = await this.providerConfigService.getAll()
-    const installed = new Set(configs.map((config) => config.manifestId))
-    const uninstalled = pending
-      .filter((update) => !installed.has(update.manifestId))
-      .map((update) => update.manifestId)
-    if (uninstalled.length > 0) {
-      try {
-        await this.manifestRegistry.applyUpdates(uninstalled)
-      } catch (e) {
-        // Best-effort: a failed background apply retries next sync and must not
-        // block recording the check or the rest of the refresh.
-        this.logger.warn('Failed to auto-apply catalog updates:', e)
+    if (fetched) {
+      // update() just reached the index, so a failure here means it died
+      // mid-sync; skip the best-effort auto-apply rather than fail the sync.
+      const pending = await this.manifestRegistry
+        .getPendingUpdates()
+        .catch((e) => {
+          this.logger.warn('Failed to detect pending updates mid-sync:', e)
+          return []
+        })
+      const configs = await this.providerConfigService.getAll()
+      const installed = new Set(configs.map((config) => config.manifestId))
+      const uninstalled = pending
+        .filter((update) => !installed.has(update.manifestId))
+        .map((update) => update.manifestId)
+      if (uninstalled.length > 0) {
+        try {
+          await this.manifestRegistry.applyUpdates(uninstalled)
+        } catch (e) {
+          // Best-effort: a failed background apply retries next sync and must
+          // not block recording the check or the rest of the refresh.
+          this.logger.warn('Failed to auto-apply catalog updates:', e)
+        }
       }
+      await this.manifestRegistry.recordChecked()
     }
-    await this.manifestRegistry.recordChecked()
+    // update() leaves the registry populated either way, from the catalog or
+    // from the bundle, so an unreachable catalog still seeds working sources
+    // instead of leaving a first-run user with an empty list.
     await this.seedDefaultProviders()
-    return true
+    return fetched
   }
 
-  // Seed the preloaded configs once, after the catalog loads so each name comes
-  // from its manifest. Skips entirely until every preloaded manifest is present
-  // so a transient partial fetch never seeds a subset and then locks.
-  async seedDefaultProviders(): Promise<void> {
+  // syncCatalog can run concurrently (install, alarm, popup refresh) and the
+  // seeded flag is read asynchronously, so two in-flight seeds can both pass
+  // the check. Sharing the run keeps the write single.
+  seedDefaultProviders(): Promise<void> {
+    this.seeding ??= this.runSeedDefaultProviders().finally(() => {
+      this.seeding = null
+    })
+    return this.seeding
+  }
+
+  // Seed the preloaded configs once, after the registry is populated so each
+  // name comes from its manifest. Skips entirely until every preloaded manifest
+  // is present so a transient partial fetch never seeds a subset and then locks.
+  private async runSeedDefaultProviders(): Promise<void> {
     if (await this.providerConfigService.hasSeeded()) {
       return
     }


### PR DESCRIPTION
## Summary

- Seed the default provider configs on both sync outcomes. An offline first install registered the bundled manifests but created zero configs, because `syncCatalog()` returned early on an unreachable index and never reached `seedDefaultProviders()`. The user landed on an empty sources list with no explanation.
- Fall back to the bundled catalog whenever the index yields no usable manifests, not just when it is unreachable. `ManifestRegistry.update()` checked `loadIndex()` for null, but a parseable index with an empty `manifests` array (or one whose entries are all dropped by the supported-api-version filter) returns `[]`, which is truthy, so the bundle was skipped.
- Never seed over configs that already exist. The seeded flag and the configs both live in `chrome.storage.sync`, which on a signed-in profile can still be arriving at boot, so an offline first run could read the flag as unset and push the three defaults out to every other device. The seed now bails and locks the flag when any config is present. That also makes the non-atomic write safe: a worker killed between `options.set()` and `markSeeded()` finds configs on the next sync and locks instead of re-seeding.
- Stop locking the flag unconditionally on an update install. A user whose first run was offline on the old code has no configs and no flag, and would have been locked at zero sources forever. Flag unset plus zero configs is not a user who deleted their configs (that user's flag is set), so that pair stays unlocked and the sync heals it.
- Report a catalog that answers but lists nothing this build can run with its own message instead of the fetch-failure one. `update()` now returns `'synced' | 'unreachable' | 'empty'` and `refreshCatalog()` picks the matching error.
- Concurrent syncs (install, alarm, popup refresh) share one in-flight seed, so the asynchronous flag read cannot be raced into a double write within a process.

## Test plan

- Verified: lint `tsc --noEmit` 0 errors + `biome ci` 0 errors (16 pre-existing warnings in untouched files) · tests `vitest run` in packages/danmaku-anywhere -> 744 passed / 77 files, including 9 new cases (2 in `ManifestRegistry.test.ts` for the empty index and the all-filtered index; 7 in `ProviderService.test.ts` for the offline seed, the locked flag, two concurrent syncs, the non-empty-config guard, healing a never-seeded install on update, not re-seeding a deleted-config install on update, and the distinct empty-catalog error) · e2e `e2e/specs/providers/offline-fallback.spec.ts` (2) and `e2e/specs/sources/update-recovery.spec.ts` (3, it asserts the refresh error toast this PR touches) -> 5 passed, rebuilt with `VITE_DA_ENV=e2e` first; rest of the suite left to CI per the affected-only rule.
- Reverted the two source files and re-ran: the 2 new registry cases, the offline-seed case, the concurrency case, and the rewritten first e2e test all fail. Reverted the non-empty guard and the update-install change on their own: `locks the flag instead of writing over configs that already exist` and `seeds an install whose first run never reached the seed when it updates` both fail.
- One new case passes either way by construction and is kept as a regression guard, not as proof: `does not seed on an unreachable catalog once the flag is locked` (on the old code that path never seeds at all).

## Notes

- `offline-fallback.spec.ts` previously documented the bug (it asserted the built-ins showed Import buttons, with a comment noting the seed never ran). It now asserts the fixed behavior: the three built-ins are installed, "Installed (3)" renders, no Import button is offered for them, and the configs are enabled. The second test lost its `markSeeded()` workaround and both tests route the login probes the seeded sources fire on render, since `applyProfile` cannot be used here (it clears the storage this spec is about).
- The non-empty-config guard narrows the sync-overwrite window but cannot close it completely: configs arriving between the guard's read and `options.set()` would still be overwritten. Closing that fully needs a merge-on-arrival strategy for `chrome.storage.sync`, which is beyond this fix.
- Healing a never-seeded install re-seeds one rare pre-flag case: a user who deleted every config on a build that predates the seeded flag and then upgrades straight to this version. Any install that passed through a flag-aware version already had the flag locked on that upgrade, so the exposure is limited to that skip-upgrade path, and it is preferred over leaving genuine offline-install victims at zero sources.