### PR TITLE
(proxy) enable Workers Cache with a no-store default [DA-705]

### DIFF
--- a/backend/proxy/src/index.ts
+++ b/backend/proxy/src/index.ts
@@ -8,6 +8,7 @@ import { openAPIRouteHandler } from 'hono-openapi'
 import { factory } from '@/factory'
 import { authContext } from '@/middleware/authContext'
 import { useCache } from '@/middleware/cache'
+import { noStoreDefault } from '@/middleware/noStoreDefault'
 import { requestLogger } from '@/middleware/requestLogger'
 import { setContext } from '@/middleware/setContext'
 import { danDanPlay } from '@/routes/api/ddp/danDanPlay'
@@ -20,6 +21,7 @@ const app = factory.createApp()
 
 app.use(
   '*',
+  noStoreDefault(),
   requestLogger(),
   prettyJSON(),
   cors({

--- a/backend/proxy/src/middleware/noStoreDefault.test.ts
+++ b/backend/proxy/src/middleware/noStoreDefault.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { factory } from '@/factory'
+import { makeUnitTestRequest } from '@/test-utils/makeUnitTestRequest'
+import { noStoreDefault } from './noStoreDefault'
+
+describe('noStoreDefault', () => {
+  const createTestApp = () => {
+    const app = factory.createApp()
+    app.use('*', noStoreDefault())
+    app.get('/bare', (c) => c.json({ ok: true }))
+    app.get('/cached', (c) => {
+      c.header('Cache-Control', 'max-age=60')
+      return c.json({ ok: true })
+    })
+    app.get(
+      '/upstream',
+      () =>
+        new Response('{}', {
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+    return app
+  }
+
+  it('sets no-store on a response that carries no Cache-Control', async () => {
+    const res = await makeUnitTestRequest(
+      new Request('http://example.com/bare'),
+      { app: createTestApp() }
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(await res.json()).toEqual({ ok: true })
+  })
+
+  it('leaves an explicit Cache-Control untouched', async () => {
+    const res = await makeUnitTestRequest(
+      new Request('http://example.com/cached'),
+      { app: createTestApp() }
+    )
+
+    expect(res.headers.get('Cache-Control')).toBe('max-age=60')
+  })
+
+  it('covers a handler that returns a raw Response', async () => {
+    const res = await makeUnitTestRequest(
+      new Request('http://example.com/upstream'),
+      { app: createTestApp() }
+    )
+
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('covers the not-found response', async () => {
+    const res = await makeUnitTestRequest(
+      new Request('http://example.com/missing'),
+      { app: createTestApp() }
+    )
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('applies to the real worker: an unknown path is not-found and no-store', async () => {
+    const res = await makeUnitTestRequest(
+      new Request('http://example.com/definitely-not-a-route')
+    )
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+})

--- a/backend/proxy/src/middleware/noStoreDefault.ts
+++ b/backend/proxy/src/middleware/noStoreDefault.ts
@@ -1,0 +1,19 @@
+import { factory } from '@/factory'
+
+// Workers Cache keeps a 200 with no Cache-Control for two hours under heuristic freshness,
+// and cookies are not part of its key. A route that wants caching says so with its own
+// header; anything else must not end up in a shared cache.
+export const noStoreDefault = () =>
+  factory.createMiddleware(async (c, next) => {
+    await next()
+    if (c.res.headers.has('Cache-Control')) {
+      return
+    }
+    const headers = new Headers(c.res.headers)
+    headers.set('Cache-Control', 'no-store')
+    c.res = new Response(c.res.body, {
+      status: c.res.status,
+      statusText: c.res.statusText,
+      headers,
+    })
+  })

--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -10,6 +10,9 @@
   "observability": {
     "enabled": true
   },
+  "cache": {
+    "enabled": true
+  },
   "vars": {
     "ENVIRONMENT": "dev",
     "ALLOWED_ORIGIN": "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,http://localhost:4200",
@@ -83,6 +86,9 @@
   ],
   "env": {
     "staging": {
+      "cache": {
+        "enabled": true
+      },
       "vars": {
         "ENVIRONMENT": "staging",
         "ALLOWED_ORIGIN": "https://danmaku.weeblify.app,https://danmaku-staging.weeblify.app,http://localhost:4200",
@@ -160,6 +166,9 @@
       "observability": {
         "enabled": true,
         "head_sampling_rate": 0.005
+      },
+      "cache": {
+        "enabled": false
       },
       "vars": {
         "ENVIRONMENT": "production",


### PR DESCRIPTION
## What

Turns on Cloudflare Workers Cache for the proxy in the dev and staging environments, and adds a `noStoreDefault` middleware that stamps `Cache-Control: no-store` on every response that did not set its own header. Production keeps `cache.enabled: false` until staging is verified.

## Why

A Workers Cache hit is billed as a request only: no CPU, no service-binding call into the DDP worker, no KV read there, and it never reaches the DDP rate limiter. Over the last seven days of admitted DDP traffic, 79 to 94 percent of requests repeated a key inside a 1h to 24h window, so most of the 429s we hand out today are for answers the edge could have served. The companion DDP change (ddp-microservice DDP-116) switches that worker's `Cache-Control` from `private` to `public, max-age, stale-while-revalidate`, which is what makes the DDP routes cacheable here; those routes return the service-binding response unchanged, so the header flows through.

The default matters because Workers Cache applies heuristic freshness: a 200 with no `Cache-Control` is stored for two hours, and cookies are not part of the cache key. better-auth 1.6.11 sets no `Cache-Control` on its session routes, so without the default `GET /auth/get-session` for one signed-in user would be served to the next requester.

CORS stays correct: `hono/cors` appends `Vary: Origin`, which Workers Cache honours, so the web app's variant is never served to a client with no Origin.

## Not in this PR

- Deleting the legacy `/proxy/api` route and its Cache API middleware. Zone analytics for 4 Sep show zero production traffic on it; separate cleanup.
- `cross_version_cache` (needs wrangler 4.107; the pinned range resolves to 4.78). Until then every proxy deploy starts with an empty cache.

## Checks

- `pnpm test` in `backend/proxy`: 16 files, 87 tests pass, including five new ones for the middleware (bare handler, explicit header left alone, raw `Response`, not-found, and the real worker's 404).
- `biome ci` clean on the changed files. The three pre-existing `biome ci` errors in `drizzle.config.ts` and the `tsconfig.json` type-check failure on master are untouched.

## Verify on staging after `pnpm deploy:staging` (a deployed version; `wrangler dev` does not exercise Workers Cache)

```sh
curl -sI 'https://api.danmaku-staging.weeblify.app/ddp/v1?path=/v2/bangumi/1' | grep -i 'cf-cache-status\|cache-control'   # MISS, then HIT on repeat
curl -sI -H 'Cookie: better-auth.session_token=x' 'https://api.danmaku-staging.weeblify.app/auth/get-session' | grep -i 'cf-cache-status\|cache-control'   # BYPASS, no-store
```

The staging DDP worker needs the DDP-116 change deployed for the first probe to show `public`. Also confirm the zone's "Force cache" Cache Rule does not rewrite `cache-control` on a HIT (docs say zone cache settings do not apply to Workers Cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQxSF6YdqvT9hUFaEVKZYJ
