### PR TITLE
(extension) force-refresh the catalog past the browser and backend caches [DA-628]

### DIFF
--- a/backend/proxy/src/middleware/cache.ts
+++ b/backend/proxy/src/middleware/cache.ts
@@ -81,6 +81,15 @@ function parseCacheControl(header?: string): RequestCacheControl {
   return directives
 }
 
+// Cloudflare caches a Worker's own outgoing fetch() subrequests, and that cache
+// is separate from caches.default: skipping the one below still leaves a route
+// free to serve bytes the origin's max-age is holding. Routes that proxy an
+// upstream use this to opt out of both for the same request.
+export function requestBypassesCache(req: HonoRequest): boolean {
+  const directives = parseCacheControl(req.header('Cache-Control'))
+  return Boolean(directives.noCache || directives.noStore)
+}
+
 export const useCache = (options: CacheOptions = {}) => {
   const { methods = ['GET'], maxAge, getCacheKey: customGetCacheKey } = options
 

--- a/backend/proxy/src/routes/api/manifest/router.test.ts
+++ b/backend/proxy/src/routes/api/manifest/router.test.ts
@@ -68,6 +68,49 @@ describe('Manifest API', () => {
     expect(content.id).toBe('builtin:bilibili')
   })
 
+  // The default-path assertions above pin a plain string URL, which is what
+  // keeps these two honest: an unconditional bypass would fail those.
+  it('bypasses the subrequest cache on a forced catalog fetch (GET /)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ packageVersion: '1', manifests: [] }), {
+        status: 200,
+      })
+    )
+
+    const request = new Request(createTestUrl('/manifest'), {
+      headers: { 'Cache-Control': 'no-cache' },
+    })
+    await makeUnitTestRequest(request)
+
+    const upstream = fetchSpy.mock.calls[0][0] as Request
+    expect(upstream).toBeInstanceOf(Request)
+    expect(upstream.url).toBe(`${dangoBaseUrl}/catalog.json`)
+    expect(upstream.cache).toBe('no-store')
+  })
+
+  it('bypasses the subrequest cache on a forced file fetch (GET /file)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'builtin:bilibili' }), {
+        status: 200,
+      })
+    )
+
+    const request = new Request(
+      createTestUrl('/manifest/file', {
+        query: { file: 'src/manifests/builtin-bilibili.json' },
+      }),
+      { headers: { 'Cache-Control': 'no-cache' } }
+    )
+    await makeUnitTestRequest(request)
+
+    const upstream = fetchSpy.mock.calls[0][0] as Request
+    expect(upstream).toBeInstanceOf(Request)
+    expect(upstream.url).toBe(
+      `${dangoBaseUrl}/src/manifests/builtin-bilibili.json`
+    )
+    expect(upstream.cache).toBe('no-store')
+  })
+
   it('returns 400 when file parameter is missing (GET /file)', async () => {
     const request = new Request(createTestUrl('/manifest/file'))
     const response = await makeUnitTestRequest(request)

--- a/backend/proxy/src/routes/api/manifest/router.ts
+++ b/backend/proxy/src/routes/api/manifest/router.ts
@@ -1,7 +1,8 @@
+import type { HonoRequest } from 'hono'
 import { describeRoute, resolver, validator } from 'hono-openapi'
 import { z } from 'zod'
 import { factory } from '@/factory'
-import { useCache } from '@/middleware/cache'
+import { requestBypassesCache, useCache } from '@/middleware/cache'
 
 export const manifestRouter = factory.createApp()
 
@@ -11,6 +12,17 @@ const dangoBaseUrl =
 const filePattern = /^src\/manifests\/[\w.-]+\.json$/
 
 const cacheMaxAge = 15 * 60
+
+// The upstream sends max-age=300, which Cloudflare honors on the Worker's own
+// subrequest, so a forced refresh that got past useCache could still be handed
+// bytes up to five minutes old. 'no-store' is the documented way to make the
+// runtime neither read nor write that cache for one subrequest.
+function fetchUpstream(req: HonoRequest, url: string): Promise<Response> {
+  if (!requestBypassesCache(req)) {
+    return fetch(url)
+  }
+  return fetch(new Request(url, { cache: 'no-store' }))
+}
 
 manifestRouter.get(
   '/',
@@ -44,7 +56,7 @@ manifestRouter.get(
     maxAge: cacheMaxAge,
   }),
   async (c) => {
-    return await fetch(`${dangoBaseUrl}/catalog.json`)
+    return await fetchUpstream(c.req, `${dangoBaseUrl}/catalog.json`)
   }
 )
 
@@ -74,6 +86,6 @@ manifestRouter.get(
   }),
   async (c) => {
     const { file } = c.req.valid('query')
-    return await fetch(`${dangoBaseUrl}/${file}`)
+    return await fetchUpstream(c.req, `${dangoBaseUrl}/${file}`)
   }
 )

--- a/packages/danmaku-anywhere/e2e/network/catalog.ts
+++ b/packages/danmaku-anywhere/e2e/network/catalog.ts
@@ -92,6 +92,35 @@ export function mockCatalog(
   }
 }
 
+export interface CatalogRequest {
+  isFile: boolean
+  cacheControl: string
+}
+
+// Wraps mockCatalog, recording each request's path kind and the Cache-Control
+// the backend would read. The fetch init's `cache` mode is not visible to route
+// interception, so only the header can be asserted from a spec.
+export function recordingCatalog(
+  ids: readonly string[],
+  versionOverrides: Record<string, string>,
+  sink: CatalogRequest[]
+): NetworkMock {
+  const base = mockCatalog(ids, versionOverrides)
+  return {
+    pattern: base.pattern,
+    respond: async (route: Route) => {
+      const headers = await route.request().allHeaders()
+      sink.push({
+        isFile: new URL(route.request().url()).pathname.endsWith(
+          '/manifest/file'
+        ),
+        cacheControl: headers['cache-control'] ?? '',
+      })
+      await base.respond(route)
+    },
+  }
+}
+
 // Simulates a fully unreachable proxy: both the index and file endpoints
 // fail. Used to exercise the offline bundled-catalog fallback in
 // ManifestRegistry, which only kicks in once the index request fails.

--- a/packages/danmaku-anywhere/e2e/specs/sources/catalog-refresh.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/sources/catalog-refresh.spec.ts
@@ -1,0 +1,93 @@
+import {
+  type CatalogRequest,
+  manifestStoreSeed,
+  manifestVersion,
+  recordingCatalog,
+} from '../../network/catalog'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Refresh and Apply on the Sources page. Each drives its button, asserts the
+ * user-visible result (the bumped version shows / the update row clears), that
+ * the request carried the backend's bypass header, and that the index was
+ * fetched once rather than once per sync step. Two things are deliberately not
+ * claimed here: the browser-side `cache: 'reload'` is invisible to route
+ * interception (ManifestRegistry.test.ts asserts it), and the route mock answers
+ * regardless of cache state, so nothing here proves a server bypass
+ * (cache.test.ts covers caches.default, manifest/router.test.ts the Cloudflare
+ * subrequest cache).
+ */
+
+const BUMPED = '9.9.9'
+const BUILT_IN_IDS = ['dandanplay', 'bilibili', 'tencent']
+
+function forced(requests: CatalogRequest[]): CatalogRequest[] {
+  return requests.filter((request) => request.cacheControl === 'no-cache')
+}
+
+test('refresh: a user refresh bypasses both caches and fetches the index once', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  const ids = [...BUILT_IN_IDS, 'iqiyi']
+  const requests: CatalogRequest[] = []
+
+  await applyProfile(context, da, {
+    providers: {},
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed({}, ids) },
+    ],
+    network: [recordingCatalog(ids, { iqiyi: BUMPED }, requests)],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+
+  await popup.providers.refreshCatalog()
+
+  await expect(popup.providers.catalogRow(/iQIYI|爱奇艺/)).toContainText(
+    `v${BUMPED}`
+  )
+
+  // Only a user refresh forces, so filtering on the header isolates it from the
+  // boot sync that may also have run.
+  const forcedRequests = forced(requests)
+  const forcedIndex = forcedRequests.filter((request) => !request.isFile)
+  const forcedFiles = forcedRequests.filter((request) => request.isFile)
+
+  expect(forcedIndex).toHaveLength(1)
+  expect(forcedFiles.length).toBeGreaterThan(0)
+})
+
+test('apply: updating an installed source bypasses both caches', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  const current = manifestVersion('bilibili')
+  const requests: CatalogRequest[] = []
+
+  await applyProfile(context, da, {
+    providers: { bilibili: {} },
+    rawStorage: [
+      { area: 'local', key: 'manifests', value: manifestStoreSeed() },
+    ],
+    network: [recordingCatalog(BUILT_IN_IDS, { bilibili: BUMPED }, requests)],
+  })
+
+  const popup = await Popup.open(page, extensionId, '/providers')
+
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeVisible()
+
+  await popup.providers.update()
+
+  await expect(page.getByText(`v${current} → v${BUMPED}`)).toBeHidden()
+
+  const forcedFiles = forced(requests).filter((request) => request.isFile)
+
+  expect(forcedFiles.length).toBeGreaterThan(0)
+})

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -138,7 +138,9 @@ export class RpcManager {
           return this.manifestRegistry.getPendingUpdates()
         },
         providerApplyUpdates: async ({ manifestIds }) => {
-          await this.manifestRegistry.applyUpdates(manifestIds)
+          // User-initiated, so force a bypassing fetch: the new manifest file
+          // must not come from a cache the user is trying to get past.
+          await this.manifestRegistry.applyUpdates(manifestIds, undefined, true)
         },
         providerValidateManifest: async ({ manifest }) => {
           return this.manifestSandbox.validate(manifest)

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.test.ts
@@ -19,7 +19,9 @@ import type {
  * fallback seeding built-ins whenever the index yields no usable manifests
  * (unreachable, empty, or all entries dropped by the apiVersion filter) and
  * never when it yields some, that neither update() nor getPendingUpdates
- * stamps lastCheckedAt (only recordChecked does), and
+ * stamps lastCheckedAt (only recordChecked does), sending the browser and
+ * backend cache bypasses only on a forced refresh, reusing a caller-supplied
+ * index (including the failed and empty ones) instead of refetching, and
  * register / unregister / hydrate-skip-invalid.
  */
 
@@ -76,12 +78,30 @@ function makeResponse(status: number, body: unknown) {
 function stubFetch(
   respond: (url: string) => { status: number; body: unknown }
 ) {
-  const fetchMock = vi.fn(async (input: unknown) => {
+  const fetchMock = vi.fn(async (input: unknown, _init?: unknown) => {
     const { status, body } = respond(String(input))
     return makeResponse(status, body)
   })
   vi.stubGlobal('fetch', fetchMock)
   return fetchMock
+}
+
+interface FetchInit {
+  cache?: string
+  headers?: Record<string, string>
+}
+
+// What the two caches in front of the catalog each key off: the request header
+// is what the backend reads, the cache mode is what the browser reads.
+function bypassOf(init: unknown): {
+  cacheMode: string | undefined
+  header: string | undefined
+} {
+  const typed = init as FetchInit | undefined
+  return {
+    cacheMode: typed?.cache,
+    header: typed?.headers?.['Cache-Control'],
+  }
 }
 
 function fileParam(url: string): string {
@@ -92,6 +112,14 @@ function fileFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
   return fetchMock.mock.calls
     .map(([url]) => String(url))
     .filter((url) => url.includes('/manifest/file'))
+}
+
+function indexFetches(fetchMock: ReturnType<typeof stubFetch>): string[] {
+  return fetchMock.mock.calls
+    .map(([url]) => String(url))
+    .filter(
+      (url) => url.includes('/manifest') && !url.includes('/manifest/file')
+    )
 }
 
 function stubCatalogFetch(
@@ -830,6 +858,132 @@ describe('ManifestRegistry', () => {
 
     expect(await store.has('test:one')).toBe(false)
     expect(() => registry.getRunner('test:one')).toThrow()
+  })
+
+  // Paired: the forced half fails if force stops reaching the fetches, the
+  // default half fails if the bypass is sent unconditionally. Either break
+  // turns this red, which a one-sided assertion would not.
+  it('sends the cache bypass on the index and file fetches only when forced', async () => {
+    const forcedFetch = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    await new ManifestRegistry(silentLogger, new InMemoryStore()).update(
+      undefined,
+      true
+    )
+
+    expect(indexFetches(forcedFetch)).toHaveLength(1)
+    expect(fileFetches(forcedFetch)).toHaveLength(1)
+    for (const [, init] of forcedFetch.mock.calls) {
+      expect(bypassOf(init)).toEqual({
+        cacheMode: 'reload',
+        header: 'no-cache',
+      })
+    }
+
+    vi.unstubAllGlobals()
+
+    const defaultFetch = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    await new ManifestRegistry(silentLogger, new InMemoryStore()).update()
+
+    expect(indexFetches(defaultFetch)).toHaveLength(1)
+    expect(fileFetches(defaultFetch)).toHaveLength(1)
+    for (const [, init] of defaultFetch.mock.calls) {
+      expect(bypassOf(init)).toEqual({
+        cacheMode: undefined,
+        header: undefined,
+      })
+    }
+  })
+
+  it('update reuses a passed-in index instead of fetching it', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {
+      [manifestPath('one')]: makeManifest('one'),
+    })
+    const registry = new ManifestRegistry(silentLogger, new InMemoryStore())
+
+    await registry.update([catalogEntry('one')], true)
+
+    expect(indexFetches(fetchMock)).toEqual([])
+    expect(fileFetches(fetchMock)).toHaveLength(1)
+    expect(bypassOf(fetchMock.mock.calls[0][1]).header).toBe('no-cache')
+  })
+
+  it('getPendingUpdates reuses a passed-in index without any fetch', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {})
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    const pending = await registry.getPendingUpdates([
+      catalogEntry('one', '2.0.0'),
+    ])
+
+    expect(pending).toEqual([
+      { manifestId: 'one', fromVersion: '1.0.0', toVersion: '2.0.0' },
+    ])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('applyUpdates reuses a passed-in index and forces the file fetch', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one', '2.0.0')], {
+      [manifestPath('one')]: makeManifest('one', 1, '2.0.0'),
+    })
+    const store = new InMemoryStore({
+      one: { manifest: makeManifest('one', 1, '1.0.0'), kind: 'preinstalled' },
+    })
+    const registry = new ManifestRegistry(silentLogger, store)
+    await registry.ready
+
+    await registry.applyUpdates(['one'], [catalogEntry('one', '2.0.0')], true)
+
+    expect(indexFetches(fetchMock)).toEqual([])
+    expect(fileFetches(fetchMock)).toHaveLength(1)
+    expect(bypassOf(fetchMock.mock.calls[0][1])).toEqual({
+      cacheMode: 'reload',
+      header: 'no-cache',
+    })
+    expect((await store.get('one'))?.manifest).toMatchObject({
+      version: '2.0.0',
+    })
+  })
+
+  // null is the shared-fetch-already-failed signal, and it must not be retried
+  // into a second failed round trip on top of the one that already happened.
+  it('update seeds the bundle without refetching when the shared index failed', async () => {
+    const fetchMock = stubCatalogFetch([catalogEntry('one')], {})
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+
+    await expect(registry.update(null, true)).resolves.toBe('unreachable')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    const seeded = await store.getAll()
+    expect(Object.keys(seeded).sort()).toEqual(
+      bundledCatalogIndex()
+        .map((entry) => entry.id)
+        .sort()
+    )
+  })
+
+  it('update seeds the bundle when the shared index came back empty', async () => {
+    const fetchMock = stubCatalogFetch([], {})
+    const store = new InMemoryStore()
+    const registry = new ManifestRegistry(silentLogger, store)
+
+    await expect(registry.update([], true)).resolves.toBe('empty')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    const seeded = await store.getAll()
+    expect(Object.keys(seeded).sort()).toEqual(
+      bundledCatalogIndex()
+        .map((entry) => entry.id)
+        .sort()
+    )
   })
 
   it('skips a manifest that fails safeParse without taking the registry down', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ManifestRegistry.ts
@@ -14,7 +14,10 @@ import type {
 } from '@/common/rpcClient/background/types'
 import { invariant, sleep } from '@/common/utils/utils'
 import { bundledCatalogIndex, bundledManifestRaw } from './bundledCatalog'
-import { extensionFetchLike } from './extensionFetchLike'
+import {
+  type ExtensionFetchInit,
+  extensionFetchLike,
+} from './extensionFetchLike'
 import {
   type IManifestStore,
   type ManifestEntry,
@@ -33,7 +36,7 @@ const zCatalogIndex = z.object({
   manifests: z.array(zCatalogEntry),
 })
 
-type CatalogEntry = z.infer<typeof zCatalogEntry>
+export type CatalogEntry = z.infer<typeof zCatalogEntry>
 type CatalogManifest = { raw: unknown; parsed: Manifest }
 
 // Shared by every catalog-gated path; tests and the popup toast match on it.
@@ -167,6 +170,13 @@ export class ManifestRegistry {
     }
   }
 
+  // Fetch the catalog index once so a single sync can share it across update,
+  // getPendingUpdates and applyUpdates instead of refetching three times.
+  async loadCatalog(force = false): Promise<CatalogEntry[] | null> {
+    await this.ready
+    return this.loadIndex(force)
+  }
+
   // Add-only for everything except a bundle-seeded entry: a changed
   // preinstalled manifest surfaces via getPendingUpdates instead of being
   // replaced here, but a 'bundled' entry auto-upgrades to the catalog copy
@@ -177,42 +187,50 @@ export class ManifestRegistry {
   // offline. The bundle can be stale, so the first successful sync replaces
   // any still-listed bundled entry outright rather than waiting for a manual
   // update, since the user never chose to install the bundled version.
-  async update(): Promise<CatalogSyncResult> {
+  //
+  // Pass a pre-fetched index to reuse one sync's fetch, or null when that fetch
+  // already failed; force flows to the file fetches.
+  async update(
+    entries?: CatalogEntry[] | null,
+    force = false
+  ): Promise<CatalogSyncResult> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = await this.resolveCatalog(entries, force)
+    if (!catalog) {
       await this.seedFromBundle()
       return 'unreachable'
     }
     // An index that parses but lists nothing usable (empty, or every entry
     // dropped by the api-version filter) leaves the user with no sources just
     // as an unreachable one does, so it falls back to the bundle too.
-    if (entries.length === 0) {
+    if (catalog.length === 0) {
       await this.seedFromBundle()
       return 'empty'
     }
     const stored = await this.store.getAll()
-    const missing = entries.filter((entry) => !stored[entry.id])
-    const bundledStale = entries.filter(
+    const missing = catalog.filter((entry) => !stored[entry.id])
+    const bundledStale = catalog.filter(
       (entry) => stored[entry.id]?.kind === 'bundled'
     )
-    await this.fetchAndStore([...missing, ...bundledStale])
+    await this.fetchAndStore([...missing, ...bundledStale], force)
     return 'synced'
   }
 
   // Index-only: diff stored versions against the catalog without fetching files
   // or applying. Throws on an unreachable catalog: "no updates" and "could not
   // check" must stay distinguishable, or a failed check would clear the
-  // popup's pending list.
-  async getPendingUpdates(): Promise<ManifestUpdate[]> {
+  // popup's pending list. Pass a pre-fetched index to reuse one sync's fetch.
+  async getPendingUpdates(
+    entries?: CatalogEntry[] | null
+  ): Promise<ManifestUpdate[]> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = await this.resolveCatalog(entries, false)
+    if (!catalog) {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     const stored = await this.store.getAll()
     const updates: ManifestUpdate[] = []
-    for (const entry of entries) {
+    for (const entry of catalog) {
       const existing = stored[entry.id]
       // 'user' is never replaced by the catalog. 'bundled' auto-upgrades in
       // update() as soon as the index is reachable, so it must not also
@@ -242,22 +260,26 @@ export class ManifestRegistry {
   // source. Throws on failure (unreachable catalog or a file that did not
   // apply) so a user-driven update surfaces the error instead of silently
   // no-op'ing.
-  async applyUpdates(manifestIds: string[]): Promise<void> {
+  async applyUpdates(
+    manifestIds: string[],
+    entries?: CatalogEntry[] | null,
+    force = false
+  ): Promise<void> {
     await this.ready
-    const entries = await this.loadIndex()
-    if (!entries) {
+    const catalog = await this.resolveCatalog(entries, force)
+    if (!catalog) {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
     const wanted = new Set(manifestIds)
     const stored = await this.store.getAll()
-    const targets = entries.filter((entry) => {
+    const targets = catalog.filter((entry) => {
       const existing = stored[entry.id]
       return (
         wanted.has(entry.id) &&
         (existing?.kind === 'preinstalled' || existing?.kind === 'bundled')
       )
     })
-    const applied = await this.fetchAndStore(targets)
+    const applied = await this.fetchAndStore(targets, force)
     if (applied.length < targets.length) {
       const failed = targets
         .map((entry) => entry.id)
@@ -322,10 +344,13 @@ export class ManifestRegistry {
 
   // Returns the ids actually stored; the caller can compare against what it
   // asked for to tell a partial failure from a complete one.
-  private async fetchAndStore(entries: CatalogEntry[]): Promise<string[]> {
+  private async fetchAndStore(
+    entries: CatalogEntry[],
+    force = false
+  ): Promise<string[]> {
     const fetched = (
       await Promise.all(
-        entries.map((entry) => this.fetchManifest(entry.file, entry.id))
+        entries.map((entry) => this.fetchManifest(entry.file, entry.id, force))
       )
     ).filter((manifest) => manifest !== null)
     if (fetched.length === 0) {
@@ -385,24 +410,36 @@ export class ManifestRegistry {
     }
   }
 
-  private async loadIndex(): Promise<CatalogEntry[] | null> {
+  // undefined means the caller has no index and this call should fetch one;
+  // null means a shared fetch already ran and failed, so do not refetch.
+  private async resolveCatalog(
+    entries: CatalogEntry[] | null | undefined,
+    force: boolean
+  ): Promise<CatalogEntry[] | null> {
+    if (entries === undefined) {
+      return this.loadIndex(force)
+    }
+    return entries
+  }
+
+  private async loadIndex(force = false): Promise<CatalogEntry[] | null> {
     try {
-      return await this.fetchIndex()
+      return await this.fetchIndex(force)
     } catch (e) {
       this.log.warn('Catalog index fetch failed, retrying:', e)
     }
     await sleep(1000)
     try {
-      return await this.fetchIndex()
+      return await this.fetchIndex(force)
     } catch (e) {
       this.log.error('Failed to fetch manifest catalog:', e)
       return null
     }
   }
 
-  private async fetchIndex(): Promise<CatalogEntry[]> {
+  private async fetchIndex(force = false): Promise<CatalogEntry[]> {
     const index = zCatalogIndex.parse(
-      await this.fetchJson(`${this.baseUrl}/manifest`)
+      await this.fetchJson(`${this.baseUrl}/manifest`, force)
     )
     return index.manifests.filter((entry) =>
       SUPPORTED_API_VERSIONS.has(entry.apiVersion)
@@ -413,12 +450,14 @@ export class ManifestRegistry {
   // rest; the next reconcile retries whatever is still missing.
   private async fetchManifest(
     file: string,
-    id: string
+    id: string,
+    force = false
   ): Promise<CatalogManifest | null> {
     let raw: unknown
     try {
       raw = await this.fetchJson(
-        `${this.baseUrl}/manifest/file?file=${encodeURIComponent(file)}`
+        `${this.baseUrl}/manifest/file?file=${encodeURIComponent(file)}`,
+        force
       )
     } catch (e) {
       this.log.error('Failed to fetch catalog manifest:', id, e)
@@ -446,10 +485,25 @@ export class ManifestRegistry {
     return { raw, parsed: parsed.data }
   }
 
-  private async fetchJson(url: string): Promise<unknown> {
-    const res = await extensionFetchLike(url, {
-      signal: AbortSignal.timeout(5000),
-    })
+  // A forced refresh has to get past two independent caches. `cache: 'reload'`
+  // is the browser one: the request header alone only asks it to revalidate,
+  // which a fresh-enough entry can still satisfy from disk. 'reload' skips the
+  // stored entry outright yet still writes the new response back, so ordinary
+  // syncs keep hitting the cache. The header is what the backend reads.
+  private fetchInit(force: boolean): ExtensionFetchInit {
+    const signal = AbortSignal.timeout(5000)
+    if (!force) {
+      return { signal }
+    }
+    return {
+      signal,
+      cache: 'reload',
+      headers: { 'Cache-Control': 'no-cache' },
+    }
+  }
+
+  private async fetchJson(url: string, force = false): Promise<unknown> {
+    const res = await extensionFetchLike(url, this.fetchInit(force))
     if (res.status !== 200) {
       throw new Error(`catalog fetch failed (${res.status}): ${url}`)
     }

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.test.ts
@@ -394,6 +394,10 @@ describe('ProviderService.refreshCatalog', () => {
     vi.clearAllMocks()
   })
 
+  const catalogEntries = [
+    { id: 'one', apiVersion: 1, version: '1.0.0', file: 'one.json' },
+  ]
+
   function buildForRefresh(opts: {
     pending: { manifestId: string; fromVersion: string; toVersion: string }[]
     installedManifestIds: string[]
@@ -401,9 +405,12 @@ describe('ProviderService.refreshCatalog', () => {
     const applyUpdates = vi.fn(async () => {})
     const recordChecked = vi.fn(async () => {})
     const getPendingUpdates = vi.fn(async () => opts.pending)
+    const loadCatalog = vi.fn(async () => catalogEntries)
+    const update = vi.fn(async () => 'synced')
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => 'synced'),
+      loadCatalog,
+      update,
       getPendingUpdates,
       applyUpdates,
       recordChecked,
@@ -429,7 +436,14 @@ describe('ProviderService.refreshCatalog', () => {
       silentExtensionOptions
     )
 
-    return { service, applyUpdates, recordChecked, getPendingUpdates }
+    return {
+      service,
+      loadCatalog,
+      update,
+      applyUpdates,
+      recordChecked,
+      getPendingUpdates,
+    }
   }
 
   it('auto-applies updates for uninstalled manifests only', async () => {
@@ -443,7 +457,43 @@ describe('ProviderService.refreshCatalog', () => {
 
     await service.refreshCatalog()
 
-    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'])
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
+  })
+
+  it('fetches the index once and forces it on a user refresh', async () => {
+    const { service, loadCatalog, update, getPendingUpdates, applyUpdates } =
+      buildForRefresh({
+        pending: [
+          { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+        ],
+        installedManifestIds: [],
+      })
+
+    await service.refreshCatalog()
+
+    expect(loadCatalog).toHaveBeenCalledTimes(1)
+    expect(loadCatalog).toHaveBeenCalledWith(true)
+    expect(update).toHaveBeenCalledWith(catalogEntries, true)
+    expect(getPendingUpdates).toHaveBeenCalledWith(catalogEntries)
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, true)
+  })
+
+  it('fetches the index once and stays cached on a background sync', async () => {
+    const { service, loadCatalog, update, getPendingUpdates, applyUpdates } =
+      buildForRefresh({
+        pending: [
+          { manifestId: 'iqiyi', fromVersion: '1.0.0', toVersion: '2.0.0' },
+        ],
+        installedManifestIds: [],
+      })
+
+    await service.syncCatalog()
+
+    expect(loadCatalog).toHaveBeenCalledTimes(1)
+    expect(loadCatalog).toHaveBeenCalledWith(false)
+    expect(update).toHaveBeenCalledWith(catalogEntries, false)
+    expect(getPendingUpdates).toHaveBeenCalledWith(catalogEntries)
+    expect(applyUpdates).toHaveBeenCalledWith(['iqiyi'], catalogEntries, false)
   })
 
   it('does not apply anything when every pending update is installed', async () => {
@@ -487,9 +537,11 @@ describe('ProviderService.refreshCatalog', () => {
   it('throws and does not record a check when the catalog index fetch fails', async () => {
     const recordChecked = vi.fn(async () => {})
     const getPendingUpdates = vi.fn(async () => [])
+    const update = vi.fn(async () => 'unreachable')
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => 'unreachable'),
+      loadCatalog: vi.fn(async () => null),
+      update,
       getPendingUpdates,
       applyUpdates: vi.fn(async () => {}),
       recordChecked,
@@ -513,6 +565,9 @@ describe('ProviderService.refreshCatalog', () => {
       /Failed to fetch the manifest catalog/
     )
 
+    // The failed index is handed on as null rather than short-circuiting, so
+    // update() still runs and the offline bundle fallback still seeds.
+    expect(update).toHaveBeenCalledWith(null, true)
     expect(getPendingUpdates).not.toHaveBeenCalled()
     expect(recordChecked).not.toHaveBeenCalled()
   })
@@ -520,6 +575,7 @@ describe('ProviderService.refreshCatalog', () => {
   it('throws a fetch-free error when the catalog answers with nothing usable', async () => {
     const registry = {
       ready: Promise.resolve(true),
+      loadCatalog: vi.fn(async () => []),
       update: vi.fn(async () => 'empty'),
       getPendingUpdates: vi.fn(async () => []),
       applyUpdates: vi.fn(async () => {}),
@@ -608,9 +664,16 @@ describe('ProviderService.seedDefaultProviders', () => {
 
     const listManifests = vi.fn(() => opts.manifests ?? DEFAULT_MANIFESTS)
     const recordChecked = vi.fn(async () => {})
+    const catalog = opts.catalog ?? 'synced'
+    // loadCatalog mirrors what update() will report, so the shared-index path
+    // under test is the one a real sync would take.
+    const sharedIndex = catalog === 'unreachable' ? null : []
+    const loadCatalog = vi.fn(async () => sharedIndex)
+    const update = vi.fn(async () => catalog)
     const registry = {
       ready: Promise.resolve(true),
-      update: vi.fn(async () => opts.catalog ?? 'synced'),
+      loadCatalog,
+      update,
       getPendingUpdates: vi.fn(async () => []),
       recordChecked,
       listManifests,
@@ -631,7 +694,16 @@ describe('ProviderService.seedDefaultProviders', () => {
       extensionOptions
     )
 
-    return { service, set, markSeeded, hasSeeded, listManifests, recordChecked }
+    return {
+      service,
+      set,
+      markSeeded,
+      hasSeeded,
+      listManifests,
+      recordChecked,
+      loadCatalog,
+      update,
+    }
   }
 
   it('seeds the preloaded set with manifest-derived names on a fresh install', async () => {
@@ -760,6 +832,43 @@ describe('ProviderService.seedDefaultProviders', () => {
     ])
     expect(markSeeded).toHaveBeenCalledTimes(1)
     expect(recordChecked).not.toHaveBeenCalled()
+  })
+
+  // The coalesced index makes 'unreachable' arrive as a null shared index and
+  // 'empty' as an empty one. Both still have to reach seedDefaultProviders:
+  // that call sits outside the 'synced' branch, and moving it back inside is
+  // what would leave an offline first-run user with no provider configs.
+  it('still seeds default configs when the shared index came back empty', async () => {
+    const { service, set, markSeeded, recordChecked, update } = buildForSeed({
+      catalog: 'empty',
+    })
+
+    await expect(service.syncCatalog()).resolves.toBe('empty')
+
+    expect(update).toHaveBeenCalledWith([], false)
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(set.mock.calls[0][0].map((c) => c.manifestId)).toEqual([
+      'dandanplay',
+      'bilibili',
+      'tencent',
+    ])
+    expect(markSeeded).toHaveBeenCalledTimes(1)
+    expect(recordChecked).not.toHaveBeenCalled()
+  })
+
+  it('still seeds default configs when a forced refresh cannot reach the catalog', async () => {
+    const { service, set, markSeeded, loadCatalog, update } = buildForSeed({
+      catalog: 'unreachable',
+    })
+
+    await expect(service.refreshCatalog()).rejects.toThrow(
+      /Failed to fetch the manifest catalog/
+    )
+
+    expect(loadCatalog).toHaveBeenCalledWith(true)
+    expect(update).toHaveBeenCalledWith(null, true)
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(markSeeded).toHaveBeenCalledTimes(1)
   })
 
   it('does not seed on an unreachable catalog once the flag is locked', async () => {

--- a/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/ProviderService.ts
@@ -423,7 +423,7 @@ export class ProviderService {
   // says which failure it was: a catalog that answered but offers nothing this
   // build can run is not a network problem.
   async refreshCatalog(locale?: string): Promise<ProviderManifestList> {
-    const result = await this.syncCatalog()
+    const result = await this.syncCatalog(true)
     if (result === 'unreachable') {
       throw new Error(CATALOG_UNREACHABLE_MESSAGE)
     }
@@ -437,14 +437,18 @@ export class ProviderService {
   // user data to disturb) are applied here, while installed-source updates stay
   // manual via the Updates list. Records the check only on a real sync, so
   // "checked Nm ago" never advances on a bare detection. Returns how the
-  // catalog index resolved.
-  async syncCatalog(): Promise<CatalogSyncResult> {
-    const result = await this.manifestRegistry.update()
+  // catalog index resolved. force makes a user-initiated refresh bypass the
+  // browser cache and both of the backend's, while background and install syncs
+  // stay cached. The index is fetched once and shared across the three steps.
+  async syncCatalog(force = false): Promise<CatalogSyncResult> {
+    const entries = await this.manifestRegistry.loadCatalog(force)
+    const result = await this.manifestRegistry.update(entries, force)
     if (result === 'synced') {
-      // update() just reached the index, so a failure here means it died
-      // mid-sync; skip the best-effort auto-apply rather than fail the sync.
+      // The index is already in hand, so this only reads the store; stay
+      // best-effort so a store failure skips the auto-apply instead of failing
+      // the whole sync.
       const pending = await this.manifestRegistry
-        .getPendingUpdates()
+        .getPendingUpdates(entries)
         .catch((e) => {
           this.logger.warn('Failed to detect pending updates mid-sync:', e)
           return []
@@ -456,7 +460,7 @@ export class ProviderService {
         .map((update) => update.manifestId)
       if (uninstalled.length > 0) {
         try {
-          await this.manifestRegistry.applyUpdates(uninstalled)
+          await this.manifestRegistry.applyUpdates(uninstalled, entries, force)
         } catch (e) {
           // Best-effort: a failed background apply retries next sync and must
           // not block recording the check or the rest of the refresh.

--- a/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.test.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { extensionFetchLike } from './extensionFetchLike'
+
+/**
+ * extensionFetchLike hands its init to the global fetch after stripping the
+ * DNR-only rewriteHeaders key. Covers that the browser cache mode survives that
+ * hop, since a forced catalog refresh relies on it to skip the HTTP cache
+ * rather than merely revalidate, and that rewriteHeaders never leaks into the
+ * RequestInit.
+ */
+
+vi.mock('@/background/netRequest/cookieReplay', () => ({
+  consumeSetCookies: () => null,
+  getCookiesForHost: () => null,
+}))
+
+vi.mock('@/background/netRequest/setSessionHeader', () => ({
+  setSessionHeader: async () => ({ removeRule: async () => {} }),
+}))
+
+function stubFetch() {
+  const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) => ({
+    status: 200,
+    url: 'https://example.com/manifest',
+    text: async () => '{}',
+    arrayBuffer: async () => new ArrayBuffer(0),
+    headers: { forEach: () => {} },
+  }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('extensionFetchLike', () => {
+  it('forwards the browser cache mode to fetch', async () => {
+    const fetchMock = stubFetch()
+
+    await extensionFetchLike('https://example.com/manifest', {
+      cache: 'reload',
+      headers: { 'Cache-Control': 'no-cache' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      cache: 'reload',
+      headers: { 'Cache-Control': 'no-cache' },
+    })
+  })
+
+  it('sends no cache mode when the caller asks for none', async () => {
+    const fetchMock = stubFetch()
+
+    await extensionFetchLike('https://example.com/manifest', {})
+
+    expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('cache')
+  })
+
+  it('strips rewriteHeaders, which is a DNR instruction and not a RequestInit', async () => {
+    const fetchMock = stubFetch()
+
+    await extensionFetchLike('https://example.com/manifest', {
+      rewriteHeaders: { Referer: 'https://example.com' },
+    })
+
+    expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('rewriteHeaders')
+  })
+})

--- a/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
+++ b/packages/danmaku-anywhere/src/background/services/providers/extensionFetchLike.ts
@@ -5,10 +5,22 @@ import {
 } from '@/background/netRequest/cookieReplay'
 import { setSessionHeader } from '@/background/netRequest/setSessionHeader'
 
+// dango's FetchLike has no `cache`, but this wrapper hands its init straight to
+// fetch(), so callers in this host can ask for a browser-cache mode. Accepting a
+// superset keeps the value assignable wherever a FetchLike is expected.
+export type ExtensionFetchInit = NonNullable<Parameters<FetchLike>[1]> & {
+  cache?: RequestCache
+}
+
+type ExtensionFetchLike = (
+  input: Parameters<FetchLike>[0],
+  init?: ExtensionFetchInit
+) => ReturnType<FetchLike>
+
 // fetch() drops forbidden request headers, so rewriteHeaders steps use a
 // short-lived DNR session rule. Captured cookies are also injected since
 // Partitioned cookies are not auto-attached on service-worker fetch() calls.
-export const extensionFetchLike: FetchLike = async (input, init) => {
+export const extensionFetchLike: ExtensionFetchLike = async (input, init) => {
   const rewrite = init?.rewriteHeaders
   let effectiveRewrite = rewrite
 


### PR DESCRIPTION
Supersedes #488, which could not be rebased: master's #524 changed `update()`'s return type to a three-state result while #488 changed the same method's signature, so the union had to be written by hand rather than resolved from conflict markers. Close #488 in favour of this.

Lets a user force a catalog refresh that actually reaches fresh bytes, past all three caches between the click and GitHub.

## There are three caches, not two

1. **The browser HTTP cache.** `Cache-Control: no-cache` as a request header only forces revalidation; it does not skip the cache. The forced path now also sets `cache: 'reload'` in the fetch init. `'reload'` over `'no-store'` because both skip the stored entry on the way out, but `'reload'` writes the fresh response back, so ordinary background syncs keep hitting the browser cache instead of becoming permanent full misses.
2. **The Worker's `caches.default`.** Already handled: `parseCacheControl` sets `noCache` for both `no-cache` and `max-age=0`, and the read is skipped when set. Both manifest routes share that middleware.
3. **Cloudflare's cache in front of the Worker's own outgoing `fetch()`.** Nothing bypassed this, so a forced refresh could skip the first two and still be served a copy up to five minutes stale, because the upstream sends `cache-control: max-age=300`. The user clicks refresh, everything reports success, and the bytes are identical.

Layer 3 is bypassed with `new Request(url, { cache: 'no-store' })`, which is the documented mechanism: the runtime will not check the cache and will not add the response to it, even when the response looks cacheable. Both routes go through one `fetchUpstream` helper sharing the same predicate as the middleware, so the two cannot disagree.

## Reconciling with #524

`update(entries?, force?)` keeps #488's parameters and master's `'unreachable' | 'empty' | 'synced'` return. Both failure paths still call `seedFromBundle()`, and `seedDefaultProviders()` stays outside the `'synced'` branch. #488's early-return on failure is gone, because that would have left a fresh offline user with manifests but no seeded provider configs, undoing #524.

`syncCatalog(force?)` loads the index once and passes it to all three steps, so a forced refresh issues one bypassing index fetch rather than three. `resolveCatalog()`'s undefined-versus-null distinction is preserved: undefined means fetch it, null means a lookup already failed, do not retry.

## Test plan

- lint: pass. `pnpm type-check` clean across all 11 projects.
- tests: backend 84 pass, extension unit 807 pass.
- e2e: catalog-refresh, updates, update-recovery, catalog-import, no-providers, 9 pass. Smoke 3 pass. Full suite left to CI.
- red before green: observed for each claim separately.
  - Backend subrequest bypass: `2 failed | 6 passed`, `expected 'https://raw.githubusercontent…' to be an instance of Request`.
  - Extension force plus coalescing, production reverted: `12 failed | 81 passed`, including `expected { cacheMode: undefined } to deeply equal { cacheMode: 'reload' }`.
  - **The #524 regression specifically**: moving `seedDefaultProviders()` back inside the `synced` branch and changing nothing else gives `3 failed`, the unreachable, empty and forced-unreachable seeding tests, all `expected "vi.fn()" to be called 1 times, but got 0 times`.
  - e2e against a build without the change: `2 failed`, `expect(forcedIndex).toHaveLength(1)` received `0`.

## Known limits and one risk

`cache: 'reload'` is invisible to Playwright route interception; the `Pragma: no-cache` header the Fetch spec describes arrives empty. So the browser-cache layer is provable only at the unit level, and `extensionFetchLike.test.ts` was added to pin that the `cache` mode survives the hop into global `fetch`. That seam was previously untested and is where this feature would silently die.

The e2e header no longer claims to prove a server-side bypass, since the route mock answers regardless of cache state. It names `cache.test.ts` and `manifest/router.test.ts` as where that is actually covered.

**Risk this introduces, not solved here:** `/manifest` and `/manifest/file` are mounted with no rate limiter, and the only limiter in the codebase is dead code with no binding in any environment. A forced refresh is triggerable by anyone sending `Cache-Control: no-cache` to a public endpoint, and it now costs one plus N unmetered requests to `raw.githubusercontent.com`. Tripping GitHub's limits would break the catalog for every user. Before this change that header did nothing to the subrequest, so this widens the surface. Mitigating: the response is still written into `caches.default`, so subsequent non-forced traffic stays cheap.
