### PR TITLE
(extension) gate the external RPC surface and narrow externally_connectable [DA-675]

### DIFF
--- a/packages/danmaku-anywhere/e2e/pom/ExternalCallerPage.ts
+++ b/packages/danmaku-anywhere/e2e/pom/ExternalCallerPage.ts
@@ -1,0 +1,61 @@
+import type { BrowserContext, Page } from '@playwright/test'
+
+const PAGE_BODY = `<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>DA external caller</title></head>
+  <body><p>External caller harness</p></body>
+</html>`
+
+export interface ExternalRpcOutcome {
+  // false when the browser refused the call outright, which is what a page on a
+  // non-connectable origin gets.
+  reached: boolean
+  state?: string
+  error?: string
+  output?: unknown
+}
+
+// A website driving the extension the way a real one does, through
+// chrome.runtime.sendMessage(extensionId, ...). The browser only exposes that
+// API to origins listed in the manifest's externally_connectable, so calls from
+// this page exercise the real boundary rather than a stubbed one.
+export class ExternalCallerPage {
+  private constructor(
+    private readonly page: Page,
+    private readonly extensionId: string
+  ) {}
+
+  static async open(
+    context: BrowserContext,
+    extensionId: string,
+    url: string
+  ): Promise<ExternalCallerPage> {
+    const page = await context.newPage()
+    await page.route(url, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: PAGE_BODY,
+      })
+    })
+    await page.goto(url)
+    return new ExternalCallerPage(page, extensionId)
+  }
+
+  async call(method: string, input?: unknown): Promise<ExternalRpcOutcome> {
+    return this.page.evaluate(
+      async ({ extensionId, method, input }) => {
+        try {
+          const response = await chrome.runtime.sendMessage(extensionId, {
+            method,
+            input,
+          })
+          return { reached: true, ...response }
+        } catch (e) {
+          return { reached: false, error: e instanceof Error ? e.message : '' }
+        }
+      },
+      { extensionId: this.extensionId, method, input }
+    )
+  }
+}

--- a/packages/danmaku-anywhere/e2e/specs/integration/external-rpc.spec.ts
+++ b/packages/danmaku-anywhere/e2e/specs/integration/external-rpc.spec.ts
@@ -1,0 +1,74 @@
+import { ExternalCallerPage } from '../../pom/ExternalCallerPage'
+import { Popup } from '../../pom/Popup'
+import { expect, test } from '../../setup/fixtures'
+import { applyProfile } from '../../setup/profile'
+
+/**
+ * Exercises the externally_connectable boundary from a real web page. An
+ * allowlisted command (mountConfigCreate) lands and its config shows up in the
+ * popup's config list; commands off the allowlist come back rejected instead of
+ * running; and the plaintext http origin cannot reach the extension at all.
+ */
+
+// Every denied call goes through the RPC server's handler-error path, which
+// logs at error level.
+test.use({ expectedConsoleErrors: ['is not available to external callers'] })
+
+const APP_URL = 'https://danmaku.weeblify.app/'
+const PLAINTEXT_URL = 'http://danmaku.weeblify.app/'
+
+const CONFIG_NAME = 'External Onboarding Config'
+const CONFIG_INPUT = {
+  name: CONFIG_NAME,
+  patterns: ['https://external-rpc.e2e.invalid/*'],
+  mediaQuery: 'video',
+  enabled: true,
+}
+
+test('external rpc: allowlisted command lands, the rest are rejected', async ({
+  context,
+  page,
+  extensionId,
+  da,
+}) => {
+  await applyProfile(context, da, {})
+
+  const caller = await ExternalCallerPage.open(context, extensionId, APP_URL)
+
+  const created = await caller.call('mountConfigCreate', CONFIG_INPUT)
+  expect(created.reached).toBe(true)
+  expect(created.state).toBe('success')
+
+  const popup = await Popup.open(page, extensionId, '/config')
+  await popup.config.expectRow(CONFIG_NAME)
+
+  const listed = await caller.call('mountConfigGetAll')
+  expect(listed.state).toBe('success')
+
+  for (const method of ['backupExport', 'dataWipeDanmaku', 'setHeaders']) {
+    const denied = await caller.call(method)
+    expect(denied.state).toBe('errored')
+    expect(denied.error).toBe(
+      `Method ${method} is not available to external callers`
+    )
+  }
+})
+
+test('external rpc: a plaintext http origin cannot reach the extension', async ({
+  context,
+  extensionId,
+  da,
+}) => {
+  await applyProfile(context, da, {})
+
+  const caller = await ExternalCallerPage.open(
+    context,
+    extensionId,
+    PLAINTEXT_URL
+  )
+
+  // lint-specs-allow-state-only: whether the browser hands a page the runtime
+  // bridge is decided by the manifest, so there is no extension UI to assert on.
+  const outcome = await caller.call('mountConfigGetAll')
+  expect(outcome.reached).toBe(false)
+})

--- a/packages/danmaku-anywhere/manifest.ts
+++ b/packages/danmaku-anywhere/manifest.ts
@@ -1,6 +1,9 @@
 import { defineManifest } from '@crxjs/vite-plugin'
 import { getBuildContext } from './scripts/getBuildContext'
-import { getAppUrls } from './src/common/appUrls'
+import {
+  getAppUrls,
+  getExternallyConnectablePatterns,
+} from './src/common/appUrls'
 
 const { isDev, browser, appVersion } = getBuildContext()
 
@@ -62,10 +65,7 @@ export const manifest = defineManifest({
     isFirefox
       ? undefined
       : {
-          matches: [
-            '*://danmaku.weeblify.app/*',
-            ...(isDev ? ['http://localhost:4321/*'] : []),
-          ],
+          matches: getExternallyConnectablePatterns(isDev),
         },
   icons: {
     16: 'normal_16.png',

--- a/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/RpcManager.ts
@@ -7,6 +7,10 @@ import { inject, injectable } from 'inversify'
 import { match } from 'ts-pattern'
 import { removeSessionRule } from '@/background/netRequest/sessionRules'
 import { setMediaCorsRule } from '@/background/netRequest/setMediaCorsRule'
+import {
+  EXTERNAL_RPC_ALLOWLIST,
+  gateExternalHandlers,
+} from '@/background/rpc/externalRpc'
 import { BackupService } from '@/background/services/Backup/BackupService.service'
 import { DataManagementService } from '@/background/services/DataManagementService'
 import { GenAIService } from '@/background/services/GenAIService'
@@ -30,7 +34,7 @@ import { ExtensionOptionsService } from '@/common/options/extensionOptions/servi
 import { MountConfigService } from '@/common/options/mountConfig/service'
 import { ProviderConfigService } from '@/common/options/providerConfig/service'
 import type { TabRPCClientMethod } from '@/common/rpc/client'
-import type { RRPServerHandler } from '@/common/rpc/server'
+import type { RPCServerHandlers, RRPServerHandler } from '@/common/rpc/server'
 import { createRpcServer } from '@/common/rpc/server'
 import type { AnyRPCDef } from '@/common/rpc/types'
 import { RpcException } from '@/common/rpc/types'
@@ -90,382 +94,385 @@ export class RpcManager {
   }
 
   setup() {
-    const rpcServer = createRpcServer<BackgroundMethods>(
-      {
-        authGetSession: async () => {
-          return this.authClientService.getSessionState()
-        },
-        authSignUp: async (input) => {
-          return this.authClientService.signUp(input)
-        },
-        authSignIn: async (input) => {
-          return this.authClientService.signIn(input)
-        },
-        authSignOut: async () => {
-          return this.authClientService.signOut()
-        },
-        authDeleteAccount: async () => {
-          return this.authClientService.deleteAccount()
-        },
-        seasonSearch: async (input) => {
-          return this.providerService.searchSeason(input)
-        },
-        seasonUpsert: async (input) => {
-          return this.providerService.upsertSeason(input)
-        },
-        mediaParseUrl: async (input) => {
-          return this.providerService.parseUrl(input.url)
-        },
-        episodeFetchBySeason: async (input: EpisodeFetchBySeasonParams) => {
-          return this.providerService.fetchEpisodesBySeason(input.seasonId)
-        },
-        episodeMatch: async (data) => {
-          return this.episodeMatchingService.findMatchingEpisodes(data)
-        },
-        providerProbeLogin: async ({ manifestId }) => {
-          return this.providerService.getLoginStatus(manifestId)
-        },
-        providerGetManifestSpec: async ({ manifestId, locale }) => {
-          return this.providerService.getManifestSpec(manifestId, locale)
-        },
-        providerListManifests: async ({ locale } = {}) => {
-          return this.providerService.listManifests(locale)
-        },
-        providerRefreshCatalog: async ({ locale } = {}) => {
-          return this.providerService.refreshCatalog(locale)
-        },
-        providerGetPendingUpdates: async () => {
-          return this.manifestRegistry.getPendingUpdates()
-        },
-        providerApplyUpdates: async ({ manifestIds }) => {
-          await this.manifestRegistry.applyUpdates(manifestIds)
-        },
-        providerValidateManifest: async ({ manifest }) => {
-          return this.manifestSandbox.validate(manifest)
-        },
-        providerTestRunSearch: async (input) => {
-          return this.manifestSandbox.search(input)
-        },
-        providerTestRunEpisodes: async (input) => {
-          return this.manifestSandbox.episodes(input)
-        },
-        providerTestRunDanmaku: async (input) => {
-          return this.manifestSandbox.danmaku(input)
-        },
-        providerSaveUserManifest: async ({ manifest, mode, expectedId }) => {
-          await this.manifestRegistry.saveUserManifest(
-            manifest,
-            mode,
-            expectedId
-          )
-        },
-        providerGetManifestSource: async ({ manifestId }) => {
-          return (await this.manifestRegistry.getSource(manifestId)) ?? null
-        },
-        bilibiliSetCookies: async () => {
-          // Credentialed homepage GET lets bilibili's Set-Cookie response
-          // seed the anti-bot cookies the API host needs.
-          await fetch('https://www.bilibili.com', { credentials: 'include' })
-        },
-        iconSet: async (data, sender) => {
-          if (sender.tab?.id === undefined) {
-            throw new RpcException('No tab id found')
-          }
-
-          const tabId = sender.tab.id
-
-          match(data)
-            .with({ state: 'active' }, (data) => {
-              void this.iconService.setActive(tabId, data.count)
-            })
-            .with({ state: 'inactive' }, () => {
-              void this.iconService.setNormal(tabId)
-            })
-            .with({ state: 'available' }, () => {
-              void this.iconService.setNormal(tabId)
-            })
-            .with({ state: 'unavailable' }, () => {
-              void this.iconService.setUnavailable(tabId)
-            })
-            .exhaustive()
-
-          this.logger.debug('Icon state set to:', data.state)
-        },
-        episodeFilter: async (filter) => {
-          const result = await this.danmakuService.filter(filter)
-          return result
-        },
-        episodeFilterLite: async (filter) => {
-          const result = await this.danmakuService.filterLite(filter)
-          return result || null
-        },
-        seasonGetAll: async (data) => {
-          const result = await this.seasonService.getAll(data)
-          return result
-        },
-        seasonFilter: async (data) => {
-          return this.seasonService.filter(data)
-        },
-        seasonDelete: async (data) => {
-          return this.seasonService.delete(data)
-        },
-        seasonRefresh: async (data) => {
-          return this.providerService.refreshSeason(data)
-        },
-        seasonMapAdd: async (data) => {
-          return this.titleMappingService.add(SeasonMap.from(data))
-        },
-        seasonMapPut: async (data) => {
-          return this.titleMappingService.put(SeasonMap.from(data))
-        },
-        seasonMapDelete: async (data) => {
-          return this.titleMappingService.remove(data.key)
-        },
-        seasonMapDeleteMany: async (data) => {
-          return this.titleMappingService.removeMany(data.keys)
-        },
-
-        seasonMapGetAll: async () => {
-          const seasonMaps = await this.titleMappingService.getAll()
-          return seasonMaps.map((map) => map.toSnapshot())
-        },
-        episodeFetch: async (data, sender) => {
-          const result = await this.providerService.getDanmaku(data)
-          void invalidateContentScriptData(sender.tab?.id)
-          return result
-        },
-        episodePreloadNext: async (data) => {
-          // Best-effort background optimization: swallow failures so a network
-          // or DB error does not bubble up as an unhandled RPC error.
-          try {
-            const { autoBookmark } = await this.extensionOptionsService.get()
-            const bookmarked = await this.bookmarkService.preloadNextEpisode(
-              data,
-              this.providerService,
-              autoBookmark
-            )
-            // Auto-bookmark happens in the background, so refresh content
-            // scripts (incl. the playing tab) to update bookmark UI.
-            if (bookmarked) {
-              void invalidateContentScriptData()
-            }
-          } catch (e) {
-            this.logger.warn('Failed to preload next episode:', e)
-          }
-        },
-        episodeImport: async (data, sender) => {
-          const result = await this.danmakuService.import(data)
-          void invalidateContentScriptData(sender.tab?.id)
-          return result
-        },
-        episodeDelete: async (filter, sender) => {
-          const result = await this.danmakuService.delete(filter)
-          void invalidateContentScriptData(sender.tab?.id)
-          return result
-        },
-        episodeFilterCustom: async (filter) => {
-          return this.danmakuService.filterCustom(filter)
-        },
-        episodeFilterCustomLite: async (filter) => {
-          return this.danmakuService.filterCustomLite(filter)
-        },
-        episodeDeleteCustom: async (filter, sender) => {
-          const result = await this.danmakuService.deleteCustom(filter)
-          void invalidateContentScriptData(sender.tab?.id)
-          return result
-        },
-        danmakuPurgeCache: async (days, sender) => {
-          const result = await this.danmakuService.purgeOlderThan(days)
-          void invalidateContentScriptData(sender.tab?.id)
-          return result
-        },
-        getExtensionManifest: async () => {
-          return chrome.runtime.getManifest() as chrome.runtime.ManifestV3
-        },
-        getAlarm: async (name) => {
-          if (!chrome.alarms) {
-            return null
-          }
-
-          return chrome.alarms.get(name)
-        },
-        getFrameId: async (_, sender) => {
-          if (sender.frameId === undefined) {
-            throw new RpcException('Sender does not have frame id')
-          }
-
-          return sender.frameId
-        },
-        remoteLog: async (data) => {
-          void this.logService.log(data)
-        },
-        exportDebugData: async () => {
-          return this.debugFileService.upload()
-        },
-        getActiveTabUrl: async () => {
-          const tabs = await chrome.tabs.query({
-            active: true,
-            currentWindow: true,
-          })
-
-          const activeTab = tabs[0]
-
-          return activeTab?.url ?? null
-        },
-        mountConfigGetAll: async () => {
-          return this.mountConfigService.getAll()
-        },
-        mountConfigCreate: async (data) => {
-          return this.mountConfigService.create(data)
-        },
-        extractTitle: async ({ text, options }) => {
-          return this.aiService.extractTitle(text, options)
-        },
-        testAiProvider: async (config) => {
-          return this.aiService.testConnection(config)
-        },
-        getFontList: async () => {
-          return chrome.fontSettings.getFontList()
-        },
-        getPlatformInfo: async () => {
-          return chrome.runtime.getPlatformInfo()
-        },
-        fetchImage: async ({ src }) => {
-          return this.imageCacheService.get(src)
-        },
-        kazumiSearchContent: async ({ keyword, policy }) => {
-          return this.kazumiService.searchContent(keyword, policy)
-        },
-        kazumiGetChapters: async ({ url, policy }) => {
-          return this.kazumiService.getChapters(url, policy)
-        },
-        genericVodSearch: async ({ baseUrl, keyword }) => {
-          return MacCmsProviderService.search(baseUrl, keyword, this.logger)
-        },
-        genericFetchDanmakuForUrl: async ({ title, url, providerConfigId }) => {
-          return MacCmsProviderService.fetchDanmakuForUrl(
-            title,
-            url,
-            providerConfigId,
-            this.danmakuService,
-            this.providerConfigService
-          )
-        },
-        setHeaders: async (rule) => {
-          await setRequestHeaderRule(rule)
-        },
-        openPopupInNewWindow: async ({ path, width, height }) => {
-          void chrome.windows.create({
-            url: chrome.runtime.getURL(`pages/popup.html?detached=1#/${path}`),
-            type: 'popup',
-            width: width ?? 550,
-            height: height ?? 650,
-          })
-        },
-        openPopupInNewTab: async ({ path }) => {
-          void chrome.tabs.create({
-            url: chrome.runtime.getURL(`pages/popup.html?detached=1#/${path}`),
-          })
-        },
-        getConfigMacCms: async (input) => {
-          const res = await getMaccmsConfig(input?.force)
-          if (!res.success) {
-            throw res.error
-          }
-          return res.data
-        },
-        getConfigDanmuIcu: async (input) => {
-          const res = await getDanmuicuConfig(input?.force)
-          if (!res.success) {
-            throw res.error
-          }
-          return res.data
-        },
-        providerConfigDelete: async (id, sender) => {
-          // Seasons and episodes are kept (orphaned: no live config matches their
-          // namespace) so downloaded danmaku stays viewable. Bookmarks are
-          // removed: they only exist to fetch new episodes, which an orphaned
-          // season can no longer do.
-          // Resolve the config's identity before deleting it; the read has no
-          // side effects, and deleteFromStorage (which throws if the config does
-          // not exist) still runs before any mutation.
-          const config = await this.providerConfigService.get(id)
-          await this.providerConfigService.deleteFromStorage(id)
-          if (config) {
-            await this.bookmarkService.deleteBySeasonIdentity(
-              config.manifestId,
-              await this.providerService.computeConfigNamespaceKey(config)
-            )
-          }
-
-          void invalidateContentScriptData(sender.tab?.id)
-        },
-        providerDeleteUserManifest: async ({ manifestId }, sender) => {
-          await this.providerService.deleteUserManifest(manifestId)
-          void invalidateContentScriptData(sender.tab?.id)
-        },
-        backupExport: async () => {
-          return this.backupService.getBackupData()
-        },
-        backupImport: async (data, sender) => {
-          const result = await this.backupService.importAll(data)
-          void invalidateContentScriptData(sender.tab?.id)
-          return result
-        },
-        cloudBackupList: async () => {
-          return this.backupService.getCloudBackups()
-        },
-        cloudBackupCreate: async () => {
-          return this.backupService.createCloudBackup()
-        },
-        cloudBackupDownload: async (id) => {
-          return this.backupService.downloadCloudBackup(id)
-        },
-        dataWipeDanmaku: async (data, sender) => {
-          await this.dataManagementService.wipeAllData(data)
-          void invalidateContentScriptData(sender.tab?.id)
-        },
-        bookmarkGetAll: async () => {
-          return this.bookmarkService.getAll()
-        },
-        bookmarkAdd: async (data) => {
-          return this.bookmarkService.add(data.seasonId, this.providerService)
-        },
-        bookmarkDelete: async (data) => {
-          return this.bookmarkService.delete(data.id)
-        },
-        bookmarkDeleteBySeason: async (data) => {
-          return this.bookmarkService.deleteBySeason(data.seasonId)
-        },
-        bookmarkRefresh: async (data) => {
-          return this.bookmarkService.refresh(data.id, this.providerService)
-        },
-        occlusionGetModels: async () => {
-          return this.occlusionModelService.getState()
-        },
-        occlusionRefreshModels: async () => {
-          return this.occlusionModelService.refresh()
-        },
-        occlusionResolveModel: async (data) => {
-          return this.occlusionModelService.resolveModel(data.id)
-        },
-        occlusionDownloadModel: async (data) => {
-          return this.occlusionModelService.download(data.id)
-        },
-        occlusionDeleteModel: async (data) => {
-          return this.occlusionModelService.delete(data.id)
-        },
-        occlusionAddCorsRule: async (data, sender) => {
-          const { ruleId } = await setMediaCorsRule(data.url, sender.tab?.id)
-          return ruleId
-        },
-        occlusionRemoveCorsRule: async (data) => {
-          await removeSessionRule(data.ruleId)
-        },
+    const handlers: RPCServerHandlers<BackgroundMethods> = {
+      authGetSession: async () => {
+        return this.authClientService.getSessionState()
       },
-      {
-        logger: this.logger,
-      }
+      authSignUp: async (input) => {
+        return this.authClientService.signUp(input)
+      },
+      authSignIn: async (input) => {
+        return this.authClientService.signIn(input)
+      },
+      authSignOut: async () => {
+        return this.authClientService.signOut()
+      },
+      authDeleteAccount: async () => {
+        return this.authClientService.deleteAccount()
+      },
+      seasonSearch: async (input) => {
+        return this.providerService.searchSeason(input)
+      },
+      seasonUpsert: async (input) => {
+        return this.providerService.upsertSeason(input)
+      },
+      mediaParseUrl: async (input) => {
+        return this.providerService.parseUrl(input.url)
+      },
+      episodeFetchBySeason: async (input: EpisodeFetchBySeasonParams) => {
+        return this.providerService.fetchEpisodesBySeason(input.seasonId)
+      },
+      episodeMatch: async (data) => {
+        return this.episodeMatchingService.findMatchingEpisodes(data)
+      },
+      providerProbeLogin: async ({ manifestId }) => {
+        return this.providerService.getLoginStatus(manifestId)
+      },
+      providerGetManifestSpec: async ({ manifestId, locale }) => {
+        return this.providerService.getManifestSpec(manifestId, locale)
+      },
+      providerListManifests: async ({ locale } = {}) => {
+        return this.providerService.listManifests(locale)
+      },
+      providerRefreshCatalog: async ({ locale } = {}) => {
+        return this.providerService.refreshCatalog(locale)
+      },
+      providerGetPendingUpdates: async () => {
+        return this.manifestRegistry.getPendingUpdates()
+      },
+      providerApplyUpdates: async ({ manifestIds }) => {
+        await this.manifestRegistry.applyUpdates(manifestIds)
+      },
+      providerValidateManifest: async ({ manifest }) => {
+        return this.manifestSandbox.validate(manifest)
+      },
+      providerTestRunSearch: async (input) => {
+        return this.manifestSandbox.search(input)
+      },
+      providerTestRunEpisodes: async (input) => {
+        return this.manifestSandbox.episodes(input)
+      },
+      providerTestRunDanmaku: async (input) => {
+        return this.manifestSandbox.danmaku(input)
+      },
+      providerSaveUserManifest: async ({ manifest, mode, expectedId }) => {
+        await this.manifestRegistry.saveUserManifest(manifest, mode, expectedId)
+      },
+      providerGetManifestSource: async ({ manifestId }) => {
+        return (await this.manifestRegistry.getSource(manifestId)) ?? null
+      },
+      bilibiliSetCookies: async () => {
+        // Credentialed homepage GET lets bilibili's Set-Cookie response
+        // seed the anti-bot cookies the API host needs.
+        await fetch('https://www.bilibili.com', { credentials: 'include' })
+      },
+      iconSet: async (data, sender) => {
+        if (sender.tab?.id === undefined) {
+          throw new RpcException('No tab id found')
+        }
+
+        const tabId = sender.tab.id
+
+        match(data)
+          .with({ state: 'active' }, (data) => {
+            void this.iconService.setActive(tabId, data.count)
+          })
+          .with({ state: 'inactive' }, () => {
+            void this.iconService.setNormal(tabId)
+          })
+          .with({ state: 'available' }, () => {
+            void this.iconService.setNormal(tabId)
+          })
+          .with({ state: 'unavailable' }, () => {
+            void this.iconService.setUnavailable(tabId)
+          })
+          .exhaustive()
+
+        this.logger.debug('Icon state set to:', data.state)
+      },
+      episodeFilter: async (filter) => {
+        const result = await this.danmakuService.filter(filter)
+        return result
+      },
+      episodeFilterLite: async (filter) => {
+        const result = await this.danmakuService.filterLite(filter)
+        return result || null
+      },
+      seasonGetAll: async (data) => {
+        const result = await this.seasonService.getAll(data)
+        return result
+      },
+      seasonFilter: async (data) => {
+        return this.seasonService.filter(data)
+      },
+      seasonDelete: async (data) => {
+        return this.seasonService.delete(data)
+      },
+      seasonRefresh: async (data) => {
+        return this.providerService.refreshSeason(data)
+      },
+      seasonMapAdd: async (data) => {
+        return this.titleMappingService.add(SeasonMap.from(data))
+      },
+      seasonMapPut: async (data) => {
+        return this.titleMappingService.put(SeasonMap.from(data))
+      },
+      seasonMapDelete: async (data) => {
+        return this.titleMappingService.remove(data.key)
+      },
+      seasonMapDeleteMany: async (data) => {
+        return this.titleMappingService.removeMany(data.keys)
+      },
+
+      seasonMapGetAll: async () => {
+        const seasonMaps = await this.titleMappingService.getAll()
+        return seasonMaps.map((map) => map.toSnapshot())
+      },
+      episodeFetch: async (data, sender) => {
+        const result = await this.providerService.getDanmaku(data)
+        void invalidateContentScriptData(sender.tab?.id)
+        return result
+      },
+      episodePreloadNext: async (data) => {
+        // Best-effort background optimization: swallow failures so a network
+        // or DB error does not bubble up as an unhandled RPC error.
+        try {
+          const { autoBookmark } = await this.extensionOptionsService.get()
+          const bookmarked = await this.bookmarkService.preloadNextEpisode(
+            data,
+            this.providerService,
+            autoBookmark
+          )
+          // Auto-bookmark happens in the background, so refresh content
+          // scripts (incl. the playing tab) to update bookmark UI.
+          if (bookmarked) {
+            void invalidateContentScriptData()
+          }
+        } catch (e) {
+          this.logger.warn('Failed to preload next episode:', e)
+        }
+      },
+      episodeImport: async (data, sender) => {
+        const result = await this.danmakuService.import(data)
+        void invalidateContentScriptData(sender.tab?.id)
+        return result
+      },
+      episodeDelete: async (filter, sender) => {
+        const result = await this.danmakuService.delete(filter)
+        void invalidateContentScriptData(sender.tab?.id)
+        return result
+      },
+      episodeFilterCustom: async (filter) => {
+        return this.danmakuService.filterCustom(filter)
+      },
+      episodeFilterCustomLite: async (filter) => {
+        return this.danmakuService.filterCustomLite(filter)
+      },
+      episodeDeleteCustom: async (filter, sender) => {
+        const result = await this.danmakuService.deleteCustom(filter)
+        void invalidateContentScriptData(sender.tab?.id)
+        return result
+      },
+      danmakuPurgeCache: async (days, sender) => {
+        const result = await this.danmakuService.purgeOlderThan(days)
+        void invalidateContentScriptData(sender.tab?.id)
+        return result
+      },
+      getExtensionManifest: async () => {
+        return chrome.runtime.getManifest() as chrome.runtime.ManifestV3
+      },
+      getAlarm: async (name) => {
+        if (!chrome.alarms) {
+          return null
+        }
+
+        return chrome.alarms.get(name)
+      },
+      getFrameId: async (_, sender) => {
+        if (sender.frameId === undefined) {
+          throw new RpcException('Sender does not have frame id')
+        }
+
+        return sender.frameId
+      },
+      remoteLog: async (data) => {
+        void this.logService.log(data)
+      },
+      exportDebugData: async () => {
+        return this.debugFileService.upload()
+      },
+      getActiveTabUrl: async () => {
+        const tabs = await chrome.tabs.query({
+          active: true,
+          currentWindow: true,
+        })
+
+        const activeTab = tabs[0]
+
+        return activeTab?.url ?? null
+      },
+      mountConfigGetAll: async () => {
+        return this.mountConfigService.getAll()
+      },
+      mountConfigCreate: async (data) => {
+        return this.mountConfigService.create(data)
+      },
+      extractTitle: async ({ text, options }) => {
+        return this.aiService.extractTitle(text, options)
+      },
+      testAiProvider: async (config) => {
+        return this.aiService.testConnection(config)
+      },
+      getFontList: async () => {
+        return chrome.fontSettings.getFontList()
+      },
+      getPlatformInfo: async () => {
+        return chrome.runtime.getPlatformInfo()
+      },
+      fetchImage: async ({ src }) => {
+        return this.imageCacheService.get(src)
+      },
+      kazumiSearchContent: async ({ keyword, policy }) => {
+        return this.kazumiService.searchContent(keyword, policy)
+      },
+      kazumiGetChapters: async ({ url, policy }) => {
+        return this.kazumiService.getChapters(url, policy)
+      },
+      genericVodSearch: async ({ baseUrl, keyword }) => {
+        return MacCmsProviderService.search(baseUrl, keyword, this.logger)
+      },
+      genericFetchDanmakuForUrl: async ({ title, url, providerConfigId }) => {
+        return MacCmsProviderService.fetchDanmakuForUrl(
+          title,
+          url,
+          providerConfigId,
+          this.danmakuService,
+          this.providerConfigService
+        )
+      },
+      setHeaders: async (rule, sender) => {
+        if (sender.tab?.id === undefined) {
+          throw new RpcException('No tab id found')
+        }
+        await setRequestHeaderRule(rule, sender.tab.id)
+      },
+      openPopupInNewWindow: async ({ path, width, height }) => {
+        void chrome.windows.create({
+          url: chrome.runtime.getURL(`pages/popup.html?detached=1#/${path}`),
+          type: 'popup',
+          width: width ?? 550,
+          height: height ?? 650,
+        })
+      },
+      openPopupInNewTab: async ({ path }) => {
+        void chrome.tabs.create({
+          url: chrome.runtime.getURL(`pages/popup.html?detached=1#/${path}`),
+        })
+      },
+      getConfigMacCms: async (input) => {
+        const res = await getMaccmsConfig(input?.force)
+        if (!res.success) {
+          throw res.error
+        }
+        return res.data
+      },
+      getConfigDanmuIcu: async (input) => {
+        const res = await getDanmuicuConfig(input?.force)
+        if (!res.success) {
+          throw res.error
+        }
+        return res.data
+      },
+      providerConfigDelete: async (id, sender) => {
+        // Seasons and episodes are kept (orphaned: no live config matches their
+        // namespace) so downloaded danmaku stays viewable. Bookmarks are
+        // removed: they only exist to fetch new episodes, which an orphaned
+        // season can no longer do.
+        // Resolve the config's identity before deleting it; the read has no
+        // side effects, and deleteFromStorage (which throws if the config does
+        // not exist) still runs before any mutation.
+        const config = await this.providerConfigService.get(id)
+        await this.providerConfigService.deleteFromStorage(id)
+        if (config) {
+          await this.bookmarkService.deleteBySeasonIdentity(
+            config.manifestId,
+            await this.providerService.computeConfigNamespaceKey(config)
+          )
+        }
+
+        void invalidateContentScriptData(sender.tab?.id)
+      },
+      providerDeleteUserManifest: async ({ manifestId }, sender) => {
+        await this.providerService.deleteUserManifest(manifestId)
+        void invalidateContentScriptData(sender.tab?.id)
+      },
+      backupExport: async () => {
+        return this.backupService.getBackupData()
+      },
+      backupImport: async (data, sender) => {
+        const result = await this.backupService.importAll(data)
+        void invalidateContentScriptData(sender.tab?.id)
+        return result
+      },
+      cloudBackupList: async () => {
+        return this.backupService.getCloudBackups()
+      },
+      cloudBackupCreate: async () => {
+        return this.backupService.createCloudBackup()
+      },
+      cloudBackupDownload: async (id) => {
+        return this.backupService.downloadCloudBackup(id)
+      },
+      dataWipeDanmaku: async (data, sender) => {
+        await this.dataManagementService.wipeAllData(data)
+        void invalidateContentScriptData(sender.tab?.id)
+      },
+      bookmarkGetAll: async () => {
+        return this.bookmarkService.getAll()
+      },
+      bookmarkAdd: async (data) => {
+        return this.bookmarkService.add(data.seasonId, this.providerService)
+      },
+      bookmarkDelete: async (data) => {
+        return this.bookmarkService.delete(data.id)
+      },
+      bookmarkDeleteBySeason: async (data) => {
+        return this.bookmarkService.deleteBySeason(data.seasonId)
+      },
+      bookmarkRefresh: async (data) => {
+        return this.bookmarkService.refresh(data.id, this.providerService)
+      },
+      occlusionGetModels: async () => {
+        return this.occlusionModelService.getState()
+      },
+      occlusionRefreshModels: async () => {
+        return this.occlusionModelService.refresh()
+      },
+      occlusionResolveModel: async (data) => {
+        return this.occlusionModelService.resolveModel(data.id)
+      },
+      occlusionDownloadModel: async (data) => {
+        return this.occlusionModelService.download(data.id)
+      },
+      occlusionDeleteModel: async (data) => {
+        return this.occlusionModelService.delete(data.id)
+      },
+      occlusionAddCorsRule: async (data, sender) => {
+        const { ruleId } = await setMediaCorsRule(data.url, sender.tab?.id)
+        return ruleId
+      },
+      occlusionRemoveCorsRule: async (data) => {
+        await removeSessionRule(data.ruleId)
+      },
+    }
+
+    const rpcServer = createRpcServer<BackgroundMethods>(handlers, {
+      logger: this.logger,
+    })
+
+    const externalRpcServer = createRpcServer<BackgroundMethods>(
+      gateExternalHandlers(handlers, EXTERNAL_RPC_ALLOWLIST),
+      { logger: this.logger }
     )
 
     const passThrough = <TRPCDef extends AnyRPCDef>(
@@ -565,7 +572,6 @@ export class RpcManager {
     rpcServer.listen(chrome.runtime.onMessage)
     rpcRelay.listen(chrome.runtime.onMessage)
 
-    // also listen to external messages
-    rpcServer.listen(chrome.runtime.onMessageExternal)
+    externalRpcServer.listen(chrome.runtime.onMessageExternal)
   }
 }

--- a/packages/danmaku-anywhere/src/background/rpc/externalRpc.test.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/externalRpc.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  EXTERNAL_RPC_ALLOWLIST,
+  gateExternalHandlers,
+} from '@/background/rpc/externalRpc'
+import type { RPCServerHandlers } from '@/common/rpc/server'
+import type { RPCDef } from '@/common/rpc/types'
+
+/**
+ * Pins the set of background RPC commands a website can reach through
+ * onMessageExternal, and checks that the gate replaces every other command with
+ * an explicit rejection. A command added to the RPC server is denied until it is
+ * added to the allowlist, which also fails the pinned list below.
+ */
+
+type TestMethods = {
+  allowed: RPCDef<void, string>
+  denied: RPCDef<void, string>
+}
+
+const sender = {} as chrome.runtime.MessageSender
+const setContext = vi.fn()
+
+function createHandlers(): RPCServerHandlers<TestMethods> {
+  return {
+    allowed: async () => 'allowed result',
+    denied: async () => 'denied result',
+  }
+}
+
+describe('EXTERNAL_RPC_ALLOWLIST', () => {
+  it('admits only the mount config commands the onboarding flow uses', () => {
+    expect([...EXTERNAL_RPC_ALLOWLIST]).toEqual([
+      'mountConfigGetAll',
+      'mountConfigCreate',
+    ])
+  })
+})
+
+describe('gateExternalHandlers', () => {
+  it('passes an allowlisted command through to the real handler', async () => {
+    const gated = gateExternalHandlers(createHandlers(), ['allowed'])
+
+    await expect(gated.allowed(undefined, sender, setContext)).resolves.toBe(
+      'allowed result'
+    )
+  })
+
+  it('rejects a command that is not on the allowlist', async () => {
+    const gated = gateExternalHandlers(createHandlers(), ['allowed'])
+
+    await expect(gated.denied(undefined, sender, setContext)).rejects.toThrow(
+      'Method denied is not available to external callers'
+    )
+  })
+
+  it('denies a newly added command that nobody remembered to allowlist', async () => {
+    const handlers = {
+      ...createHandlers(),
+      addedLater: async () => 'added later result',
+    } as RPCServerHandlers<TestMethods & { addedLater: RPCDef<void, string> }>
+
+    const gated = gateExternalHandlers(handlers, ['allowed'])
+
+    await expect(
+      gated.addedLater(undefined, sender, setContext)
+    ).rejects.toThrow('Method addedLater is not available to external callers')
+  })
+})

--- a/packages/danmaku-anywhere/src/background/rpc/externalRpc.ts
+++ b/packages/danmaku-anywhere/src/background/rpc/externalRpc.ts
@@ -1,0 +1,36 @@
+import type { RPCServerHandlers } from '@/common/rpc/server'
+import type { RPCRecord } from '@/common/rpc/types'
+import { RpcException } from '@/common/rpc/types'
+import type { BackgroundMethods } from '@/common/rpcClient/background/types'
+
+/**
+ * The only commands a website may run through chrome.runtime.onMessageExternal.
+ * Everything else in the background RPC surface is denied, including commands
+ * added later: a command becomes reachable from a website only by being listed
+ * here.
+ */
+export const EXTERNAL_RPC_ALLOWLIST = [
+  'mountConfigGetAll',
+  'mountConfigCreate',
+] as const satisfies readonly (keyof BackgroundMethods)[]
+
+export function gateExternalHandlers<TRecords extends RPCRecord>(
+  handlers: RPCServerHandlers<TRecords>,
+  allowlist: readonly (keyof TRecords & string)[]
+): RPCServerHandlers<TRecords> {
+  const allowed = new Set<string>(allowlist)
+  const gated = { ...handlers }
+
+  for (const method of Object.keys(gated) as (keyof TRecords & string)[]) {
+    if (allowed.has(method)) {
+      continue
+    }
+    gated[method] = async () => {
+      throw new RpcException(
+        `Method ${method} is not available to external callers`
+      )
+    }
+  }
+
+  return gated
+}

--- a/packages/danmaku-anywhere/src/common/appUrls.test.ts
+++ b/packages/danmaku-anywhere/src/common/appUrls.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { getExternallyConnectablePatterns } from '@/common/appUrls'
+
+/**
+ * The externally_connectable patterns are what the browser uses to decide which
+ * websites may talk to the background RPC server. A plaintext http entry in a
+ * shipped build hands that channel to anyone on the network path, so a released
+ * build must only list https origins.
+ */
+
+describe('getExternallyConnectablePatterns', () => {
+  it('ships https origins only', () => {
+    expect(getExternallyConnectablePatterns(false)).toEqual([
+      'https://danmaku.weeblify.app/*',
+    ])
+  })
+
+  it('only adds a loopback origin in dev builds', () => {
+    const devOnly = getExternallyConnectablePatterns(true).filter((pattern) => {
+      return !getExternallyConnectablePatterns(false).includes(pattern)
+    })
+
+    expect(devOnly).toEqual(['http://localhost:4321/*'])
+  })
+})

--- a/packages/danmaku-anywhere/src/common/appUrls.ts
+++ b/packages/danmaku-anywhere/src/common/appUrls.ts
@@ -9,9 +9,25 @@ const DEV_APP_URLS = [
   'http://localhost:4200/*', // local dev
 ]
 
+// Sites allowed to reach the background RPC server through
+// chrome.runtime.onMessageExternal. https only: a `*://` scheme wildcard would
+// let a network attacker on the plaintext leg drive the extension.
+const EXTERNALLY_CONNECTABLE_URLS = ['https://danmaku.weeblify.app/*']
+
+const DEV_EXTERNALLY_CONNECTABLE_URLS = [
+  'http://localhost:4321/*', // local docs site
+]
+
 export function getAppUrls(isDev: boolean): string[] {
   if (isDev) {
     return [...APP_URLS, ...DEV_APP_URLS]
   }
   return APP_URLS
+}
+
+export function getExternallyConnectablePatterns(isDev: boolean): string[] {
+  if (isDev) {
+    return [...EXTERNALLY_CONNECTABLE_URLS, ...DEV_EXTERNALLY_CONNECTABLE_URLS]
+  }
+  return EXTERNALLY_CONNECTABLE_URLS
 }

--- a/packages/danmaku-anywhere/src/common/constants.ts
+++ b/packages/danmaku-anywhere/src/common/constants.ts
@@ -1,9 +1,9 @@
+import { getExternallyConnectablePatterns } from '@/common/appUrls'
 import { matchUrl } from '@/common/utils/matchUrl'
 
-export const EXTERNALLY_CONNECTABLE_PATTERNS = [
-  '*://danmaku.weeblify.app/*',
-  ...(import.meta.env.DEV ? ['http://localhost:4321/*'] : []),
-]
+export const EXTERNALLY_CONNECTABLE_PATTERNS = getExternallyConnectablePatterns(
+  import.meta.env.DEV
+)
 
 export const IS_EXTERNALLY_CONNECTABLE = EXTERNALLY_CONNECTABLE_PATTERNS.some(
   (pattern) => {

--- a/packages/danmaku-anywhere/src/common/rpc/server.ts
+++ b/packages/danmaku-anywhere/src/common/rpc/server.ts
@@ -17,7 +17,7 @@ export type RRPServerHandler<TDef extends AnyRPCDef> = (
   options?: RpcOptions
 ) => Promise<TDef['output']>
 
-type RPCServerHandlers<TRecords extends RPCRecord> = {
+export type RPCServerHandlers<TRecords extends RPCRecord> = {
   [TKey in keyof TRecords]: RRPServerHandler<TRecords[TKey]>
 }
 

--- a/packages/web-scraper/src/messaging/messaging.test.ts
+++ b/packages/web-scraper/src/messaging/messaging.test.ts
@@ -60,4 +60,17 @@ describe('setRequestHeaderRule', () => {
       findHeader(action.responseHeaders, 'Access-Control-Allow-Origin')?.value
     ).toBe('*')
   })
+
+  it('scopes the rule to the requesting tab', async () => {
+    await setRequestHeaderRule(
+      {
+        url: 'https://cdn.example.com',
+        referer: 'https://source.example.com',
+        origin: 'https://source.example.com',
+      },
+      42
+    )
+
+    expect(getAddedRule().condition.tabIds).toEqual([42])
+  })
 })

--- a/packages/web-scraper/src/messaging/messaging.ts
+++ b/packages/web-scraper/src/messaging/messaging.ts
@@ -147,7 +147,13 @@ export type SetHeaderRule = {
   origin?: string
 }
 
-export const setRequestHeaderRule = async (headerRule: SetHeaderRule) => {
+// tabId scopes the rule to the tab that asked for it. The rule forces
+// Access-Control-Allow-Origin: *, so leaving it unscoped would hand every tab
+// in the browser a CORS bypass for the matched url.
+export const setRequestHeaderRule = async (
+  headerRule: SetHeaderRule,
+  tabId?: number
+) => {
   const existingRules = await chrome.declarativeNetRequest.getSessionRules()
 
   // check if url exists, if it does, remove the rule
@@ -249,6 +255,7 @@ export const setRequestHeaderRule = async (headerRule: SetHeaderRule) => {
         condition: {
           urlFilter: `|${headerRule.url}`,
           resourceTypes: resourceTypes,
+          tabIds: tabId === undefined ? undefined : [tabId],
         },
       },
     ],


### PR DESCRIPTION
Closes the second route into the background RPC surface. PR #523 hardened the `window.message` bridge deliberately and did not seal this one.

## The hole

`externally_connectable.matches` was `*://danmaku.weeblify.app/*`. The scheme wildcard includes plaintext http, and that host sends no HSTS header on either the HTTPS response or the redirect, so a browser genuinely sends cleartext to it on a first visit, cleared state, or a new device.

`RpcManager` then bound the entire background RPC server to `chrome.runtime.onMessageExternal` with no filter. Roughly 78 commands, including `backupExport`, `cloudBackupList` and `cloudBackupDownload` riding the extension's own session, `dataWipeDanmaku`, `authDeleteAccount` with no re-auth, and `setHeaders`.

## The allowlist is two commands, and the evidence says it could be zero

`['mountConfigGetAll', 'mountConfigCreate']`.

The web app does not use this route at all. `grep -rn "chrome\." app/web/src` returns nothing; it detects the extension via a DOM attribute and talks over `window.postMessage`, which is the bridge #523 hardened. Kazumi search, chapter list and media extraction all live there.

The only in-repo external caller is `docs/src/components/onboarding/useConfig.tsx`, which sends exactly those two commands, and which is currently unreachable: `OnboardingAstro.astro` has no references, and the docs are served from `docs.danmaku.weeblify.app`, which the old pattern never matched. So the two admitted commands are the documented original purpose of the manifest key rather than anything with a live caller. Emptying the list is a one-line change if you want maximum lockdown.

Deleting `externally_connectable` outright is not the answer: omitting the key lets any other **extension** message the background, while specifying it with only `matches` blocks extensions. Narrowed is the correct shape.

## Mechanism

Gated by projecting the handler map, not by the RPC server's `filter` option. `filter`'s contract is "stay silent, this message is not mine", which the player frame routing depends on, so an external caller hitting a denied command would get an ambiguous port-closed failure instead of a clear error. `gateExternalHandlers` instead replaces every non-allowlisted method with a stub that throws a named error, and the ungated server no longer listens on `onMessageExternal`.

Default-deny by construction: a command added tomorrow is denied without anyone remembering.

## setHeaders

Denied externally, and separately scoped: `setRequestHeaderRule(rule, tabId)` now sets `tabIds: [tabId]` and the handler throws when `sender.tab?.id` is undefined, matching what `setMediaCorsRule` already did. Unscoped, that rule handed every tab in the browser a CORS bypass with a forced `Access-Control-Allow-Origin: *`.

No expiry, deliberately: DNR session rules have no TTL, and a `setTimeout` in an MV3 worker does not survive suspension, so an expiry would be a lie. `setMediaCorsRule` has the same lifecycle and relies on an explicit teardown. Giving `setHeaders` one means extending the app-extension contract, which is filed separately.

## Test plan

- lint: pass. `pnpm type-check` all 10 packages, `pnpm lint` clean, `lint-specs` ok.
- tests: extension 800 pass across 84 files, web-scraper 8 pass.
- e2e: `external-rpc.spec.ts` and `mount-config-crud.spec.ts` 3 pass, smoke 3 pass. Full suite left to CI.
- red before green: observed against a build of the merge base.

```
✘ external rpc: allowlisted command lands, the rest are rejected
    Expected: "errored"   Received: "success"     <- backupExport ran for an external page
✘ external rpc: a plaintext http origin cannot reach the extension
    Expected: false       Received: true          <- http://danmaku.weeblify.app reached the extension
```

Both pass after the change.

The http test navigates a real page to `http://danmaku.weeblify.app/` and calls `chrome.runtime.sendMessage`. Chrome only exposes `chrome.runtime` to origins matching an installed extension's `externally_connectable`, so this is the browser's own enforcement observed, not an assertion about config. Chromium only; Firefox has no `externally_connectable`, so there is nothing to verify there.

Regression guard is three-layered: unknown commands are denied by construction, the allowlist is pinned to an exact literal so widening it fails a test, and the e2e fails if anyone re-binds the ungated server.

## Notes

`appUrls.ts` turned out to take `isDev` as a parameter rather than reading `import.meta.env.DEV`, with a comment saying it must stay Node-importable, so the origin list is now de-duplicated through `getExternallyConnectablePatterns(isDev)` feeding both the manifest and the runtime constant.

Narrowing the patterns also gates `useExternalConnection`, a `window.message` handler in the controller content script accepting `hello` and `openPopup`, which is now off on plaintext too.

Not exercised end to end: the kazumi local-playback flow that consumes the header rule has no e2e coverage anywhere in the suite. The fetch happens in the same tab the content script sent from, so the scoping should hold, but the `messaging.ts` hunk is independently revertable if you want zero risk on this release.
