### PR TITLE
(chore) drop devtools MCP, make verification a spec that went red [DA-680]

### DIFF
--- a/.claude/commands/da-dev.md
+++ b/.claude/commands/da-dev.md
@@ -70,7 +70,7 @@ Make the changes. Apply these in order:
 | Packages      | `pnpm --filter <package> test`                     | N/A                                               |
 | Cross-cutting | `pnpm lint && pnpm --filter '...[origin/master]' test` | Depends on areas touched                          |
 
-Run e2e (`pnpm --filter @mr-quin/danmaku-anywhere test:e2e`) for any PR that adds or touches an e2e spec, or that changes content scripts, mount profiles, integration policies, dango manifests, or popup flows. The suite should be running before push.
+Run e2e (`pnpm --filter @mr-quin/danmaku-anywhere test:e2e`) before pushing any PR that adds or touches an e2e spec, or that changes content scripts, mount profiles, integration policies, dango manifests, or popup flows. The full suite is ~1.8 minutes, so there is no cheaper rule worth the risk of missing something. `test:e2e:changed` and `test:e2e:smoke` are for the inner loop, not for the final check.
 
 #### Record a verify summary
 
@@ -79,7 +79,7 @@ Verification you only narrate is unauditable: a reviewer can't tell whether the 
 - `lint` (tsc + biome): pass / fail
 - tests: the scope you ran (e.g. `pnpm --filter '...[origin/master]' test`) and the result (N passed)
 - e2e: which specs ran, or skipped + a one-line reason
-- browser-verify: what you observed, if you ran it
+- red before green: the spec you added, and that you saw it fail without the change (or why the change is a refactor with no natural red)
 
 This is a record of what you actually did, not a second gate: deciding *what* to run stays your judgment, the summary just makes that judgment reviewable. Writing it also surfaces a step you meant to run and didn't.
 
@@ -97,7 +97,9 @@ Skip for trivial changes (config-only, types, docs).
 
 #### Extension: agentic verification (for the agent)
 
-For any change with runtime behavior worth observing (not just visual changes), self-verify via the `browser-verify` skill. Use it to confirm wiring (commands fire, RPC propagates, storage writes invalidate) and to capture selectors and event sequencing for the e2e spec. To exercise an already-published preview build instead (reproducing against build N, bisecting nightlies), use `preview-build`.
+For any change with runtime behavior, the verification that counts is **a spec that went red before it went green** (see `e2e-spec`). Writing it is the verification; there is no separate "I looked at it in a browser" step to report.
+
+When you don't yet know what to assert, explore first with the `browser-verify` skill and lift selectors with `generate-locator` instead of retyping them. To exercise an already-published preview build (reproducing against build N, bisecting nightlies), use `preview-build`.
 
 #### Web app: Cloudflare preview
 
@@ -118,7 +120,7 @@ Before pushing, run reviews using **clean subagents** (no prior context). They h
 - Run `/security-review` when the change touches user input, auth, APIs, or data storage
 - When the change carries runtime behavior, data contracts, migrations, non-trivial logic, or new-or-changed tests, also do a manual pass on two axes the commands above don't cover (skip for config-only, docs-only, or types-only changes). Each axis must end in a named failure; "the structure looks fine" is not a finding.
   - **Architecture / pattern fit**: does the change sit at the right seam, consistent with how the codebase already solves this? Look for a new coupling that other code now silently depends on, an invariant the types don't enforce (so a future caller can break it unnoticed), or an abstraction that duplicates one already in the tree. Name the specific seam or invariant at risk.
-  - **Test gaps & theatre**: for each new or changed test, mentally invert its guard or mutate the value under assertion; if the test would still pass, it protects nothing. Then find the behavior this PR changed that no test would catch if it regressed. Name the test that would survive its own breakage, or the behavior left unasserted.
+  - **Test gaps & theatre**: red-before-green already proves each new spec fails without the change, so spend this pass on what it does not cover: find the behavior this PR changed that no test would catch if it regressed, and name it.
 
 Fix any issues found, then add a commit. Never include Co-Authored-By or AI attribution.
 

--- a/.claude/commands/da-dev.md
+++ b/.claude/commands/da-dev.md
@@ -56,7 +56,7 @@ Make the changes. Apply these in order:
 - **YAGNI**: don't add a config knob, parameter, or branch unless *this* PR needs it. "In case someone later wants to…" is the smell. Future flexibility is cheaper to add when it's actually needed than to remove when it isn't.
 - **Library / framework idioms**: use each library's blessed patterns rather than inventing your own. Before writing a helper, check whether the framework already exposes the primitive (e.g. React hook, Hono middleware, Playwright fixture, octokit method, MUI component). For unfamiliar APIs or recent versions, fetch current docs via the `context7` MCP instead of trusting model memory. Match the project's existing usage of a library; if everywhere else uses pattern A and you're tempted to introduce pattern B, the burden of proof is on B.
 - **e2e coverage**: every feature/fix lands with e2e coverage under `packages/danmaku-anywhere/e2e/` unless coverage is genuinely infeasible. State *why* in the PR body when skipping. Use `browser-verify` while authoring the spec.
-- **Committed agent docs stay portable.** Files under `.claude/`, `CLAUDE.md`, `AGENTS.md` must not contain absolute paths into a developer's machine, OS-specific commands without an alternative, or project-specific magic values. Workspace-specific values (ClickUp IDs, browser executable paths, etc.) live in environment variables (e.g. `CLICKUP_DA_*`, `CHROME_DEVTOOLS_EXECUTABLE`) that the developer sets in their shell, not in committed files; env vars are inherited across worktrees, unlike per-project agent memory. If a workflow depends on an MCP or local tool that may not be present, declare the prerequisite so the agent can stop and tell the human on a miss.
+- **Committed agent docs stay portable.** Files under `.claude/`, `CLAUDE.md`, `AGENTS.md` must not contain absolute paths into a developer's machine, OS-specific commands without an alternative, or project-specific magic values. Workspace-specific values (ClickUp IDs, browser executable paths, etc.) live in environment variables (e.g. `CLICKUP_DA_*`) that the developer sets in their shell, not in committed files; env vars are inherited across worktrees, unlike per-project agent memory. If a workflow depends on an MCP or local tool that may not be present, declare the prerequisite so the agent can stop and tell the human on a miss.
 
 ### 4. Verify
 
@@ -70,7 +70,7 @@ Make the changes. Apply these in order:
 | Packages      | `pnpm --filter <package> test`                     | N/A                                               |
 | Cross-cutting | `pnpm lint && pnpm --filter '...[origin/master]' test` | Depends on areas touched                          |
 
-Run e2e (`pnpm --filter @mr-quin/danmaku-anywhere test:e2e`) before pushing any PR that adds or touches an e2e spec, or that changes content scripts, mount profiles, integration policies, dango manifests, or popup flows. The full suite is ~1.8 minutes, so there is no cheaper rule worth the risk of missing something. `test:e2e:changed` and `test:e2e:smoke` are for the inner loop, not for the final check.
+For extension changes, the `verifying-changes` skill owns which tier to run and the red-before-green rule. The short version: the full e2e suite is ~1.8 minutes, so run it before pushing anything that touches a spec, content scripts, mount profiles, integration policies, dango manifests, or popup flows.
 
 #### Record a verify summary
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,5 @@
   "enabledPlugins": {
     "cloudflare@claude-plugins-official": true
   },
-  "enabledMcpjsonServers": ["chrome-devtools-ext", "context7"]
+  "enabledMcpjsonServers": ["context7"]
 }

--- a/.claude/skills/browser-verify/SKILL.md
+++ b/.claude/skills/browser-verify/SKILL.md
@@ -37,8 +37,21 @@ npx -y @playwright/cli@0.1.18 -s=<session> close
 `snapshot` returns the accessibility tree with a `ref` per element. Feed a ref to `click`,
 `fill`, `hover`, or `generate-locator`.
 
-The extension's own pages work like any other URL: `goto chrome-extension://<id>/pages/popup.html`.
-Get `<id>` from the service worker (below).
+The extension's own pages work like any other URL. Get `<id>` from the service worker (below),
+and note that the built paths are not the source paths:
+
+| Page | URL |
+|---|---|
+| Popup | `chrome-extension://<id>/pages/popup.html` |
+| Dashboard | `chrome-extension://<id>/pages/dashboard.html` |
+| Segmenter | `chrome-extension://<id>/pages/segmenter.html` |
+
+Guessing a path from the source layout gets you `net::ERR_FILE_NOT_FOUND`. When in doubt, read
+`build/manifest.json` (`action.default_popup`) rather than inferring.
+
+The popup renders in whatever locale the profile resolves to, which is `zh_CN` on a fresh profile.
+Accessible names come back translated, so a locator lifted here is locale-coupled unless the
+element has a `data-testid`.
 
 ## 2. Turn what you found into spec code
 

--- a/.claude/skills/browser-verify/SKILL.md
+++ b/.claude/skills/browser-verify/SKILL.md
@@ -1,129 +1,137 @@
 ---
 name: browser-verify
-description: Use when an extension change needs agentic verification in a real browser — content scripts, popup UI, network calls, fonts, console errors. Spawns the agent's own Chrome via the chrome-devtools-ext MCP. Complements (does not replace) human-eye verification via `pnpm dev:browser`.
+description: Use when an extension change needs exploration in a real browser — finding selectors, watching a flow, reading console or network. Drives the agent's own headless Chromium through the Playwright CLI. Exploration only; the verification that counts is a spec (see `e2e-spec`).
 ---
 
-# browser-verify — agentic browser verification
+# browser-verify — exploring the extension in a real browser
 
-The agent gets its **own** Chrome (spawned by the MCP, isolated profile) so it can navigate, inspect, screenshot, and reload without interfering with the human's `dev:browser` session. Both browsers load from the **same** `packages/danmaku-anywhere/dev/chrome/` build dir, so Vite's HMR feeds both at once.
+This skill is for the part of the loop where you **don't yet know what to assert**: finding a
+selector, watching what a flow actually does, reading a console error, checking a request.
 
-## 0. Setup check
+It is not the verification. Verification is a spec that went red before it went green, on the same
+harness CI runs. See `e2e-spec`. If you already know what you're checking, skip this skill and
+write the spec.
 
-The MCP is declared as a project server in `.mcp.json` at the repo root (name `chrome-devtools-ext`, args `--isolated --categoryExtensions=true`). Confirm tools `mcp__chrome-devtools-ext__*` are available in this session. If they are, go to step 1.
-
-If they are not available:
-
-1. Approve the project server if Claude prompts for it (servers from `.mcp.json` need a one-time approval; reset with `claude mcp reset-project-choices`).
-2. Give it a browser binary. The MCP is Puppeteer-based and launches Chrome directly over a pipe connection (required by `--categoryExtensions`; `--browserUrl` / `--wsEndpoint` do not work for the extension tools). `.mcp.json` passes `--executablePath=${CHROME_DEVTOOLS_EXECUTABLE:-}`: leave the var unset to use system Chrome (stable channel), or set `CHROME_DEVTOOLS_EXECUTABLE` to a Chrome/Chromium executable. Playwright's Chromium matches the e2e suite and works:
-
-   ```bash
-   pnpm exec playwright install chromium
-   # export CHROME_DEVTOOLS_EXECUTABLE=~/.cache/ms-playwright/chromium-<rev>/chrome-linux64/chrome
-   ```
-
-   Set the var in your shell env (e.g. `~/.zshenv`) so Claude inherits it, then do a full restart. A `/mcp` reload alone will not pick up a newly exported var. Wait for confirmation before continuing.
-
-## 1. Dev loop (default during implementation)
-
-Prereq: `pnpm dev:browser` is running. Vite is writing to `packages/danmaku-anywhere/dev/chrome/`.
-
-```
-install_extension(<absolute path to packages/danmaku-anywhere/dev/chrome>)
-navigate_page(<test URL>)
-```
-
-The agent's Chrome now runs the same source the human is looking at. When code changes, Vite rewrites the bundle and both browsers pick it up. If the SW gets stale (manifest change, major refactor, lost message channel) call `reload_extension(<id>)` to nudge it.
-
-If the state machine needs seeded data (providers toggled, mount profile, custom episodes), prefer the **dev API** over raw `chrome.storage` writes. `globalThis.__da` is attached for every non-prod env — `dev`, `preview`, and `e2e` (`background/index.ts` calls `attachDevApi` when `!IS_DA_PROD`). It exposes 8 namespaces — `providerConfig`, `storage`, `extensionOptions`, `runtime`, `season`, `episode`, `bookmark`, `mount` — each going through the same write + invalidation pipeline the production code uses, so subscribers (React Query, Zustand) re-render correctly. Run from the SW context via `evaluate_script({ serviceWorkerId })`:
-
-```js
-await __da.providerConfig.toggle('builtin:dandanplay', false)
-await __da.providerConfig.toggle('builtin:bilibili', false)
-const list = await __da.providerConfig.list()  // verify
-```
-
-Discover methods with `__da.describe()` (returns `[{ name, methods: [{ name, ... }] }]`). Raw `chrome.storage.set` is a fallback for keys not exposed through the API; it works but skips the in-memory invalidation, so the UI may not pick up the change without a reload.
-
-For mount-policy seeding specifically:
-
-```js
-await chrome.storage.local.set({
-  xpathPolicy: { data: [INTEGRATION], version: LATEST_INTEGRATION_POLICY_VERSION },
-})
-await chrome.storage.sync.set({
-  mountConfig: { data: [CONFIG], version: LATEST_MOUNT_CONFIG_VERSION },
-})
-```
-
-Poll `chrome.scripting.getRegisteredContentScripts` before navigating to confirm registration.
-
-## 2. Build verify (final pass before /review)
-
-For runtime behavior that depends on prod-mode behavior (minified bundle, prod-only paths, no HMR client):
+## 0. Preflight
 
 ```bash
-cd packages/danmaku-anywhere && pnpm build
+cd packages/danmaku-anywhere && pnpm run verify:explore
 ```
 
-Then:
+This rebuilds `build/` if it is stale, hard-fails if chromium is missing, writes a ready CLI
+config, and prints the exact commands with a fresh session name. Copy them from its output.
 
+The config points at the same chromium binary the e2e suite uses, so anything you observe here
+behaves the same way inside a spec.
+
+## 1. Drive it
+
+```bash
+npx -y @playwright/cli@0.1.18 -s=<session> open --persistent --config=<config> about:blank
+npx -y @playwright/cli@0.1.18 -s=<session> goto <url>
+npx -y @playwright/cli@0.1.18 -s=<session> snapshot
+npx -y @playwright/cli@0.1.18 -s=<session> click <ref>
+npx -y @playwright/cli@0.1.18 -s=<session> close
 ```
-uninstall_extension(<dev id>)
-install_extension(<absolute path to packages/danmaku-anywhere/build>)
+
+`snapshot` returns the accessibility tree with a `ref` per element. Feed a ref to `click`,
+`fill`, `hover`, or `generate-locator`.
+
+The extension's own pages work like any other URL: `goto chrome-extension://<id>/pages/popup.html`.
+Get `<id>` from the service worker (below).
+
+## 2. Turn what you found into spec code
+
+```bash
+npx -y @playwright/cli@0.1.18 -s=<session> generate-locator <ref>
+# -> getByRole('tab', { name: '搜索番剧' })
 ```
 
-Same MCP browser, fresh artifact. For shadow-root introspection use `VITE_DA_ENV=e2e pnpm build` — the controller's shadow root opens in e2e builds only.
+Paste that straight into the spec. Don't retype a selector from a screenshot; that is how a spec
+ends up asserting something adjacent to what you actually saw.
 
-**Install the dir you actually just wrote.** `pnpm build` writes to `build/`, but a bare `vite build` writes to `dev/chrome` (the config default). If you build manually, install that dir, not whichever was sitting in `build/` from an earlier run: a stale `build/` silently runs old code and the build banner's `gitBranch` still reads correct, so a "broken" fix can really be a stale install. Confirm freshness (`ls -la <dir>/manifest.json`, or grep the compiled `<dir>/assets/*.js` for your change) before trusting a result.
+## 3. Seed state through the dev API
 
-## 3. Inspect
+`globalThis.__da` is attached on the service worker for every non-prod env. Reach it the same way
+`e2e/setup/fixtures.ts` does:
 
-| Need | Tool |
+```bash
+npx -y @playwright/cli@0.1.18 -s=<session> run-code \
+  "async page => page.context().serviceWorkers()[0].evaluate(() => globalThis.__da.describe())"
+```
+
+Namespaces: `providerConfig`, `storage`, `extensionOptions`, `runtime`, `season`, `episode`,
+`bookmark`, `mount`. Each goes through the same write and invalidation pipeline production uses,
+so subscribers re-render correctly. Raw `chrome.storage` writes skip that and the UI may not update.
+
+## 4. Inspect
+
+| Need | Command |
 |---|---|
-| Visual confirm | `take_screenshot({ filePath })` |
-| DOM / a11y tree | `take_snapshot()` |
-| Run JS in page or SW | `evaluate_script({ ..., serviceWorkerId })` |
-| Console errors | `list_console_messages({ types: ['error', 'warn'] })` |
-| Network requests | `list_network_requests({ resourceTypes: [...] })` |
+| Accessibility tree | `snapshot` |
+| Search the snapshot | `find <text>` |
+| Console | `console [min-level]` |
+| Network | `requests`, `request <n>`, `response-body <n>` |
+| Mock a request | `route <pattern>` |
+| Screenshot | `screenshot` |
+| Arbitrary Playwright | `run-code "async page => ..."` |
 
-Screenshots go to `.tmp/<topic>-<n>.png` (gitignored). Never commit them to the repo and never put them under `.claude-verify/`. There is no agentic path to attach them to PRs or ClickUp tasks; the file just stays in `.tmp/` for the human to view locally if needed.
+`run-code` gives you the real `page`, so `page.context()` reaches the whole context: service
+workers, CDP sessions, other tabs.
 
-## 4. Tear down when done
+## 5. After a rebuild, reload in place
 
-Always close the MCP browser at the end of a verification pass — otherwise a Chromium instance lingers, holding the Vite HMR socket and a `dev/chrome` filesystem lock until the Claude session exits.
-
+```bash
+npx -y @playwright/cli@0.1.18 -s=<session> run-code \
+  "async page => { const cdp = await page.context().browser().newBrowserCDPSession(); return cdp.send('Extensions.loadUnpacked', { path: '<abs>/packages/danmaku-anywhere/build' }); }"
 ```
-uninstall_extension(<id>)
-list_pages()  // close any chrome-extension://<id>/... tabs left open
-close_page(...)  // for each non-blank page
+
+This is the same CDP call `e2e/setup/swapExtension.ts` uses, and the preflight config already
+passes `--enable-unsafe-extension-debugging` to unlock it. `chrome.runtime.reload()` is not a
+substitute: it kills the worker and it does not come back.
+
+## 6. Tear down
+
+```bash
+npx -y @playwright/cli@0.1.18 -s=<session> close
+npx -y @playwright/cli@0.1.18 close-all   # if sessions were left behind
 ```
 
-When switching dev → build verify, also close any open `chrome-extension://<dev id>/...` tabs *before* the uninstall — those navigations become dead URLs once the extension is gone.
+A leftover session holds a browser process and a profile directory.
 
 ---
 
-## Notes (read when relevant)
+## Notes
 
-### Shadow DOM access on prod/dev builds
+### Profiles are disposable on purpose
 
-The controller's shadow root is `closed` outside `VITE_DA_ENV=e2e`. To inspect a closed shadow root, use `evaluate_script` — the page's V8 context can dereference the shadowRoot directly:
+Use the fresh session name the preflight prints, every run. Reusing one carries state between
+runs, and a wedged extension survives into the next session as a service worker that never
+appears. If you must reuse a session, `delete-data` clears its profile.
 
-```js
-document.getElementById('danmaku-anywhere-controller').shadowRoot.querySelector('...')
-```
+### Working directory
 
-### Ground-truth font verification
+The CLI writes `.playwright-cli/` (snapshots, console logs, screenshots, video, traces) into
+whatever directory you run it from. It is gitignored at the repo root and in the extension
+package.
 
-`document.fonts.load(...)` only proves the font reached the FontFaceSet, not that the browser actually painted with it. For what *rendered*, use CDP `CSS.getPlatformFontsForNode` (same source as DevTools' "Rendered Fonts" panel) via `evaluate_script`:
+### Rendered fonts
+
+`document.fonts.load(...)` only proves a font reached the FontFaceSet, not that it painted. For
+what actually rendered, go through CDP:
 
 ```js
 const cdp = await page.context().newCDPSession(page)
-await cdp.send('DOM.enable')
-await cdp.send('CSS.enable')
-const { result } = await cdp.send('Runtime.evaluate', { expression: '/* selector */' })
-const { nodeId } = await cdp.send('DOM.requestNode', { objectId: result.objectId })
+await cdp.send('DOM.enable'); await cdp.send('CSS.enable')
+const { root } = await cdp.send('DOM.getDocument', { depth: -1 })
+const { nodeId } = await cdp.send('DOM.querySelector', { nodeId: root.nodeId, selector: '#probe' })
 const { fonts } = await cdp.send('CSS.getPlatformFontsForNode', { nodeId })
-// fonts: Array<{ familyName, glyphCount, isCustomFont }>
 ```
 
-The target element needs a layout box — push off-screen with `position:fixed; top:-9999px;` rather than `visibility:hidden`.
+The target element needs a layout box: push it off-screen with `position:fixed; top:-9999px`
+rather than `visibility:hidden`.
+
+### The human's dev browser is separate
+
+`pnpm dev:browser` opens the human's Chrome against `dev/chrome` with HMR. That is a different
+lane and the agent does not touch it. Everything here runs off `build/`.

--- a/.claude/skills/e2e-spec/SKILL.md
+++ b/.claude/skills/e2e-spec/SKILL.md
@@ -42,26 +42,14 @@ Don't write a migration spec from this cheat sheet alone; read AGENTS.md's migra
 
 ## Red before green
 
-**A spec that has never failed has not been tested.** Before a spec counts as verification, you
-must have watched it fail without the change and pass with it. A spec that passes against the
-unmodified build asserts something other than what you fixed.
+**A spec that has never failed has not been tested.** Watch it fail against the build without your
+change before you trust it passing with the change. A spec that passes both ways asserts something
+other than what you fixed. Refactors are the exception: behavior deliberately did not change, so
+the spec goes green immediately, and weakening an assertion to manufacture a red is worse than no
+red at all.
 
-Default (cheapest): write the spec **before** the fix. The "without" build is just the current
-tree, so no extra build is needed.
-
-Fallback, when the fix is already written (the common real case): build the merge base and run the
-spec against it.
-
-```bash
-git worktree add ../da-base $(git merge-base HEAD origin/master)
-cd ../da-base && pnpm install --frozen-lockfile && pnpm build:packages
-cd packages/danmaku-anywhere && VITE_DA_ENV=e2e pnpm run build
-```
-
-Roughly 35s of building, measured. Copy the spec in, run it, watch it fail, throw the worktree away.
-
-**Refactors are the honest exception.** When behavior deliberately did not change, the spec goes
-green immediately and that is correct. Do not manufacture a red by weakening an assertion.
+`verifying-changes` owns the mechanics: how to get a build without your change, which tier to run
+afterwards, and what to record.
 
 ## Authoring loop
 
@@ -71,23 +59,7 @@ green immediately and that is correct. Do not manufacture a red by weakening an 
 4. Write it as a scratch spec under `e2e/specs/.scratch/` (gitignored, exempt from the spec lint).
 5. Watch it go **red** against the build without your change, then **green** with it.
 6. Graduate it: move the file into `e2e/specs/<area>/`. It is now real coverage.
-7. Run the tiers below.
-
-## Which tests to run
-
-Measured on this suite: the **full run is ~1.8 minutes** (89 tests). It is cheap enough that
-"run everything before pushing" is the honest default, and any rule more clever than that mostly
-buys a chance to miss something.
-
-```bash
-pnpm test:e2e:changed   # inner loop: specs you edited
-pnpm test:e2e:smoke     # ~7s sanity band: install, mount, search
-pnpm test:e2e           # before pushing: the whole suite, ~1.8 min
-```
-
-`--only-changed` selects on **changed spec files**. Specs load a built artifact rather than
-importing product source, so editing a content script selects nothing. Never treat tier 1 as a
-safety net for a product change.
+7. Run the tiers in `verifying-changes`.
 
 ## When the AGENTS.md doctrine and an AI reviewer disagree
 

--- a/.claude/skills/e2e-spec/SKILL.md
+++ b/.claude/skills/e2e-spec/SKILL.md
@@ -40,14 +40,54 @@ If you're writing under `e2e/specs/migration/`, AGENTS.md has a dedicated sectio
 
 Don't write a migration spec from this cheat sheet alone; read AGENTS.md's migration section in full.
 
+## Red before green
+
+**A spec that has never failed has not been tested.** Before a spec counts as verification, you
+must have watched it fail without the change and pass with it. A spec that passes against the
+unmodified build asserts something other than what you fixed.
+
+Default (cheapest): write the spec **before** the fix. The "without" build is just the current
+tree, so no extra build is needed.
+
+Fallback, when the fix is already written (the common real case): build the merge base and run the
+spec against it.
+
+```bash
+git worktree add ../da-base $(git merge-base HEAD origin/master)
+cd ../da-base && pnpm install --frozen-lockfile && pnpm build:packages
+cd packages/danmaku-anywhere && VITE_DA_ENV=e2e pnpm run build
+```
+
+Roughly 35s of building, measured. Copy the spec in, run it, watch it fail, throw the worktree away.
+
+**Refactors are the honest exception.** When behavior deliberately did not change, the spec goes
+green immediately and that is correct. Do not manufacture a red by weakening an assertion.
+
 ## Authoring loop
 
 1. Read `packages/danmaku-anywhere/e2e/AGENTS.md`.
 2. Find the closest existing spec under `e2e/specs/` and use it as a template. POM usage, seeding patterns, assertion shape.
-3. Use `browser-verify` while authoring to find selectors, confirm timing, and capture the event sequence. The dev API (`globalThis.__da.describe()`) lists what's available for seeding.
-4. Write the spec.
-5. Run it: `cd packages/danmaku-anywhere && pnpm test:e2e -- <spec>`. Iterate.
-6. Before pushing: full e2e run (`pnpm test:e2e`); the suite is the load-bearing verification per `da-dev` step 4.
+3. If you don't yet know what to assert, explore with `browser-verify` and lift selectors with `generate-locator` rather than retyping them.
+4. Write it as a scratch spec under `e2e/specs/.scratch/` (gitignored, exempt from the spec lint).
+5. Watch it go **red** against the build without your change, then **green** with it.
+6. Graduate it: move the file into `e2e/specs/<area>/`. It is now real coverage.
+7. Run the tiers below.
+
+## Which tests to run
+
+Measured on this suite: the **full run is ~1.8 minutes** (89 tests). It is cheap enough that
+"run everything before pushing" is the honest default, and any rule more clever than that mostly
+buys a chance to miss something.
+
+```bash
+pnpm test:e2e:changed   # inner loop: specs you edited
+pnpm test:e2e:smoke     # ~7s sanity band: install, mount, search
+pnpm test:e2e           # before pushing: the whole suite, ~1.8 min
+```
+
+`--only-changed` selects on **changed spec files**. Specs load a built artifact rather than
+importing product source, so editing a content script selects nothing. Never treat tier 1 as a
+safety net for a product change.
 
 ## When the AGENTS.md doctrine and an AI reviewer disagree
 

--- a/.claude/skills/preview-build/SKILL.md
+++ b/.claude/skills/preview-build/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: preview-build
-description: Use when you need to load a specific published preview/nightly extension build into the agent's MCP browser by run-number, branch name, or tag. Faster than rebuilding locally when you only want to exercise an existing artifact.
+description: Use when you need to load a specific published preview/nightly extension build into the agent's browser by run-number, branch name, or tag. Faster than rebuilding locally when you only want to exercise an existing artifact.
 ---
 
 # preview-build
 
-Resolve a GitHub release published by CI (nightly or branch-preview), download its Chrome zip, expand to `.tmp/`, and `install_extension` it via the `chrome-devtools-ext` MCP. For active HMR development use `browser-verify` instead.
+Resolve a GitHub release published by CI (nightly or branch-preview), download its Chrome zip, expand it to `.tmp/`, and load that directory instead of a local build. For exploring the build you just compiled, use `browser-verify` instead.
 
 ## Prerequisites
 
 - `gh` CLI authenticated against this repo
-- `chrome-devtools-ext` MCP (see `browser-verify` for install)
 - A shell with `unzip` (macOS/Linux/git-bash) or `Expand-Archive` (PowerShell)
 
 If any are missing, stop and tell the human.
@@ -60,23 +59,33 @@ gh release download $TAG --pattern $ASSET --dir $DEST
 Expand-Archive -Path "$DEST/$ASSET" -DestinationPath "$DEST/unpacked" -Force
 ```
 
-## 3. Load into the MCP browser
+## 3. Load into the browser
 
-```
-install_extension(<absolute path to the unpacked dir>)
+Point the Playwright CLI at the unpacked directory instead of `build/`. Copy the config
+`pnpm run verify:explore` writes, and swap the two extension paths for the absolute path to
+`unpacked/`:
+
+```json
+"args": [
+  "--enable-unsafe-extension-debugging",
+  "--disable-extensions-except=<abs>/.tmp/preview-<tag>/unpacked",
+  "--load-extension=<abs>/.tmp/preview-<tag>/unpacked"
+]
 ```
 
-Resolve the absolute path from the current working directory (`pwd` / `Get-Location`); don't embed a host-specific prefix.
+Then open a session as in `browser-verify`, using a fresh session name so the profile is
+disposable. Resolve the absolute path from the current working directory (`pwd` / `Get-Location`);
+don't embed a host-specific prefix.
 
 The dev API (`globalThis.__da`) is NOT present in these builds; nightly tags ship prod, and `attachDevApi` is gated by `!IS_DA_PROD`. Seed state via `chrome.storage.set` directly.
 
 ## 4. Tear down
 
-```
-uninstall_extension(<id from list_extensions>)
+```bash
+npx -y @playwright/cli@0.1.18 -s=<session> close
 ```
 
-Close lingering `chrome-extension://<id>/...` tabs first.
+A leftover session holds a browser process and its profile directory.
 
 ## Gotchas
 

--- a/.claude/skills/verifying-changes/SKILL.md
+++ b/.claude/skills/verifying-changes/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: verifying-changes
+description: Use after changing extension code, to prove it works: which test tier to run, the red-before-green rule, and what to record in the PR test plan. Start here, then branch to `browser-verify` or `e2e-spec` as needed.
+---
+
+# verifying-changes
+
+The entry point for "I changed something, now show that it works."
+
+Verification here is not a report you write. It is **a spec that failed before your change and
+passes after it**, plus the commands you actually ran. An agent that narrates "verified in
+browser" produces output indistinguishable from one that never opened a browser, which is why the
+loop below is built around artifacts instead of claims.
+
+## The loop
+
+1. **Know what you're asserting?**
+   - No: explore first with `browser-verify` (headless Chromium, extension loaded, dev-API
+     seeding). Lift selectors with `generate-locator` rather than retyping them.
+   - Yes: skip straight to the spec.
+2. **Write the spec** as a scratch file under `e2e/specs/.scratch/` (gitignored, skipped by the
+   spec lint). See `e2e-spec` for the rules that get specs bounced in review.
+3. **Watch it go red** against the build *without* your change. A spec that passes both ways
+   asserts something other than what you fixed.
+4. **Make it green**, then graduate it: move the file into `e2e/specs/<area>/`.
+5. **Run the right tier** (below) and record what you ran.
+
+Refactors are the honest exception to step 3: behavior deliberately did not change, so the spec
+goes green immediately. Do not weaken an assertion to manufacture a red.
+
+## Which tier to run
+
+From `packages/danmaku-anywhere`:
+
+```bash
+pnpm lint                # tsc + biome + the spec theatre lint
+pnpm test:e2e:changed    # inner loop: specs you edited
+pnpm test:e2e:smoke      # ~7s band: install, mount, search
+pnpm test:e2e            # before pushing: whole suite, ~1.8 min
+```
+
+The full suite is ~1.8 minutes, so **run it before pushing**. Anything cleverer buys seconds and
+risks missing a regression.
+
+`--only-changed` selects on changed *spec files*. Specs load a built artifact rather than
+importing product source, so editing a content script selects **nothing**. Never treat tier 1 as a
+safety net for a product change.
+
+Unit and package tests: `pnpm --filter <package> test`, or
+`pnpm --filter '...[origin/master]' test` for a cross-cutting change.
+
+## Getting a build without your change
+
+For step 3, when the fix is already written:
+
+```bash
+git worktree add ../da-base $(git merge-base HEAD origin/master)
+cd ../da-base && pnpm install --frozen-lockfile && pnpm build:packages
+cd packages/danmaku-anywhere && VITE_DA_ENV=e2e pnpm run build
+```
+
+About 35s of building, measured. Copy the spec in, watch it fail, throw the worktree away.
+
+## What to record
+
+In the PR's Test plan, one line each. This is a record of what you did, not a second gate.
+
+- `lint`: pass or fail
+- tests: the scope you ran and the result
+- e2e: which specs ran, or skipped with a one-line reason
+- red before green: the spec you added and that you saw it fail first, or why the change is a
+  refactor with no natural red
+
+## Gotchas that waste a loop
+
+- **The build must match the tree.** `globalSetup` refuses a stale or wrong-env `build/`, and
+  `pnpm run verify:explore` repairs it. If a spec behaves impossibly, check that first.
+- **Sibling worktrees exist.** Use absolute paths; a relative `cd` can land you in another
+  checkout and your edits will appear to vanish.
+- **Extensions need `build/`**, not `dev/chrome`. The latter is the human's `pnpm dev:browser`
+  lane and the agent never touches it.
+
+## Canonical doctrine
+
+`packages/danmaku-anywhere/e2e/AGENTS.md` owns the e2e rules and auto-loads when you work in that
+directory. This skill is the entry point; that file is the authority.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,5 @@
 {
   "mcpServers": {
-    "chrome-devtools-ext": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "chrome-devtools-mcp@latest",
-        "--isolated",
-        "--categoryExtensions=true",
-        "--executablePath=${CHROME_DEVTOOLS_EXECUTABLE:-}"
-      ]
-    },
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,23 +116,6 @@ Don't hardcode a model name as policy; the roster changes. Reason in tiers and p
 - Use TDD when refactoring — write tests first, start with reusable primitives
 - Step back and think holistically before refactoring — don't anchor to the current implementation
 
-## Skills
-
-Task-specific playbooks live in `.claude/skills/`. Reach for one when its trigger matches; each is
-short and points at the canonical docs rather than restating them.
-
-| Skill | Reach for it when |
-|---|---|
-| `verifying-changes` | You changed code and need to prove it works. Start here: which tier to run, red before green, what to record. |
-| `browser-verify` | You don't yet know what to assert. Explores the extension in headless Chromium via the Playwright CLI. |
-| `e2e-spec` | You are writing or modifying a spec under `packages/danmaku-anywhere/e2e/`. |
-| `i18n` | You are adding or changing user-facing strings. |
-| `reviewing-ai-feedback` | An AI reviewer left comments on a PR. |
-| `babysit-pr` | A PR is open and you want it watched to green. |
-| `preview-build` | You want to exercise an already-published preview or nightly build. |
-| `specs-in-clickup` | You are finishing a brainstorm, design spec, or implementation plan. |
-| `worktree-tab` | You need a fresh session in a new terminal tab for a worktree. |
-
 ## Per-package context
 
 Each package/app has its own `AGENTS.md` with package-specific conventions and gotchas. Read the relevant `AGENTS.md` when working on a specific package. See `package.json` in each package for available scripts and dependencies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,23 @@ Don't hardcode a model name as policy; the roster changes. Reason in tiers and p
 - Use TDD when refactoring — write tests first, start with reusable primitives
 - Step back and think holistically before refactoring — don't anchor to the current implementation
 
+## Skills
+
+Task-specific playbooks live in `.claude/skills/`. Reach for one when its trigger matches; each is
+short and points at the canonical docs rather than restating them.
+
+| Skill | Reach for it when |
+|---|---|
+| `verifying-changes` | You changed code and need to prove it works. Start here: which tier to run, red before green, what to record. |
+| `browser-verify` | You don't yet know what to assert. Explores the extension in headless Chromium via the Playwright CLI. |
+| `e2e-spec` | You are writing or modifying a spec under `packages/danmaku-anywhere/e2e/`. |
+| `i18n` | You are adding or changing user-facing strings. |
+| `reviewing-ai-feedback` | An AI reviewer left comments on a PR. |
+| `babysit-pr` | A PR is open and you want it watched to green. |
+| `preview-build` | You want to exercise an already-published preview or nightly build. |
+| `specs-in-clickup` | You are finishing a brainstorm, design spec, or implementation plan. |
+| `worktree-tab` | You need a fresh session in a new terminal tab for a worktree. |
+
 ## Per-package context
 
 Each package/app has its own `AGENTS.md` with package-specific conventions and gotchas. Read the relevant `AGENTS.md` when working on a specific package. See `package.json` in each package for available scripts and dependencies.

--- a/packages/danmaku-anywhere/.gitignore
+++ b/packages/danmaku-anywhere/.gitignore
@@ -10,3 +10,4 @@ blob-report
 .playwright-profile
 .e2e-cache
 .playwright-cli
+e2e/specs/.scratch

--- a/packages/danmaku-anywhere/e2e/AGENTS.md
+++ b/packages/danmaku-anywhere/e2e/AGENTS.md
@@ -12,6 +12,46 @@ Three layers, in increasing cost and fragility:
 
 The deciding question for any spec: **if you removed every UI assertion, would the test still pass on data alone?** If yes, it isn't e2e — move it down a layer. State-only assertions wearing a Playwright costume cost ~100× a unit test and catch less.
 
+## Red before green
+
+A spec that has never failed has not been tested. Before a spec counts as verification, watch it
+fail against the build *without* the change and pass *with* it. A spec that passes both ways
+asserts something other than what changed.
+
+Write the spec first where you can; that makes the "without" build the current tree and costs
+nothing. When the change is already written, build the merge base into a throwaway worktree and
+run the spec against that (~35s of building, measured).
+
+Refactors are the exception: behavior deliberately did not change, so the spec goes green
+immediately. Do not weaken an assertion to manufacture a red.
+
+Scratch specs live in `e2e/specs/.scratch/`, which is gitignored and skipped by the spec lint.
+A scratch spec becomes real coverage by moving the file into `e2e/specs/<area>/`.
+
+## The spec lint
+
+`pnpm run lint:specs` (part of `pnpm lint`) fails any spec that asserts only on state with no
+user-visible signal. It hard-fails locally and only warns under `CI`, so it bites the loop that
+wrote the spec without gating an outside contributor's PR.
+
+Behavior with genuinely no UI surface opts out by naming the reason in a comment:
+
+```
+lint-specs-allow-state-only: OPFS scope has no DOM signal, so it asserts storage state.
+```
+
+Treat an opt-out the same as an `expectedConsoleErrors` entry: one line, and it has to say why.
+
+## Which tests to run
+
+The full suite is ~1.8 minutes (89 tests), measured. That is cheap enough that running everything
+before a push is the default.
+
+- `pnpm test:e2e:changed` — inner loop, specs you edited. Selects on changed *spec files*: a
+  content-script edit selects nothing, so this is never a safety net for a product change.
+- `pnpm test:e2e:smoke` — ~7s band tagged `@smoke`: install, mount, search.
+- `pnpm test:e2e` — before pushing.
+
 ## Every e2e spec asserts at least one user-visible signal
 
 User-visible means observable from the rendered DOM, a download, or a navigation. Concretely:


### PR DESCRIPTION
Stacked on #534.

## Problem

The devtools MCP was the only reason the agent lane touched `dev/chrome`, needed `CHROME_DEVTOOLS_EXECUTABLE`, and copied builds between worktrees. It also produced screenshots the agent chose, so verification evidence was still a self-report with pictures attached, and every selector had to be retyped from what the agent remembered seeing.

Three docs disagreed about which tests to run before pushing: the `e2e-spec` skill said full suite, `da-dev.md:73` said the suite should be running, and the standing agent memory said never run it locally.

## Fix

Replace the MCP with the Playwright CLI, which drives the same chromium the e2e suite uses. Parity was checked against a real build: extension load, service worker and all eight `__da` namespaces, popup render and drive, CDP `CSS.getPlatformFontsForNode`, console, network, screenshot. It adds video, tracing, and `generate-locator`, which turns a probed element into spec-ready code. Reloading the extension in place uses the same CDP `Extensions.loadUnpacked` call `swapExtension` already relies on.

- `browser-verify` is rewritten as exploration only, for when you don't yet know what to assert.
- `e2e-spec` and `e2e/AGENTS.md` make **red before green** the verification that counts: a spec has to fail against the build without the change. This replaces the mental mutate-the-assertion pass in `da-dev.md:121` with a run that actually has to fail. Refactors are named as the exception so nobody weakens an assertion to manufacture a red.
- Scratch specs live in `e2e/specs/.scratch/` (gitignored, skipped by the lint) and graduate by moving the file.
- Which-tests-to-run is settled with a measurement: the full suite is ~1.8 minutes, so it is the pre-push default and the tiers are for the inner loop. `--only-changed` selects on changed spec files, and specs load a built artifact rather than importing product source, so a content-script edit selects nothing.

## Tests

Docs and config only; no runtime code. The parity claims above were each executed against `packages/danmaku-anywhere/build` before writing them down, and the commands in the rewritten skill are the ones that were run.