### PR TITLE
(extension) wait for navigation to settle in the source-chips spec [DA-700]

### DIFF
--- a/packages/danmaku-anywhere/e2e/specs/sources/search-source-chips.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/search-source-chips.spec.ts
@@ -52,8 +52,10 @@ test('source chips: selection persists across season details navigation', async 
     'true'
   )
   await popup.search.openFirstResult('Bilibili')
+  await expect(page).toHaveURL(/#\/search\/season$/)
 
   await page.goBack()
+  await expect(page).toHaveURL(/#\/search$/)
 
   await expect(popup.search.sourceChip('Bilibili')).toHaveAttribute(
     'aria-pressed',


### PR DESCRIPTION
`search-source-chips.spec.ts` was the only red across the last fifteen CI runs, and it blocked an unrelated PR twice.

## Cause

The test clicked into season details and immediately called `goBack()`. Nothing waited for the forward navigation to complete, so `goBack()` could return to somewhere other than the search page. The `aria-pressed` assertion that follows then had nothing to retry against, and Playwright's auto-retry could not save it, which is why it presented as a five second timeout rather than an obvious wrong-page failure.

## Fix

Waits for the season-details route before going back, and for the search route before asserting. Both transitions now have a settled signal rather than an implicit one. No sleep, no loosened assertion, no skip.

## Test plan

- lint: pass. `pnpm type-check` pass.
- e2e: `search-source-chips.spec.ts` only. Full suite left to CI.
- red before green: reproduced under contention, not reasoned.

The flake does not appear at low contention: 10 repeats across 4 workers passed 20 out of 20 before the change. Raising contention to 25 repeats across 8 workers reproduced it:

```
2 failed
  e2e/specs/sources/search-source-chips.spec.ts:18:1 › source chips: selection persists across season details navigation
  e2e/specs/sources/search-source-chips.spec.ts:18:1 › source chips: selection persists across season details navigation
48 passed (1.1m)
```

After the change, the same command passed 50 of 50, run twice. Given the roughly 4 percent pre-fix failure rate, one clean run of 50 was not conclusive on its own, so it was repeated.
