### PR TITLE
(proxy) enable Workers Cache in production [DA-705]

### DIFF
--- a/backend/proxy/wrangler.json
+++ b/backend/proxy/wrangler.json
@@ -168,7 +168,7 @@
         "head_sampling_rate": 0.005
       },
       "cache": {
-        "enabled": false
+        "enabled": true
       },
       "vars": {
         "ENVIRONMENT": "production",


### PR DESCRIPTION
## What

Flips `env.production.cache.enabled` from `false` to `true`. One line; no code.

## After merge

```sh
cd backend/proxy && pnpm deploy:prod
```

Then watch for a week: KV reads on the ddp worker (should fall), 429 count (should fall without any limit change), and `cacheStatus` in zone analytics for the hit share. Rollback is this line back to `false` plus a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQxSF6YdqvT9hUFaEVKZYJ
