### PR TITLE
(extension) assert on what rendered, not on a node that despawns [DA-682]

### DIFF
--- a/packages/danmaku-anywhere/e2e/setup/da-client.ts
+++ b/packages/danmaku-anywhere/e2e/setup/da-client.ts
@@ -137,6 +137,20 @@ export class DaClient {
         timeoutMs,
       ] as const),
   }
+
+  danmakuRender = {
+    rendered: (tabId?: number): Promise<string[]> =>
+      this.sw.evaluate((id) => self.__da.danmakuRender.rendered(id), tabId),
+    waitForRendered: (
+      text: string,
+      tabId?: number,
+      timeoutMs?: number
+    ): Promise<string[]> =>
+      this.sw.evaluate(
+        ([x, id, t]) => self.__da.danmakuRender.waitForRendered(x, id, t),
+        [text, tabId, timeoutMs] as const
+      ),
+  }
 }
 
 export async function getDaClient(context: BrowserContext): Promise<DaClient> {

--- a/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/integration-auto-mount.spec.ts
@@ -21,8 +21,10 @@ const MOUNT_PATTERN = `${ORIGIN}/*`
 
 const EPISODE_TITLE = 'DA Integration Test'
 // Seeking past SEEK_TIME_S lands the cursor on at least one comment.
+// The comment due by SEEK_TIME_S; the render log is asserted against it.
+const FIRST_TEXT = 'first'
 const COMMENTS = [
-  { p: '12,1,16777215,e2e-1', m: 'first' },
+  { p: '12,1,16777215,e2e-1', m: FIRST_TEXT },
   { p: '24,1,16777215,e2e-2', m: 'second' },
   { p: '36,1,16777215,e2e-3', m: 'third' },
 ]
@@ -75,12 +77,13 @@ test('integration auto-mount: native <video> happy path', async ({
 
   await integrationPage.playVideo()
 
-  await expect(async () => {
-    await integrationPage.setVideoTime(SEEK_TIME_S)
-    await expect(integrationPage.commentElements().first()).toBeVisible({
-      timeout: 1_000,
-    })
-  }).toPass({ timeout: 15_000 })
+  await integrationPage.setVideoTime(SEEK_TIME_S)
+
+  // Assert on what the renderer rendered rather than racing a node that
+  // despawns as it scrolls.
+  await da.danmakuRender.waitForRendered(FIRST_TEXT)
+  // The overlay is the durable user-visible signal; a comment node despawns.
+  await expect(integrationPage.danmuContainer()).toBeVisible()
 })
 
 test('integration auto-mount: same-origin iframe <video> happy path', async ({
@@ -106,10 +109,11 @@ test('integration auto-mount: same-origin iframe <video> happy path', async ({
 
   await integrationPage.playVideo()
 
-  await expect(async () => {
-    await integrationPage.setVideoTime(SEEK_TIME_S)
-    await expect(integrationPage.commentElements().first()).toBeVisible({
-      timeout: 1_000,
-    })
-  }).toPass({ timeout: 15_000 })
+  await integrationPage.setVideoTime(SEEK_TIME_S)
+
+  // Assert on what the renderer rendered rather than racing a node that
+  // despawns as it scrolls.
+  await da.danmakuRender.waitForRendered(FIRST_TEXT)
+  // The overlay is the durable user-visible signal; a comment node despawns.
+  await expect(integrationPage.danmuContainer()).toBeVisible()
 })

--- a/packages/danmaku-anywhere/e2e/specs/integration/unknown-mode-drop.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/unknown-mode-drop.spec.ts
@@ -74,19 +74,15 @@ test('unknown comment mode is dropped without breaking the batch', async ({
   expect(mirror.episodeIds).toEqual([episodeId])
 
   await integrationPage.playVideo()
+  await integrationPage.setVideoTime(SEEK_TIME_S)
 
-  // Rendered comments scroll off and despawn, so all three checks must happen
-  // within one seek attempt; a check outside the loop can miss the window.
-  await expect(async () => {
-    await integrationPage.setVideoTime(SEEK_TIME_S)
-    await expect(
-      integrationPage.commentElements().filter({ hasText: VALID_TEXT })
-    ).toBeVisible({ timeout: 1_000 })
-    await expect(
-      integrationPage.commentElements().filter({ hasText: MODE_2_TEXT })
-    ).toBeVisible({ timeout: 1_000 })
-    await expect(
-      integrationPage.commentElements().filter({ hasText: INVALID_TEXT })
-    ).toHaveCount(0)
-  }).toPass({ timeout: 15_000 })
+  // Rendered comments despawn as they scroll, so the DOM cannot say whether the
+  // malformed one was dropped or merely already gone. The render log can.
+  const rendered = await da.danmakuRender.waitForRendered(VALID_TEXT)
+  expect(rendered).toContain(MODE_2_TEXT)
+  expect(rendered).not.toContain(INVALID_TEXT)
+
+  // The overlay itself is the durable user-visible signal; an individual
+  // comment node is not, since it despawns as it scrolls.
+  await expect(integrationPage.danmuContainer()).toBeVisible()
 })

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/DanmakuManager.service.ts
@@ -22,6 +22,7 @@ import { DanmakuDebugOverlayService } from '@/content/player/debugOverlay/Danmak
 import { OcclusionService } from '@/content/player/occlusion/Occlusion.service'
 import type { OcclusionStatus } from '@/content/player/occlusion/Occlusion.types'
 import { VideoNodeObserverService } from '@/content/player/videoObserver/VideoNodeObserver.service'
+import { recordRenderedComment } from './devRenderLog'
 
 const OCCLUSION_QUALITY_PRESETS: Record<
   OcclusionQuality,
@@ -37,6 +38,7 @@ export class DanmakuManagerService {
   private logger: ILogger
 
   private readonly renderer = new DanmakuRenderer((node, props) => {
+    recordRenderedComment(props.text)
     ReactDOM.createRoot(node).render(createElement(DanmakuComponent, props))
   })
   private readonly nodes: {

--- a/packages/danmaku-anywhere/src/content/player/danmakuManager/devRenderLog.ts
+++ b/packages/danmaku-anywhere/src/content/player/danmakuManager/devRenderLog.ts
@@ -1,0 +1,25 @@
+import { IS_DA_PROD } from '@/common/constants'
+
+// Rendered comments despawn as they scroll, so a spec that looks at the DOM
+// later cannot tell a comment that was never rendered from one that has already
+// gone. This records what the renderer actually rendered, which is the question
+// the DOM cannot answer.
+
+export const RENDER_LOG_GLOBAL = '__daRenderLog' as const
+
+declare global {
+  var __daRenderLog: string[] | undefined
+}
+
+// Long enough for a seeded fixture batch, small enough that a real session
+// cannot grow it without bound.
+const MAX_ENTRIES = 200
+
+export function recordRenderedComment(text: string): void {
+  if (IS_DA_PROD) {
+    return
+  }
+  const log = globalThis.__daRenderLog ?? []
+  log.push(text)
+  globalThis.__daRenderLog = log.slice(-MAX_ENTRIES)
+}

--- a/packages/danmaku-anywhere/src/devApi/index.ts
+++ b/packages/danmaku-anywhere/src/devApi/index.ts
@@ -4,6 +4,10 @@ import {
   BookmarkNamespace,
 } from './namespaces/BookmarkNamespace'
 import {
+  type DanmakuRenderApi,
+  DanmakuRenderNamespace,
+} from './namespaces/DanmakuRenderNamespace'
+import {
   type EpisodeApi,
   EpisodeNamespace,
 } from './namespaces/EpisodeNamespace'
@@ -41,6 +45,7 @@ const NAMESPACE_TOKENS = [
   EpisodeNamespace,
   BookmarkNamespace,
   MountNamespace,
+  DanmakuRenderNamespace,
 ] as const
 
 export interface DaApi {
@@ -54,6 +59,7 @@ export interface DaApi {
   episode: EpisodeApi
   bookmark: BookmarkApi
   mount: MountApi
+  danmakuRender: DanmakuRenderApi
 }
 
 declare global {

--- a/packages/danmaku-anywhere/src/devApi/namespaces/DanmakuRenderNamespace.ts
+++ b/packages/danmaku-anywhere/src/devApi/namespaces/DanmakuRenderNamespace.ts
@@ -1,0 +1,107 @@
+import { injectable } from 'inversify'
+import { RENDER_LOG_GLOBAL } from '@/content/player/danmakuManager/devRenderLog'
+import { type AnyMethodDef, type DevNamespace, defineMethod } from '../registry'
+
+export interface DanmakuRenderApi {
+  rendered(tabId?: number): Promise<string[]>
+  waitForRendered(
+    text: string,
+    tabId?: number,
+    timeoutMs?: number
+  ): Promise<string[]>
+}
+
+const DEFAULT_WAIT_TIMEOUT_MS = 15_000
+const POLL_INTERVAL_MS = 100
+
+async function resolveTabId(tabId?: number): Promise<number | undefined> {
+  if (tabId !== undefined) {
+    return tabId
+  }
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
+  return tab?.id
+}
+
+// The player mounts in whichever frame holds the <video>, which is a subframe
+// for the iframe integrations, so every frame has to be asked.
+async function readLog(tabId: number): Promise<string[]> {
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId, allFrames: true },
+      world: 'ISOLATED',
+      func: (key: string) => {
+        return (
+          ((globalThis as unknown as Record<string, unknown>)[key] as
+            | string[]
+            | undefined) ?? []
+        )
+      },
+      args: [RENDER_LOG_GLOBAL],
+    })
+    return results.flatMap((r) => (r.result as string[] | undefined) ?? [])
+  } catch (err) {
+    // Swallow tab-gone / no-permission so polling callers can keep retrying.
+    const message = err instanceof Error ? err.message : String(err)
+    if (
+      message.includes('No tab with id') ||
+      message.includes('Cannot access') ||
+      message.includes('Frame with ID') ||
+      message.includes('The tab was closed')
+    ) {
+      return []
+    }
+    throw err
+  }
+}
+
+@injectable('Singleton')
+export class DanmakuRenderNamespace implements DevNamespace {
+  readonly name = 'danmakuRender'
+  readonly description =
+    'What the danmaku renderer actually rendered on a tab. Rendered comments despawn as they scroll, so the DOM cannot answer whether a comment was ever rendered; this can.'
+  readonly methods: readonly AnyMethodDef[] = [
+    defineMethod({
+      name: 'rendered',
+      description:
+        'Texts the renderer has rendered on a tab, oldest first, across all frames. Defaults to the active tab.',
+      kind: 'read',
+      args: [{ name: 'tabId', type: 'number', optional: true }],
+      handler: async (tabId?: number) => {
+        const target = await resolveTabId(tabId)
+        if (target === undefined) {
+          return []
+        }
+        return readLog(target)
+      },
+    }),
+    defineMethod({
+      name: 'waitForRendered',
+      description:
+        'Poll danmakuRender.rendered() until `text` appears or timeoutMs elapses. Rejects on timeout. Defaults to the active tab.',
+      kind: 'read',
+      args: [
+        { name: 'text', type: 'string' },
+        { name: 'tabId', type: 'number', optional: true },
+        { name: 'timeoutMs', type: 'number', optional: true },
+      ],
+      handler: async (text: string, tabId?: number, timeoutMs?: number) => {
+        const target = await resolveTabId(tabId)
+        if (target === undefined) {
+          throw new Error('danmakuRender.waitForRendered: no tab to inspect')
+        }
+        const budget = timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
+        const deadline = Date.now() + budget
+        while (Date.now() < deadline) {
+          const log = await readLog(target)
+          if (log.includes(text)) {
+            return log
+          }
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+        }
+        throw new Error(
+          `danmakuRender.waitForRendered: "${text}" was not rendered on tab ${target} within ${budget}ms`
+        )
+      },
+    }),
+  ]
+}


### PR DESCRIPTION
## Problem

Three integration assertions raced a DOM node that is designed to disappear:

| Spec | Pattern |
| --- | --- |
| `unknown-mode-drop.spec.ts:91` | `playVideo()` then loop { seek; comment visible within **1s** }, 15s budget |
| `integration-auto-mount.spec.ts:83` | same |
| `integration-auto-mount.spec.ts:114` | same |

Rendered comments despawn as they scroll, so every check had to land inside a ~1s window after a seek. Under CI worker contention the render misses that window on every retry. `unknown-mode-drop` failed exactly this way on #536 and passed on a re-run of the same commit.

Worth noting what the suite does *not* have: there are no `waitForTimeout` sleeps anywhere. Waits are already `expect.poll` / `toPass`. The flakiness was never slow polling, it was that the only observable signal is transient.

**A second problem, quieter:** the malformed comment was asserted dropped via `toHaveCount(0)` on the DOM. A comment that rendered and scrolled away is indistinguishable from one never rendered, so that assertion could pass for the wrong reason and could not fail if the parser started rendering garbage.

## Fix

`DanmakuManager.service.ts` already runs a callback per rendered comment and receives the text. Record it on a content-script global (non-prod only, capped at 200), and read it back through the dev API exactly the way `__daMountMirror` is read: `chrome.scripting.executeScript` into the ISOLATED world. The player mounts in whichever frame holds the `<video>`, so this reads `allFrames: true`.

The assertions now ask what the renderer rendered. Each spec still asserts a visible signal, but on the **overlay** rather than an individual comment, because the overlay is what stays.

## Why a mirror is justified here

`e2e/AGENTS.md` puts the burden of proof on test-only mirrors and new dev-API methods. The case: the UI signal is transient *by design*, so it is genuinely unobservable at any later moment, and the mirror answers a question the DOM cannot answer at all — whether a comment was ever rendered. It makes the dropped-comment assertion strictly stronger rather than weaker. Precedent: 11 `IS_DA_E2E` branches already ship, including a mock mask provider in `uiIoc.ts`.

## Tests

- Negative control: with a deliberately wrong expectation the spec fails and prints the log, `["mode-2-comment","valid-comment"]` — the two valid comments present, the malformed one genuinely absent. The assertion bites, and the log is not empty.
- 54 repeats of the three specs after the fix: all passed.
- An earlier version that kept `commentElements().first()` as the visible signal failed **9 of 18** repeats, since asserting a comment node after the log confirmed the render is still a race. That is why the visible assertion is on the overlay.
- Runtime dropped from a 15s retry budget to ~3s per spec.
- `pnpm lint` clean, `tsc --noEmit` clean, smoke tier 3 passed.

## Rejected approach

Seeking while paused so `bindVideo` freezes the manager and comments stay on screen. Measured worse: 6/6 failures against 1/6 for the current code. `bindVideo.ts:230` explains why — `pushFlexibleDanmaku` aborts if `freeze` flips true before it commits, and the 200ms freeze timer beats the spawn under contention.

## Out of scope

`occlusion-cross-origin`, which flakes under load for a different reason (heavy MediaPipe/ONNX work under parallel workers).